### PR TITLE
Add `verbose` parameter

### DIFF
--- a/art/attacks/evasion/carlini.py
+++ b/art/attacks/evasion/carlini.py
@@ -70,6 +70,7 @@ class CarliniL2Method(EvasionAttack):
         "max_halving",
         "max_doubling",
         "batch_size",
+        "verbose",
     ]
     _estimator_requirements = (BaseEstimator, ClassGradientsMixin)
 
@@ -85,6 +86,7 @@ class CarliniL2Method(EvasionAttack):
         max_halving: int = 5,
         max_doubling: int = 5,
         batch_size: int = 1,
+        verbose: bool = True,
     ) -> None:
         """
         Create a Carlini L_2 attack instance.
@@ -106,6 +108,7 @@ class CarliniL2Method(EvasionAttack):
         :param max_halving: Maximum number of halving steps in the line search optimization.
         :param max_doubling: Maximum number of doubling steps in the line search optimization.
         :param batch_size: Size of the batch on which adversarial samples are generated.
+        :param verbose: Indicates whether to print verbose messages.
         """
         super(CarliniL2Method, self).__init__(estimator=classifier)
 
@@ -118,6 +121,7 @@ class CarliniL2Method(EvasionAttack):
         self.max_halving = max_halving
         self.max_doubling = max_doubling
         self.batch_size = batch_size
+        self.verbose = verbose
         self._check_params()
 
         # There are internal hyperparameters:
@@ -240,7 +244,7 @@ class CarliniL2Method(EvasionAttack):
 
         # Compute perturbation with implicit batching
         nb_batches = int(np.ceil(x_adv.shape[0] / float(self.batch_size)))
-        for batch_id in trange(nb_batches, desc="C&W L_2"):
+        for batch_id in trange(nb_batches, desc="C&W L_2", disable=not self.verbose):
             batch_index_1, batch_index_2 = batch_id * self.batch_size, (batch_id + 1) * self.batch_size
             x_batch = x_adv[batch_index_1:batch_index_2]
             y_batch = y[batch_index_1:batch_index_2]
@@ -488,6 +492,7 @@ class CarliniLInfMethod(EvasionAttack):
         "max_doubling",
         "eps",
         "batch_size",
+        "verbose",
     ]
     _estimator_requirements = (BaseEstimator, ClassGradientsMixin)
 
@@ -502,6 +507,7 @@ class CarliniLInfMethod(EvasionAttack):
         max_doubling: int = 5,
         eps: float = 0.3,
         batch_size: int = 128,
+        verbose: bool = True,
     ) -> None:
         """
         Create a Carlini L_Inf attack instance.
@@ -517,6 +523,7 @@ class CarliniLInfMethod(EvasionAttack):
         :param max_doubling: Maximum number of doubling steps in the line search optimization.
         :param eps: An upper bound for the L_0 norm of the adversarial perturbation.
         :param batch_size: Size of the batch on which adversarial samples are generated.
+        :param verbose: Indicates whether to print verbose messages.
         """
         super(CarliniLInfMethod, self).__init__(estimator=classifier)
 
@@ -528,6 +535,7 @@ class CarliniLInfMethod(EvasionAttack):
         self.max_doubling = max_doubling
         self.eps = eps
         self.batch_size = batch_size
+        self.verbose = verbose
         self._check_params()
 
         # There is one internal hyperparameter:
@@ -621,7 +629,7 @@ class CarliniLInfMethod(EvasionAttack):
 
         # Compute perturbation with implicit batching
         nb_batches = int(np.ceil(x_adv.shape[0] / float(self.batch_size)))
-        for batch_id in trange(nb_batches, desc="C&W L_inf"):
+        for batch_id in trange(nb_batches, desc="C&W L_inf", disable=not self.verbose):
             batch_index_1, batch_index_2 = batch_id * self.batch_size, (batch_id + 1) * self.batch_size
             x_batch = x_adv[batch_index_1:batch_index_2]
             y_batch = y[batch_index_1:batch_index_2]

--- a/art/attacks/evasion/deepfool.py
+++ b/art/attacks/evasion/deepfool.py
@@ -51,6 +51,7 @@ class DeepFool(EvasionAttack):
         "epsilon",
         "nb_grads",
         "batch_size",
+        "verbose",
     ]
     _estimator_requirements = (ClassGradientsMixin,)
 
@@ -61,6 +62,7 @@ class DeepFool(EvasionAttack):
         epsilon: float = 1e-6,
         nb_grads: int = 10,
         batch_size: int = 1,
+        verbose: bool = True,
     ) -> None:
         """
         Create a DeepFool attack instance.
@@ -77,6 +79,7 @@ class DeepFool(EvasionAttack):
         self.epsilon = epsilon
         self.nb_grads = nb_grads
         self.batch_size = batch_size
+        self.verbose = verbose
         self._check_params()
         if self.estimator.clip_values is None:
             logger.warning(
@@ -116,7 +119,10 @@ class DeepFool(EvasionAttack):
         tol = 10e-8
 
         # Compute perturbation with implicit batching
-        for batch_id in trange(int(np.ceil(x_adv.shape[0] / float(self.batch_size))), desc="DeepFool"):
+        for batch_id in trange(
+                int(np.ceil(x_adv.shape[0] / float(self.batch_size))),
+                desc="DeepFool",
+                disable=not self.verbose):
             batch_index_1, batch_index_2 = batch_id * self.batch_size, (batch_id + 1) * self.batch_size
             batch = x_adv[batch_index_1:batch_index_2].copy()
 


### PR DESCRIPTION
Signed-off-by: Ben <bstriner@gmail.com>

# Description

Add a `verbose` parameter that enables/disables the `tqdm` progress bar to CWL1, CWL2 and DF. Add `tqdm(..., disable=not self.verbose)`. Minor new feature. Defaults to `true` to match current behavior and named `verbose` to match other attacks.

Fixes # (issue)

## Type of change

Please check all relevant options.

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Testing

Manual testing.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
