### PR TITLE
Fix bugs in PyTorchFasterRCNN and DPatch

### DIFF
--- a/art/attacks/evasion/dpatch.py
+++ b/art/attacks/evasion/dpatch.py
@@ -99,7 +99,7 @@ class DPatch(EvasionAttack):
                 logger.info("Training Step: %i", i_step + 1)
 
             patched_images, transforms = self._augment_images_with_patch(
-                x, self._patch, random_location=True, channel_index=self.estimator.channel_index
+                x, self._patch, random_location=True, channels_first=self.estimator.channels_first
             )
             patch_target: List[Dict[str, np.ndarray]] = list()
 
@@ -219,7 +219,7 @@ class DPatch(EvasionAttack):
             patch_local = self._patch
 
         patched_images, _ = self._augment_images_with_patch(
-            x=x, patch=patch_local, random_location=random_location, channel_index=self.estimator.channel_index
+            x=x, patch=patch_local, random_location=random_location, channels_first=self.estimator.channels_first
         )
 
         return patched_images

--- a/art/config.py
+++ b/art/config.py
@@ -21,7 +21,7 @@ This module loads and provides configuration parameters for ART.
 import json
 import logging
 import os
-from typing import Tuple, Union
+from typing import Tuple, Union, Optional
 
 import numpy as np
 
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 ART_NUMPY_DTYPE = np.float32
 DATASET_TYPE = Tuple[Tuple[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray], float, float]
 CLIP_VALUES_TYPE = Tuple[Union[int, float, np.ndarray], Union[int, float, np.ndarray]]
-PREPROCESSING_TYPE = Tuple[Union[int, float, np.ndarray], Union[int, float, np.ndarray]]
+PREPROCESSING_TYPE = Optional[Tuple[Union[int, float, np.ndarray], Union[int, float, np.ndarray]]]
 
 # --------------------------------------------------------------------------------------------- DEFAULT PACKAGE CONFIGS
 

--- a/art/estimators/object_detection/PyTorchFasterRCNN.py
+++ b/art/estimators/object_detection/PyTorchFasterRCNN.py
@@ -51,7 +51,7 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
         channels_first: Optional[bool] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: Optional["PREPROCESSING_TYPE"] = None,
+        preprocessing: "PREPROCESSING_TYPE" = None,
         attack_losses: Tuple[str, ...] = ("loss_classifier", "loss_box_reg", "loss_objectness", "loss_rpn_box_reg",),
         device_type: str = "gpu",
     ):

--- a/art/estimators/object_detection/PyTorchFasterRCNN.py
+++ b/art/estimators/object_detection/PyTorchFasterRCNN.py
@@ -51,7 +51,7 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
         channels_first: Optional[bool] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: Optional["PREPROCESSING_TYPE"] = None,
         attack_losses: Tuple[str, ...] = ("loss_classifier", "loss_box_reg", "loss_objectness", "loss_rpn_box_reg",),
         device_type: str = "gpu",
     ):


### PR DESCRIPTION
# Description

Hello.
I found some small bugs while trying to use DPatch attack.

1. Unnecessary default preprocessing in  ```PyTorchFasterRCNN```

```PyTorchFasterRCNN``` estimator does not support preprocessing and raises error if preprocessing is assigned. But its ```__init__``` method have default value for preprocessing. This causes ```PyTorchFasterRCNN``` can not be instantiated without explicitly set preprocessing as None.

2. Calling ```_augment_images_with_patch``` with insufficient arguments in ```DPatch```.

In ```DPatch```, ```generate``` and ```apply_patch``` methods are calling ```_augment_images_with_patch``` without required argument ```channels_first```. This causes the attack not working.

This PR is going to fix bugs described above.

## Type of change

Please check all relevant options.

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Checked that adversarial patch is successfully generated by DPatch

**Test Configuration**:
- Ubuntu 18.04
- Python 3.7
- ART 1.3.1
- PyTorch1.5.1

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
