### PR TITLE
Fix dtype in AutoProjectedGradientDescent and SquareAttack

### DIFF
--- a/art/attacks/evasion/auto_projected_gradient_descent.py
+++ b/art/attacks/evasion/auto_projected_gradient_descent.py
@@ -304,6 +304,13 @@ class AutoProjectedGradientDescent(EvasionAttack):
 
                     self._loss_fn = difference_logits_ratio
                     self._loss_object = difference_logits_ratio
+            elif loss_type is None:
+                self._loss_object = estimator._loss_object
+            else:
+                raise ValueError(
+                    "The argument loss_type has an invalid value. The following options for loss_type are "
+                    "supported: {}".format([None, "cross_entropy", "difference_logits_ratio"])
+                )
 
             estimator_apgd = PyTorchClassifier(
                 model=estimator.model,

--- a/art/attacks/evasion/auto_projected_gradient_descent.py
+++ b/art/attacks/evasion/auto_projected_gradient_descent.py
@@ -255,7 +255,9 @@ class AutoProjectedGradientDescent(EvasionAttack):
                     self._loss_fn = loss_fn
                     self._loss_object = torch.nn.CrossEntropyLoss()
             elif loss_type == "difference_logits_ratio":
-                if is_probability(estimator.predict(x=np.ones(shape=(1, *estimator.input_shape)))):
+                if is_probability(
+                    estimator.predict(x=np.ones(shape=(1, *estimator.input_shape), dtype=ART_NUMPY_DTYPE))
+                ):
                     raise ValueError(
                         "The provided estimator seems to predict probabilities. If loss_type='difference_logits_ratio' "
                         "the estimator has to to predict logits."
@@ -268,6 +270,8 @@ class AutoProjectedGradientDescent(EvasionAttack):
                             y_true = torch.from_numpy(y_true)
                         if isinstance(y_pred, np.ndarray):
                             y_pred = torch.from_numpy(y_pred)
+
+                        y_true = y_true.float()
 
                         # dlr = torch.mean((y_pred - y_true) ** 2)
                         # return loss

--- a/art/attacks/evasion/square_attack.py
+++ b/art/attacks/evasion/square_attack.py
@@ -141,7 +141,7 @@ class SquareAttack(EvasionAttack):
                     x_robust + self.eps * np.random.choice([-1, 1], size=size),
                     a_min=self.estimator.clip_values[0],
                     a_max=self.estimator.clip_values[1],
-                )
+                ).astype(ART_NUMPY_DTYPE)
 
                 sample_logits_diff_new = self._get_logits_diff(x_robust_new, y_robust)
                 logits_diff_improved = (sample_logits_diff_new - sample_logits_diff_init) < 0.0
@@ -189,7 +189,7 @@ class SquareAttack(EvasionAttack):
 
                     x_robust_new = np.clip(
                         x_robust_new, a_min=self.estimator.clip_values[0], a_max=self.estimator.clip_values[1]
-                    )
+                    ).astype(ART_NUMPY_DTYPE)
 
                     sample_logits_diff_new = self._get_logits_diff(x_robust_new, y_robust)
                     logits_diff_improved = (sample_logits_diff_new - sample_logits_diff_init) < 0.0


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request fixes the dtype in `AutoProjectedGradientDescent` and `SquareAttack`.

Fixes #497 

## Type of change

Please check all relevant options.

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
