### PR TITLE
Add support for rectangular images and videos to AdversarialPatch attack

### DIFF
--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
@@ -226,8 +226,11 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
         )
 
         image_mask = tf.pad(
-            image_mask, paddings=tf.constant([[0, 0, ], [0, 0, ], [100, 100], [0, 0]]), mode='CONSTANT',
-            constant_values=0, name=None
+            image_mask,
+            paddings=tf.constant([[0, 0,], [0, 0,], [100, 100], [0, 0]]),
+            mode="CONSTANT",
+            constant_values=0,
+            name=None,
         )
 
         image_mask = tf.cast(image_mask, images.dtype)
@@ -251,7 +254,11 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
         pad_h_1 = self.image_shape[1] - smallest_image_edge - pad_h_0
 
         padded_patch = tf.pad(
-            padded_patch, paddings=tf.constant([[0, 0], [pad_h_0, pad_h_1], [pad_w_0, pad_w_1], [0, 0]]), mode='CONSTANT', constant_values=0, name=None
+            padded_patch,
+            paddings=tf.constant([[0, 0], [pad_h_0, pad_h_1], [pad_w_0, pad_w_1], [0, 0]]),
+            mode="CONSTANT",
+            constant_values=0,
+            name=None,
         )
 
         padded_patch = tf.cast(padded_patch, images.dtype)
@@ -296,7 +303,9 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
             transform_vectors.append(np.array([a0, a1, a2, b0, b1, b2, 0, 0]).astype(np.float32))
 
         image_mask = tfa.image.transform(image_mask, transform_vectors, "BILINEAR", output_shape=self.image_shape[:2])
-        padded_patch = tfa.image.transform(padded_patch, transform_vectors, "BILINEAR", output_shape=self.image_shape[:2])
+        padded_patch = tfa.image.transform(
+            padded_patch, transform_vectors, "BILINEAR", output_shape=self.image_shape[:2]
+        )
         inverted_mask = 1 - image_mask
 
         return images * inverted_mask + padded_patch * image_mask

--- a/tests/attacks/test_adversarial_patch.py
+++ b/tests/attacks/test_adversarial_patch.py
@@ -19,9 +19,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import unittest
-import numpy as np
 
-from art.attacks.evasion.adversarial_patch.adversarial_patch import AdversarialPatch
+import numpy as np
+import keras
+import tensorflow as tf
+
+from art.attacks.evasion.adversarial_patch.adversarial_patch import AdversarialPatch, AdversarialPatchNumpy
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin
 from art.estimators.classification.classifier import ClassifierMixin
 
@@ -43,8 +46,8 @@ class TestAdversarialPatch(TestBase):
         master_seed(seed=1234)
         super().setUpClass()
 
-        cls.n_train = 10
-        cls.n_test = 10
+        cls.n_train = 1
+        cls.n_test = 1
         cls.x_train_mnist = cls.x_train_mnist[0 : cls.n_train]
         cls.y_train_mnist = cls.y_train_mnist[0 : cls.n_train]
         cls.x_test_mnist = cls.x_test_mnist[0 : cls.n_test]
@@ -54,14 +57,41 @@ class TestAdversarialPatch(TestBase):
         master_seed(seed=1234)
         super().setUp()
 
-    def test_tensorflow(self):
+    def test_tensorflow_numpy(self):
         """
         First test with the TensorFlowClassifier.
         :return:
         """
         import tensorflow as tf
 
-        tfc, sess = get_image_classifier_tf()
+        tfc, sess = get_image_classifier_tf(from_logits=True)
+
+        attack_ap = AdversarialPatchNumpy(
+            tfc, rotation_max=0.5, scale_min=0.4, scale_max=0.41, learning_rate=5.0, batch_size=10, max_iter=5,
+        )
+
+        target = np.zeros(self.x_train_mnist.shape[0])
+        patch_adv, _ = attack_ap.generate(self.x_train_mnist, target, shuffle=False)
+
+        if tf.__version__[0] == "2":
+            self.assertAlmostEqual(patch_adv[8, 8, 0], 0.67151666, delta=0.05)
+            self.assertAlmostEqual(patch_adv[14, 14, 0], 0.6292826, delta=0.05)
+            self.assertAlmostEqual(float(np.sum(patch_adv)), 424.31439208984375, delta=1.0)
+        else:
+            self.assertAlmostEqual(patch_adv[8, 8, 0], 0.67151666, delta=0.05)
+            self.assertAlmostEqual(patch_adv[14, 14, 0], 0.6292826, delta=0.05)
+            self.assertAlmostEqual(float(np.sum(patch_adv)), 424.31439208984375, delta=1.0)
+
+        if sess is not None:
+            sess.close()
+
+    @unittest.skipIf(int(tf.__version__.split(".")[0]) != 2, reason="Skip unittests if not TensorFlow>=2.0.")
+    def test_tensorflow_v2_framework(self):
+        """
+        First test with the TensorFlowClassifier.
+        :return:
+        """
+        tfc, _ = get_image_classifier_tf(from_logits=True)
 
         attack_ap = AdversarialPatch(
             tfc,
@@ -73,58 +103,55 @@ class TestAdversarialPatch(TestBase):
             max_iter=5,
             patch_shape=(28, 28, 1),
         )
+
         target = np.zeros(self.x_train_mnist.shape[0])
         patch_adv, _ = attack_ap.generate(self.x_train_mnist, target, shuffle=False)
 
-        if tf.__version__[0] == "2":
-            self.assertAlmostEqual(patch_adv[8, 8, 0], 0.55935985, delta=0.05)
-            self.assertAlmostEqual(patch_adv[14, 14, 0], 0.5917497, delta=0.05)
-            self.assertAlmostEqual(float(np.sum(patch_adv)), 400.0701904296875, delta=1.0)
-        else:
-            self.assertAlmostEqual(patch_adv[8, 8, 0], 0.5332792, delta=0.05)
-            self.assertAlmostEqual(patch_adv[14, 14, 0], 0.54590017, delta=0.05)
-            self.assertAlmostEqual(float(np.sum(patch_adv)), 398.8515625, delta=1.0)
+        self.assertAlmostEqual(patch_adv[8, 8, 0], 0.123679265, delta=0.05)
+        self.assertAlmostEqual(patch_adv[14, 14, 0], 0.0, delta=0.05)
+        self.assertAlmostEqual(float(np.sum(patch_adv)), 411.5689392089844, delta=1.0)
 
-        if sess is not None:
-            sess.close()
-
+    @unittest.skipIf(
+        int(keras.__version__.split(".")[0]) == 2 and int(keras.__version__.split(".")[1]) < 3,
+        reason="Skip unittests if not Keras>=2.3.",
+    )
     def test_keras(self):
         """
         Second test with the KerasClassifier.
         :return:
         """
-        krc = get_image_classifier_kr()
+        krc = get_image_classifier_kr(from_logits=True)
 
         attack_ap = AdversarialPatch(
             krc, rotation_max=0.5, scale_min=0.4, scale_max=0.41, learning_rate=5.0, batch_size=10, max_iter=5
         )
-        master_seed(seed=1234)
+
         target = np.zeros(self.x_train_mnist.shape[0])
         patch_adv, _ = attack_ap.generate(self.x_train_mnist, target)
 
-        self.assertAlmostEqual(patch_adv[8, 8, 0], 0.7993435, delta=0.05)
-        self.assertAlmostEqual(patch_adv[14, 14, 0], 1.0, delta=0.05)
-        self.assertAlmostEqual(float(np.sum(patch_adv)), 392.3392333984375, delta=1.0)
+        self.assertAlmostEqual(patch_adv[8, 8, 0], 0.67151666, delta=0.05)
+        self.assertAlmostEqual(patch_adv[14, 14, 0], 0.6292826, delta=0.05)
+        self.assertAlmostEqual(float(np.sum(patch_adv)), 424.31439208984375, delta=1.0)
 
     def test_pytorch(self):
         """
         Third test with the PyTorchClassifier.
         :return:
         """
-        ptc = get_image_classifier_pt()
+        ptc = get_image_classifier_pt(from_logits=True)
 
         x_train = np.reshape(self.x_train_mnist, (self.n_train, 1, 28, 28)).astype(np.float32)
 
         attack_ap = AdversarialPatch(
             ptc, rotation_max=0.5, scale_min=0.4, scale_max=0.41, learning_rate=5.0, batch_size=10, max_iter=5
         )
-        master_seed(seed=1234)
+
         target = np.zeros(self.x_train_mnist.shape[0])
         patch_adv, _ = attack_ap.generate(x_train, target)
 
-        self.assertAlmostEqual(patch_adv[0, 8, 8], 0.5002671, delta=0.05)
-        self.assertAlmostEqual(patch_adv[0, 14, 14], 0.5109714, delta=0.05)
-        self.assertAlmostEqual(float(np.sum(patch_adv)), 393.09832763671875, delta=1.0)
+        self.assertAlmostEqual(patch_adv[0, 8, 8], 0.6715167, delta=0.05)
+        self.assertAlmostEqual(patch_adv[0, 14, 14], 0.6292826, delta=0.05)
+        self.assertAlmostEqual(float(np.sum(patch_adv)), 424.31439208984375, delta=1.0)
 
     def test_failure_feature_vectors(self):
         attack_params = {
@@ -137,16 +164,15 @@ class TestAdversarialPatch(TestBase):
         }
         classifier = get_tabular_classifier_kr()
         classifier._clip_values = (0, 1)
-        attack = AdversarialPatch(classifier=classifier)
-        attack.set_params(**attack_params)
-        data = np.random.rand(10, 4)
-        labels = np.random.randint(0, 3, 10)
 
         # Assert that value error is raised for feature vectors
         with self.assertRaises(ValueError) as context:
-            attack.generate(data, labels)
+            _ = AdversarialPatch(classifier=classifier)
 
-        self.assertIn("Feature vectors detected.", str(context.exception))
+        self.assertIn(
+            "Wrong input_shape in estimator detected. AdversarialPatch is expecting images as input.",
+            str(context.exception),
+        )
 
     def test_classifier_type_check_fail(self):
         backend_test_classifier_type_check_fail(AdversarialPatch, [BaseEstimator, NeuralNetworkMixin, ClassifierMixin])

--- a/tests/attacks/test_adversarial_patch.py
+++ b/tests/attacks/test_adversarial_patch.py
@@ -170,7 +170,7 @@ class TestAdversarialPatch(TestBase):
             _ = AdversarialPatch(classifier=classifier)
 
         self.assertIn(
-            "Wrong input_shape in estimator detected. AdversarialPatch is expecting images as input.",
+            "Unexpected input_shape in estimator detected. AdversarialPatch is expecting images or videos as input.",
             str(context.exception),
         )
 


### PR DESCRIPTION
# Description

This pull request adds support for rectangular images and videos to `AdversarialPatch` attack including `AdversarialPatchNunpy` and `AdversarialPatchTensorFlowV2`.

- `AdversarialPatchNunpy` supports videos of shape `NFCHW` or `NFHWC`
- `AdversarialPatchTensorFlowV2` supports videos of shape `NFHWC`

This pull request builds on PR #404 by @yusong-tan , thank you very much.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
