### PR TITLE
SquareAttack: Use model predictions if true labels not provided

### DIFF
--- a/art/attacks/evasion/square_attack.py
+++ b/art/attacks/evasion/square_attack.py
@@ -32,7 +32,7 @@ from art.config import ART_NUMPY_DTYPE
 from art.attacks.attack import EvasionAttack
 from art.estimators.estimator import BaseEstimator
 from art.estimators.classification.classifier import ClassifierMixin, ClassifierGradients
-from art.utils import check_and_transform_label_format
+from art.utils import check_and_transform_label_format, get_labels_np_array
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +105,11 @@ class SquareAttack(EvasionAttack):
         x_adv = x.astype(ART_NUMPY_DTYPE)
 
         y = check_and_transform_label_format(y, self.estimator.nb_classes)
+
+        if y is None:
+            # Use model predictions as true labels
+            logger.info("Using model predictions as true labels.")
+            y = get_labels_np_array(self.estimator.predict(x, batch_size=self.batch_size))
 
         if self.estimator.channels_first:
             channels = x.shape[1]


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request extends `SquareAttack` to use model predictions if true labels are not provided.

Fixes #536 

## Type of change

Please check all relevant options.

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
