### PR TITLE
Update requirements.txt to Pillow 7.1.0 to prevent vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ scipy==1.4.1
 matplotlib==3.2.1
 scikit-learn==0.22.1
 six==1.13.0
-Pillow==6.2.2
+Pillow==7.1.0
 tqdm==4.45.0
 statsmodels==0.11.0
 pydub==0.24.1


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

Update requirements.txt to Pillow 7.1.0 to prevent vulnerabilities in earlier versions.

Fixes dependabot alert

