### PR TITLE
Fix numerical precision in AutoAttack success criteria

### DIFF
--- a/art/attacks/evasion/auto_attack.py
+++ b/art/attacks/evasion/auto_attack.py
@@ -151,10 +151,10 @@ class AutoAttack(EvasionAttack):
             x_robust_adv = attack.generate(x=x_robust, y=y_robust)
             y_pred_robust_adv = self.estimator_orig.predict(x_robust_adv)
 
-            norm_is_smaller_eps = (
-                np.linalg.norm((x_robust_adv - x_robust).reshape((x_robust_adv.shape[0], -1)), axis=1, ord=self.norm)
-                <= self.eps
-            )
+            rel_acc = 1e-4
+            norm_is_smaller_eps = (1 - rel_acc) * np.linalg.norm(
+                (x_robust_adv - x_robust).reshape((x_robust_adv.shape[0], -1)), axis=1, ord=self.norm
+            ) <= self.eps
 
             sample_is_not_robust = np.logical_and(
                 np.argmax(y_pred_robust_adv, axis=1) != np.argmax(y_robust, axis=1), norm_is_smaller_eps


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request fixes the numerical accuracy issue in the success criteria of `AutoAttack` comparing the adversarial perturbation to `eps`.

Fixes #507

## Type of change

Please check all relevant options.

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
