### PR TITLE
Allow eps_step larger than eps for norms other than inf

### DIFF
--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
@@ -198,7 +198,7 @@ class ProjectedGradientDescent(EvasionAttack):
         if self.batch_size <= 0:
             raise ValueError("The batch size `batch_size` has to be positive.")
 
-        if self.eps_step > self.eps:
+        if self.norm == np.inf and self.eps_step > self.eps:
             raise ValueError("The iteration step `eps_step` has to be smaller than the total attack `eps`.")
 
         if self.max_iter <= 0:


### PR DESCRIPTION
# Description

This pull request allows `eps_step` to be larger than `eps` for norms other than `inf` in the `ProjectedGradientDescent` attacks.

## Type of change

Please check all relevant options.

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
