### PR TITLE
Fix a small pydub workaround in the MP3 compression preprocessor

### DIFF
--- a/art/defences/preprocessor/mp3_compression.py
+++ b/art/defences/preprocessor/mp3_compression.py
@@ -81,13 +81,6 @@ class Mp3Compression(Preprocessor):
             """
             Apply MP3 compression to audio input of shape (samples, channel).
             """
-            # WARNING: Writing and reading MP3 from byte stream causes pydub to extend the original
-            # length. Writing and reading MP3 from local file system works without problems. It is
-            # easy to move from using BytesIO to local read/writes with the following:
-            # import os
-            # from art import config
-            # tmp_wav = os.path.join(config.ART_DATA_PATH, "tmp.wav")
-            # tmp_mp3 = os.path.join(config.ART_DATA_PATH, "tmp.mp3")
             from pydub import AudioSegment
             from scipy.io.wavfile import write
 
@@ -107,12 +100,6 @@ class Mp3Compression(Preprocessor):
             tmp_wav.close()
             tmp_mp3.close()
             x_mp3 = np.array(audio_segment.get_array_of_samples()).reshape((-1, audio_segment.channels))
-            # WARNING: Due to above problem, we need to manually resize x_mp3 to original length.
-            x_mp3 = x_mp3[: x.shape[0]]
-
-            if normalized:
-                # x was normalized. Therefore normalizing x_mp3.
-                x_mp3 = x_mp3 * 2 ** -15
             return x_mp3
 
         if x.dtype != np.object and x.ndim != 3:

--- a/tests/defences/preprocessor/test_mp3_compression.py
+++ b/tests/defences/preprocessor/test_mp3_compression.py
@@ -43,9 +43,10 @@ class AudioInput:
 
     def get_data(self):
         if self.channels_first:
-            return np.zeros((self.batch_size, self.channels, self.sample_rate), dtype=np.int16)
+            shape = (self.batch_size, self.channels, self.sample_rate)
         else:
-            return np.zeros((self.batch_size, self.sample_rate, self.channels), dtype=np.int16)
+            shape = (self.batch_size, self.sample_rate, self.channels)
+        return np.zeros(shape, dtype=np.int16)
 
 
 @pytest.fixture(params=[1, 2], ids=["mono", "stereo"])


### PR DESCRIPTION
# Description

This PR fixes a workaround related to a bug in `pydub`, which was fixed with the latest `pydub` release. More information can be found in this issue: https://github.com/jiaaro/pydub/issues/474

## Type of change

Please check all the relevant options.

- [x] Bug fix (non-breaking)

**Test Configuration**:
- Fedora 31
- Python 3.6.10
- ART 1.3.0 development

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
