### PR TITLE
Debug fbf pytorch

### DIFF
--- a/art/defences/trainer/adversarial_trainer_FBF_Pytorch.py
+++ b/art/defences/trainer/adversarial_trainer_FBF_Pytorch.py
@@ -120,7 +120,7 @@ class AdversarialTrainerFBFPyTorch(AdversarialTrainerFBF):
                 output = np.argmax(self.predict(x_test), axis=1)
                 nb_correct_pred = np.sum(output == np.argmax(y_test, axis=1))
                 logger.info(
-                    "epoch {} \t time(s) {:.1f} \t lr {:.4f} \t loss {:.4f} \t train-acc {:.4f} \t val-acc {:.4f}".format(
+                    "epoch {}\ttime(s) {:.1f}\tlr {:.4f}\tloss {:.4f}\tacc(tr) {:.4f}\tacc(val) {:.4f}".format(
                         i_epoch,
                         train_time - start_time,
                         lr,
@@ -131,7 +131,7 @@ class AdversarialTrainerFBFPyTorch(AdversarialTrainerFBF):
                 )
             else:
                 logger.info(
-                    "epoch {} \t time(s) {:.1f} \t lr {:.4f} \t loss {:.4f} \t acc {:.4f}".format(
+                    "epoch {}\t time(s) {:.1f}\t lr {:.4f}\t loss {:.4f}\t acc {:.4f}".format(
                         i_epoch, train_time - start_time, lr, train_loss / train_n, train_acc / train_n
                     )
                 )
@@ -181,7 +181,7 @@ class AdversarialTrainerFBFPyTorch(AdversarialTrainerFBF):
 
             train_time = time.time()
             logger.info(
-                "epoch {} \t time(s) {:.1f} \t lr {:.4f} \t loss {:.4f} \t acc {:.4f}".format(
+                "epoch {}\t time(s) {:.1f}\t lr {:.4f}\t loss {:.4f}\t acc {:.4f}".format(
                     i_epoch, train_time - start_time, lr, train_loss / train_n, train_acc / train_n
                 )
             )

--- a/art/defences/trainer/adversarial_trainer_FBF_Pytorch.py
+++ b/art/defences/trainer/adversarial_trainer_FBF_Pytorch.py
@@ -89,9 +89,9 @@ class AdversarialTrainerFBFPyTorch(AdversarialTrainerFBF):
         def lr_schedule(t):
             return np.interp([t], [0, nb_epochs * 2 // 5, nb_epochs], [0, 0.21, 0])[0]
 
-        for i_epoch in range(nb_epochs):
-            logger.info("Adversarial training FBF epoch %i/%i", i_epoch, nb_epochs)
+        logger.info("Adversarial training FBF")
 
+        for i_epoch in range(nb_epochs):
             # Shuffle the examples
             np.random.shuffle(ind)
             start_time = time.time()
@@ -103,8 +103,8 @@ class AdversarialTrainerFBFPyTorch(AdversarialTrainerFBF):
                 lr = lr_schedule(i_epoch + (batch_id + 1) / nb_batches)
 
                 # Create batch data
-                x_batch = x[ind[batch_id * batch_size : min((batch_id + 1) * batch_size, x.shape[0])]].copy()
-                y_batch = y[ind[batch_id * batch_size : min((batch_id + 1) * batch_size, x.shape[0])]]
+                x_batch = x[ind[batch_id * batch_size: min((batch_id + 1) * batch_size, x.shape[0])]].copy()
+                y_batch = y[ind[batch_id * batch_size: min((batch_id + 1) * batch_size, x.shape[0])]]
 
                 _train_loss, _train_acc, _train_n = self._batch_process(x_batch, y_batch, lr)
 
@@ -120,7 +120,7 @@ class AdversarialTrainerFBFPyTorch(AdversarialTrainerFBF):
                 output = np.argmax(self.predict(x_test), axis=1)
                 nb_correct_pred = np.sum(output == np.argmax(y_test, axis=1))
                 logger.info(
-                    "{} \t {:.1f} \t {:.4f} \t {:.4f} \t {:.4f} \t {:.4f}".format(
+                    "epoch {} \t time(s) {:.1f} \t lr {:.4f} \t loss {:.4f} \t train-acc {:.4f} \t val-acc {:.4f}".format(
                         i_epoch,
                         train_time - start_time,
                         lr,
@@ -131,7 +131,7 @@ class AdversarialTrainerFBFPyTorch(AdversarialTrainerFBF):
                 )
             else:
                 logger.info(
-                    "{} \t {:.1f} \t {:.4f} \t {:.4f} \t {:.4f}".format(
+                    "epoch {} \t time(s) {:.1f} \t lr {:.4f} \t loss {:.4f} \t acc {:.4f}".format(
                         i_epoch, train_time - start_time, lr, train_loss / train_n, train_acc / train_n
                     )
                 )
@@ -158,8 +158,9 @@ class AdversarialTrainerFBFPyTorch(AdversarialTrainerFBF):
         def lr_schedule(t):
             return np.interp([t], [0, nb_epochs * 2 // 5, nb_epochs], [0, 0.21, 0])[0]
 
+        logger.info("Adversarial training FBF")
+
         for i_epoch in range(nb_epochs):
-            logger.info("Adversarial training FBF epoch %i/%i", i_epoch, nb_epochs)
             start_time = time.time()
             train_loss = 0
             train_acc = 0
@@ -180,7 +181,7 @@ class AdversarialTrainerFBFPyTorch(AdversarialTrainerFBF):
 
             train_time = time.time()
             logger.info(
-                "{} \t {:.1f} \t {:.4f} \t {:.4f} \t {:.4f}".format(
+                "epoch {} \t time(s) {:.1f} \t lr {:.4f} \t loss {:.4f} \t acc {:.4f}".format(
                     i_epoch, train_time - start_time, lr, train_loss / train_n, train_acc / train_n
                 )
             )

--- a/art/defences/trainer/adversarial_trainer_FBF_Pytorch.py
+++ b/art/defences/trainer/adversarial_trainer_FBF_Pytorch.py
@@ -103,8 +103,8 @@ class AdversarialTrainerFBFPyTorch(AdversarialTrainerFBF):
                 lr = lr_schedule(i_epoch + (batch_id + 1) / nb_batches)
 
                 # Create batch data
-                x_batch = x[ind[batch_id * batch_size: min((batch_id + 1) * batch_size, x.shape[0])]].copy()
-                y_batch = y[ind[batch_id * batch_size: min((batch_id + 1) * batch_size, x.shape[0])]]
+                x_batch = x[ind[batch_id * batch_size : min((batch_id + 1) * batch_size, x.shape[0])]].copy()
+                y_batch = y[ind[batch_id * batch_size : min((batch_id + 1) * batch_size, x.shape[0])]]
 
                 _train_loss, _train_acc, _train_n = self._batch_process(x_batch, y_batch, lr)
 

--- a/examples/adversarial_training_FBF.py
+++ b/examples/adversarial_training_FBF.py
@@ -180,6 +180,7 @@ model.train()
 opt = torch.optim.SGD(model.parameters(), lr=0.21, momentum=0.9, weight_decay=5e-4)
 
 # if you have apex installed, the following line should be uncommented for faster processing
+# import apex.amp as amp
 # model, opt = amp.initialize(model, opt, opt_level="O2", loss_scale=1.0, master_weights=False)
 
 criterion = nn.CrossEntropyLoss()

--- a/examples/adversarial_training_FBF.py
+++ b/examples/adversarial_training_FBF.py
@@ -135,7 +135,7 @@ class CIFAR10_dataset(Dataset):
         self.transform = transform
 
     def __getitem__(self, index):
-        x = Image.fromarray(((self.data[index]*255).round()).astype(np.uint8).transpose(1, 2, 0))
+        x = Image.fromarray(((self.data[index] * 255).round()).astype(np.uint8).transpose(1, 2, 0))
         x = self.transform(x)
         y = self.targets[index]
         return x, y
@@ -221,16 +221,12 @@ trainer.fit_generator(art_datagen, nb_epochs=30)
 x_test_pred = np.argmax(classifier.predict(x_test), axis=1)
 print(
     "Accuracy on benign test samples after adversarial training: %.2f%%"
-    % (np.sum(x_test_pred == np.argmax(y_test, axis=1))
-    / x_test.shape[0]
-    * 100)
+    % (np.sum(x_test_pred == np.argmax(y_test, axis=1)) / x_test.shape[0] * 100)
 )
 
 x_test_attack = attack.generate(x_test)
 x_test_attack_pred = np.argmax(classifier.predict(x_test_attack), axis=1)
 print(
     "Accuracy on original PGD adversarial samples after adversarial training: %.2f%%"
-    % (np.sum(x_test_attack_pred == np.argmax(y_test, axis=1))
-    / x_test.shape[0]
-    * 100)
+    % (np.sum(x_test_attack_pred == np.argmax(y_test, axis=1)) / x_test.shape[0] * 100)
 )

--- a/examples/adversarial_training_FBF.py
+++ b/examples/adversarial_training_FBF.py
@@ -211,6 +211,7 @@ attack = ProjectedGradientDescent(
     num_random_init=5,
     batch_size=32,
 )
+
 x_test_attack = attack.generate(x_test)
 x_test_attack_pred = np.argmax(classifier.predict(x_test_attack), axis=1)
 print(

--- a/examples/adversarial_training_FBF.py
+++ b/examples/adversarial_training_FBF.py
@@ -221,16 +221,16 @@ trainer.fit_generator(art_datagen, nb_epochs=30)
 x_test_pred = np.argmax(classifier.predict(x_test), axis=1)
 print(
     "Accuracy on benign test samples after adversarial training: %.2f%%"
-    % np.sum(x_test_pred == np.argmax(y_test, axis=1))
+    % (np.sum(x_test_pred == np.argmax(y_test, axis=1))
     / x_test.shape[0]
-    * 100
+    * 100)
 )
 
 x_test_attack = attack.generate(x_test)
 x_test_attack_pred = np.argmax(classifier.predict(x_test_attack), axis=1)
 print(
     "Accuracy on original PGD adversarial samples after adversarial training: %.2f%%"
-    % np.sum(x_test_attack_pred == np.argmax(y_test, axis=1))
+    % (np.sum(x_test_attack_pred == np.argmax(y_test, axis=1))
     / x_test.shape[0]
-    * 100
+    * 100)
 )


### PR DESCRIPTION
# Description

This PR corrects the dataloaders for CIFAR10 in the example script for Fast-is-better-than-free adversarial training protocol. It also modifies the logging messages in the `fit` and `fit_generator` functions.

Fixes #505 

## Type of change

- [X] Bug fix (non-breaking)

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
