### PR TITLE
Extend framework-specific preprocessing defences to TensorFlow v2

### DIFF
--- a/art/defences/preprocessor/__init__.py
+++ b/art/defences/preprocessor/__init__.py
@@ -11,6 +11,8 @@ from art.defences.preprocessor.pixel_defend import PixelDefend
 from art.defences.preprocessor.preprocessor import Preprocessor
 from art.defences.preprocessor.resample import Resample
 from art.defences.preprocessor.spatial_smoothing import SpatialSmoothing
+from art.defences.preprocessor.spatial_smoothing_pytorch import SpatialSmoothingPyTorch
+from art.defences.preprocessor.spatial_smoothing_tensorflow import SpatialSmoothingTensorFlowV2
 from art.defences.preprocessor.thermometer_encoding import ThermometerEncoding
 from art.defences.preprocessor.variance_minimization import TotalVarMin
 from art.defences.preprocessor.video_compression import VideoCompression

--- a/art/defences/preprocessor/preprocessor.py
+++ b/art/defences/preprocessor/preprocessor.py
@@ -21,9 +21,12 @@ This module implements the abstract base class for defences that pre-process inp
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import abc
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    import torch
 
 
 class Preprocessor(abc.ABC):

--- a/art/defences/preprocessor/preprocessor.py
+++ b/art/defences/preprocessor/preprocessor.py
@@ -125,6 +125,8 @@ class PreprocessorPyTorch(Preprocessor):
     Abstract base class for preprocessing defences implemented in PyTorch that support efficient preprocessor-chaining.
     """
 
+    import torch
+
     @abc.abstractmethod
     def forward(self, x: torch.Tensor, y: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """
@@ -137,7 +139,9 @@ class PreprocessorPyTorch(Preprocessor):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def estimate_forward(self, x: tf.Tensor, y: Optional[tf.Tensor] = None) -> Tuple[tf.Tensor, Optional[tf.Tensor]]:
+    def estimate_forward(
+        self, x: torch.Tensor, y: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """
         Provide a differentiable estimate of the forward function, so that autograd can calculate gradients
         of the defence for the backward pass. If the defence is differentiable, just call `self.forward()`.
@@ -156,6 +160,8 @@ class PreprocessorTensorFlowV2(Preprocessor):
     Abstract base class for preprocessing defences implemented in TensorFlow v2 that support efficient
     preprocessor-chaining.
     """
+
+    import tensorflow as tf
 
     @abc.abstractmethod
     def forward(self, x: tf.Tensor, y: Optional[tf.Tensor] = None) -> Tuple[tf.Tensor, Optional[tf.Tensor]]:

--- a/art/defences/preprocessor/preprocessor.py
+++ b/art/defences/preprocessor/preprocessor.py
@@ -27,6 +27,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     import torch
+    import tensorflow as tf
 
 
 class Preprocessor(abc.ABC):
@@ -124,8 +125,6 @@ class PreprocessorPyTorch(Preprocessor):
     Abstract base class for preprocessing defences implemented in PyTorch that support efficient preprocessor-chaining.
     """
 
-    import torch
-
     @abc.abstractmethod
     def forward(self, x: torch.Tensor, y: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """
@@ -138,9 +137,39 @@ class PreprocessorPyTorch(Preprocessor):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def estimate_forward(self,
-                         x: torch.Tensor,
-                         y: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def estimate_forward(self, x: tf.Tensor, y: Optional[tf.Tensor] = None) -> Tuple[tf.Tensor, Optional[tf.Tensor]]:
+        """
+        Provide a differentiable estimate of the forward function, so that autograd can calculate gradients
+        of the defence for the backward pass. If the defence is differentiable, just call `self.forward()`.
+        If the defence is not differentiable and a differentiable estimate is not available, replace with
+        an identity function.
+
+        :param x: Dataset to be preprocessed.
+        :param y: Labels to be preprocessed.
+        :return: Preprocessed data.
+        """
+        raise NotImplementedError
+
+
+class PreprocessorTensorFlowV2(Preprocessor):
+    """
+    Abstract base class for preprocessing defences implemented in TensorFlow v2 that support efficient
+    preprocessor-chaining.
+    """
+
+    @abc.abstractmethod
+    def forward(self, x: tf.Tensor, y: Optional[tf.Tensor] = None) -> Tuple[tf.Tensor, Optional[tf.Tensor]]:
+        """
+        Perform data preprocessing in TensorFlow v2 and return preprocessed data as tuple.
+
+        :param x: Dataset to be preprocessed.
+        :param y: Labels to be preprocessed.
+        :return: Preprocessed data.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def estimate_forward(self, x: tf.Tensor, y: Optional[tf.Tensor] = None) -> Tuple[tf.Tensor, Optional[tf.Tensor]]:
         """
         Provide a differentiable estimate of the forward function, so that autograd can calculate gradients
         of the defence for the backward pass. If the defence is differentiable, just call `self.forward()`.

--- a/art/defences/preprocessor/spatial_smoothing_pytorch.py
+++ b/art/defences/preprocessor/spatial_smoothing_pytorch.py
@@ -52,6 +52,7 @@ class SpatialSmoothingPyTorch(PreprocessorPyTorch):
         https://arxiv.org/abs/1902.06705
     """
 
+    import torch
     from kornia.filters import MedianBlur
 
     class MedianBlurCustom(MedianBlur):
@@ -122,6 +123,8 @@ class SpatialSmoothingPyTorch(PreprocessorPyTorch):
         :param device_type: Type of device on which the classifier is run, either `gpu` or `cpu`.
         :param **kwargs: Parameters from the parent.
         """
+        import torch
+
         super().__init__()
 
         self._apply_fit = apply_fit
@@ -134,8 +137,6 @@ class SpatialSmoothingPyTorch(PreprocessorPyTorch):
         self.median_blur = self.MedianBlurCustom(kernel_size=(self.window_size, self.window_size))
 
         # Set device
-        import torch
-
         if device_type == "cpu" or not torch.cuda.is_available():
             self._device = torch.device("cpu")
         else:

--- a/art/defences/preprocessor/spatial_smoothing_pytorch.py
+++ b/art/defences/preprocessor/spatial_smoothing_pytorch.py
@@ -73,7 +73,6 @@ class SpatialSmoothingPyTorch(PreprocessorPyTorch):
 
         def forward(self, input: torch.Tensor):  # type: ignore
             import torch
-            from kornia.filters.kernels import get_binary_kernel2d
             import torch.nn.functional as F
 
             if not torch.is_tensor(input):
@@ -88,7 +87,7 @@ class SpatialSmoothingPyTorch(PreprocessorPyTorch):
             _input = input.reshape(b * c, 1, h, w)
             if input.dtype == torch.int64:
                 # "reflection_pad2d" not implemented for 'Long'
-                # "reflect" in scipy.ndimage.median_filter has no equivalance in F.pad.
+                # "reflect" in scipy.ndimage.median_filter has no equivalence in F.pad.
                 # "reflect" in PyTorch maps to "mirror" in scipy.ndimage.median_filter.
                 _input = _input.to(torch.float32)
                 _input = F.pad(_input, self.p2d, "reflect")

--- a/art/defences/preprocessor/spatial_smoothing_pytorch.py
+++ b/art/defences/preprocessor/spatial_smoothing_pytorch.py
@@ -34,8 +34,6 @@ import numpy as np
 
 from art.config import CLIP_VALUES_TYPE
 from art.defences.preprocessor.preprocessor import PreprocessorPyTorch
-from art.defences.preprocessor.spatial_smoothing import SpatialSmoothing
-from art.utils import Deprecated, deprecated_keyword_arg
 
 logger = logging.getLogger(__name__)
 

--- a/art/defences/preprocessor/spatial_smoothing_pytorch.py
+++ b/art/defences/preprocessor/spatial_smoothing_pytorch.py
@@ -52,7 +52,7 @@ class SpatialSmoothingPyTorch(PreprocessorPyTorch):
         https://arxiv.org/abs/1902.06705
     """
 
-    import torch
+    import torch  # lgtm [py/repeated-import]
     from kornia.filters import MedianBlur
 
     class MedianBlurCustom(MedianBlur):
@@ -60,7 +60,7 @@ class SpatialSmoothingPyTorch(PreprocessorPyTorch):
         An ongoing effort to reproduce the median blur function in SciPy.
         """
 
-        import torch
+        import torch  # lgtm [py/repeated-import]
 
         def __init__(self, kernel_size: Tuple[int, int]) -> None:
             super().__init__(kernel_size)
@@ -77,7 +77,7 @@ class SpatialSmoothingPyTorch(PreprocessorPyTorch):
             # PyTorch requires Padding size should be less than the corresponding input dimension,
 
         def forward(self, input: torch.Tensor):  # type: ignore
-            import torch
+            import torch  # lgtm [py/repeated-import]
             import torch.nn.functional as F
 
             if not torch.is_tensor(input):
@@ -123,7 +123,7 @@ class SpatialSmoothingPyTorch(PreprocessorPyTorch):
         :param device_type: Type of device on which the classifier is run, either `gpu` or `cpu`.
         :param **kwargs: Parameters from the parent.
         """
-        import torch
+        import torch  # lgtm [py/repeated-import]
 
         super().__init__()
 
@@ -221,7 +221,7 @@ class SpatialSmoothingPyTorch(PreprocessorPyTorch):
         :param y: Labels of the sample `x`. This function does not affect them in any way.
         :return: Smoothed sample.
         """
-        import torch
+        import torch  # lgtm [py/repeated-import]
 
         x = torch.tensor(x, device=self._device)
         if y is not None:
@@ -237,7 +237,7 @@ class SpatialSmoothingPyTorch(PreprocessorPyTorch):
 
     # Backward compatibility.
     def estimate_gradient(self, x: np.ndarray, grad: np.ndarray) -> np.ndarray:
-        import torch
+        import torch  # lgtm [py/repeated-import]
 
         x = torch.tensor(x, device=self._device, requires_grad=True)
         grad = torch.tensor(grad, device=self._device)

--- a/art/defences/preprocessor/spatial_smoothing_tensorflow.py
+++ b/art/defences/preprocessor/spatial_smoothing_tensorflow.py
@@ -53,7 +53,7 @@ class SpatialSmoothingTensorFlowV2(PreprocessorTensorFlowV2):
         https://arxiv.org/abs/1902.06705
     """
 
-    import tensorflow as tf
+    import tensorflow as tf  # lgtm [py/repeated-import]
 
     def __init__(
         self,
@@ -68,7 +68,7 @@ class SpatialSmoothingTensorFlowV2(PreprocessorTensorFlowV2):
 
         :param **kwargs: Parameters from the parent.
         """
-        import tensorflow as tf
+        import tensorflow as tf  # lgtm [py/repeated-import]
 
         super().__init__()
 
@@ -116,7 +116,7 @@ class SpatialSmoothingTensorFlowV2(PreprocessorTensorFlowV2):
 
         if x_ndim == 4:
             x = x_nhwc
-        elif x_ndim == 5:
+        elif x_ndim == 5:  # lgtm [py/redundant-comparison]
             # NFHWC <-- NHWC
             x = x_nhwc.reshape(nb_clips, clip_size, h, w, c)
 
@@ -139,7 +139,7 @@ class SpatialSmoothingTensorFlowV2(PreprocessorTensorFlowV2):
         :param y: Labels of the sample `x`. This function does not affect them in any way.
         :return: Smoothed sample.
         """
-        import tensorflow as tf
+        import tensorflow as tf  # lgtm [py/repeated-import]
 
         x = tf.convert_to_tensor(x)
         if y is not None:
@@ -154,7 +154,7 @@ class SpatialSmoothingTensorFlowV2(PreprocessorTensorFlowV2):
 
     # Backward compatibility.
     def estimate_gradient(self, x: np.ndarray, grad: np.ndarray) -> np.ndarray:
-        import tensorflow as tf
+        import tensorflow as tf  # lgtm [py/repeated-import]
 
         with tf.GradientTape() as tape:
             x = tf.convert_to_tensor(x, dtype=ART_NUMPY_DTYPE)

--- a/art/defences/preprocessor/spatial_smoothing_tensorflow.py
+++ b/art/defences/preprocessor/spatial_smoothing_tensorflow.py
@@ -1,0 +1,190 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+This module implements the local spatial smoothing defence in `SpatialSmoothing` in PyTorch.
+
+| Paper link: https://arxiv.org/abs/1704.01155
+
+
+| Please keep in mind the limitations of defences. For more information on the limitations of this defence,
+    see https://arxiv.org/abs/1803.09868 . For details on how to evaluate classifier security in general, see
+    https://arxiv.org/abs/1902.06705
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+from typing import Optional, Tuple, TYPE_CHECKING
+
+import numpy as np
+
+from art.utils import ART_NUMPY_DTYPE
+from art.config import CLIP_VALUES_TYPE
+from art.defences.preprocessor.preprocessor import PreprocessorTensorFlowV2
+
+if TYPE_CHECKING:
+    import tensorflow as tf
+
+logger = logging.getLogger(__name__)
+
+
+class SpatialSmoothingTensorFlowV2(PreprocessorTensorFlowV2):
+    """
+    Implement the local spatial smoothing defence approach in TensorFlow v2.
+
+    | Paper link: https://arxiv.org/abs/1704.01155
+
+    | Please keep in mind the limitations of defences. For more information on the limitations of this defence,
+        see https://arxiv.org/abs/1803.09868 . For details on how to evaluate classifier security in general, see
+        https://arxiv.org/abs/1902.06705
+    """
+
+    import tensorflow as tf
+
+    def __init__(
+        self,
+        window_size: int = 3,
+        channels_first: bool = False,
+        clip_values: Optional[CLIP_VALUES_TYPE] = None,
+        apply_fit: bool = False,
+        apply_predict: bool = True,
+    ) -> None:
+        """
+        Create an instance of local spatial smoothing.
+
+        :param **kwargs: Parameters from the parent.
+        """
+        import tensorflow as tf
+
+        super().__init__()
+
+        self._apply_fit = apply_fit
+        self._apply_predict = apply_predict
+        self.channels_first = channels_first
+        self.window_size = window_size
+        self.clip_values = clip_values
+        self._check_params()
+
+        if self.clip_values is not None:
+            self.clip_values = tf.constant(value=self.clip_values)
+
+    @property
+    def apply_fit(self) -> bool:
+        return self._apply_fit
+
+    @property
+    def apply_predict(self) -> bool:
+        return self._apply_predict
+
+    def forward(self, x: tf.Tensor, y: Optional[tf.Tensor] = None) -> Tuple[tf.Tensor, Optional[tf.Tensor]]:
+        """
+        Apply local spatial smoothing to sample `x`.
+        """
+        import tensorflow_addons as tfa
+
+        x_ndim = x.ndim
+
+        if x_ndim == 4:
+            x_nhwc = x
+        elif x_ndim == 5:
+            # NFHWC --> NHWC
+            nb_clips, clip_size, h, w, c = x.shape
+            x_nhwc = x.reshape(nb_clips * clip_size, h, w, c)
+        else:
+            raise ValueError(
+                "Unrecognized input dimension. Spatial smoothing can only be applied to image (NHWC) and video (NFHWC) "
+                "data."
+            )
+
+        x_nhwc = tfa.image.median_filter2d(
+            x_nhwc, filter_shape=[self.window_size, self.window_size], padding="REFLECT", constant_values=0, name=None
+        )
+
+        if x_ndim == 4:
+            x = x_nhwc
+        elif x_ndim == 5:
+            # NFHWC <-- NHWC
+            x = x_nhwc.reshape(nb_clips, clip_size, h, w, c)
+
+        if self.clip_values is not None:
+            x = x.clip_by_value(min=self.clip_values[0], max=self.clip_values[1])
+
+        return x, y
+
+    def estimate_forward(self, x: tf.Tensor, y: Optional[tf.Tensor] = None) -> Tuple[tf.Tensor, Optional[tf.Tensor]]:
+        """
+        No need to estimate, since the forward pass is differentiable.
+        """
+        return self.forward(x, y)[0]
+
+    def __call__(self, x: np.ndarray, y: Optional[np.ndarray] = None) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+        """
+        Apply local spatial smoothing to sample `x`.
+
+        :param x: Sample to smooth with shape `(batch_size, width, height, depth)`.
+        :param y: Labels of the sample `x`. This function does not affect them in any way.
+        :return: Smoothed sample.
+        """
+        import tensorflow as tf
+
+        x = tf.convert_to_tensor(x)
+        if y is not None:
+            y = tf.convert_to_tensor(y)
+
+        x, y = self.forward(x, y)
+
+        result = x.numpy()
+        if y is not None:
+            y = y.numpy()
+        return result, y
+
+    # Backward compatibility.
+    def estimate_gradient(self, x: np.ndarray, grad: np.ndarray) -> np.ndarray:
+        import tensorflow as tf
+
+        with tf.GradientTape() as tape:
+            x = tf.convert_to_tensor(x, dtype=ART_NUMPY_DTYPE)
+            tape.watch(x)
+            grad = tf.convert_to_tensor(grad, dtype=ART_NUMPY_DTYPE)
+
+            x_prime = self.estimate_forward(x)
+
+        x_grad = tape.gradient(target=x_prime, sources=x, output_gradients=grad)
+
+        x_grad = x_grad.numpy()
+        if x_grad.shape != x.shape:
+            raise ValueError("The input shape is {} while the gradient shape is {}".format(x.shape, x_grad.shape))
+        return x_grad
+
+    def fit(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> None:
+        """
+        No parameters to learn for this method; do nothing.
+        """
+        pass
+
+    def _check_params(self) -> None:
+        if not (isinstance(self.window_size, (int, np.int)) and self.window_size > 0):
+            raise ValueError("Sliding window size must be a positive integer.")
+
+        if self.clip_values is not None and len(self.clip_values) != 2:
+            raise ValueError("'clip_values' should be a tuple of 2 floats or arrays containing the allowed data range.")
+
+        if self.clip_values is not None and np.array(self.clip_values[0] >= self.clip_values[1]).any():
+            raise ValueError("Invalid 'clip_values': min >= max.")
+
+        if self.channels_first:
+            raise ValueError("Only channels last input data is supported (`channels_first=False`)")

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -111,6 +111,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
             preprocessing=preprocessing,
+            device_type=device_type,
         )
         self._nb_classes = nb_classes
         self._input_shape = input_shape
@@ -121,13 +122,6 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
 
         # Get the internal layers
         self._layer_names = self._model.get_layers
-
-        # Set device
-        if device_type == "cpu" or not torch.cuda.is_available():
-            self._device = torch.device("cpu")
-        else:
-            cuda_idx = torch.cuda.current_device()
-            self._device = torch.device("cuda:{}".format(cuda_idx))
 
         self._model.to(self._device)
 

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -28,7 +28,6 @@ import time
 from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
-import torch
 import six
 
 from art.config import ART_DATA_PATH, CLIP_VALUES_TYPE, PREPROCESSING_TYPE
@@ -37,7 +36,6 @@ from art.estimators.classification.classifier import (
     ClassifierMixin,
 )
 from art.estimators.pytorch import PyTorchEstimator
-from art.defences.preprocessor.preprocessor import PreprocessorPyTorch
 from art.utils import Deprecated, deprecated_keyword_arg, check_and_transform_label_format
 
 if TYPE_CHECKING:
@@ -703,117 +701,3 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
 
         except ImportError:
             raise ImportError("Could not find PyTorch (`torch`) installation.")
-
-    def _apply_preprocessing_defences(self, x, y, fit: bool = False) -> Tuple[Any, Any]:
-        """
-        Apply all preprocessing defences of the estimator on the raw inputs `x` and `y`. This function is should
-        only be called from function `_apply_preprocessing`.
-
-        The method overrides art.estimators.estimator::BaseEstimator._apply_preprocessing_defences().
-        It requires all defenses to have a method `forward()`.
-        It converts numpy arrays to PyTorch tensors first, then chains a series of defenses by calling
-        defence.forward() which contains PyTorch operations. At the end, it converts PyTorch tensors
-        back to numpy arrays.
-
-        :param x: Samples.
-        :type x: Format as expected by the `model`
-        :param y: Target values.
-        :type y: Format as expected by the `model`
-        :param fit: `True` if the function is call before fit/training and `False` if the function is called before a
-                    predict operation.
-        :return: Tuple of `x` and `y` after applying the defences and standardisation.
-        :rtype: Format as expected by the `model`
-        """
-
-        if not hasattr(self, "preprocessing_defences") or \
-           self.preprocessing_defences is None or \
-           len(self.preprocessing_defences) == 0:
-            return x, y
-
-        if len(self.preprocessing_defences) == 1:
-            # Compatible with non-PyTorch defences if no chaining.
-            defence = self.preprocessing_defences[0]
-            x, y = defence(x, y)
-        else:
-            # Check if all defences are implemented in PyTorch.
-            for defence in self.preprocessing_defences:
-                if not isinstance(defence, PreprocessorPyTorch):
-                    raise NotImplementedError(f"{defence.__class__} is not PyTorch-specific.")
-
-            # Convert np arrays to torch tensors.
-            x = torch.tensor(x, device=self._device)
-            if y is not None:
-                y = torch.tensor(y, device=self._device)
-
-            with torch.no_grad():
-                for defence in self.preprocessing_defences:
-                    if fit:
-                        if defence.apply_fit:
-                            x, y = defence.forward(x, y)
-                    else:
-                        if defence.apply_predict:
-                            x, y = defence.forward(x, y)
-
-            # Convert torch tensors back to np arrays.
-            x = x.cpu().numpy()
-            if y is not None:
-                y = y.cpu().numpy()
-
-        return x, y
-
-    def _apply_preprocessing_defences_gradient(self, x, gradients, fit=False):
-        """
-        Apply the backward pass to the gradients through all preprocessing defences that have been applied to `x`
-        and `y` in the forward pass. This function is should only be called from function
-        `_apply_preprocessing_gradient`.
-
-        The method overrides art.estimators.estimator::LossGradientsMixin._apply_preprocessing_defences_gradient().
-        It requires all defenses to have a method estimate_forward().
-        It converts numpy arrays to PyTorch tensors first, then chains a series of defenses by calling
-        defence.estimate_forward() which contains differentiable estimate of the operations. At the end,
-        it converts PyTorch tensors back to numpy arrays.
-
-        :param x: Samples.
-        :type x: Format as expected by the `model`
-        :param gradients: Gradients before backward pass through preprocessing defences.
-        :type gradients: Format as expected by the `model`
-        :param fit: `True` if the gradients are computed during training.
-        :return: Gradients after backward pass through preprocessing defences.
-        :rtype: Format as expected by the `model`
-        """
-        if not hasattr(self, "preprocessing_defences") or \
-           self.preprocessing_defences is None or \
-           len(self.preprocessing_defences) == 0:
-            return gradients
-
-        if len(self.preprocessing_defences) == 1:
-            # Compatible with non-PyTorch defences if no chaining.
-            defence = self.preprocessing_defences[0]
-            gradients = defence.estimate_gradient(x, gradients)
-        else:
-            # Check if all defences are implemented in PyTorch.
-            for defence in self.preprocessing_defences:
-                if not isinstance(defence, PreprocessorPyTorch):
-                    raise NotImplementedError(f"{defence.__class__} is not PyTorch-specific.")
-
-            # Convert np arrays to torch tensors.
-            x = torch.tensor(x, device=self._device, requires_grad=True)
-            gradients = torch.tensor(gradients, device=self._device)
-            x_orig = x
-
-            for defence in self.preprocessing_defences:
-                if fit:
-                    if defence.apply_fit:
-                        x = defence.estimate_forward(x)
-                else:
-                    if defence.apply_predict:
-                        x = defence.estimate_forward(x)
-
-            x.backward(gradients)
-
-            # Convert torch tensors back to np arrays.
-            gradients = x_orig.grad.detach().cpu().numpy()
-            if gradients.shape != x_orig.shape:
-                raise ValueError("The input shape is {} while the gradient shape is {}".format(
-                    x.shape, gradients.shape))
-        return gradients

--- a/art/estimators/pytorch.py
+++ b/art/estimators/pytorch.py
@@ -19,6 +19,7 @@
 This module implements the abstract estimator `PyTorchEstimator` for PyTorch models.
 """
 import logging
+from typing import Any, Tuple
 
 import numpy as np
 
@@ -27,6 +28,7 @@ from art.estimators.estimator import (
     LossGradientsMixin,
     NeuralNetworkMixin,
 )
+from art.defences.preprocessor.preprocessor import PreprocessorPyTorch
 
 logger = logging.getLogger(__name__)
 
@@ -66,3 +68,120 @@ class PyTorchEstimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimator):
         :param nb_epochs: Number of training epochs.
         """
         NeuralNetworkMixin.fit(self, x, y, batch_size=128, nb_epochs=20, **kwargs)
+
+    def _apply_preprocessing_defences(self, x, y, fit: bool = False) -> Tuple[Any, Any]:
+        """
+        Apply all preprocessing defences of the estimator on the raw inputs `x` and `y`. This function is should
+        only be called from function `_apply_preprocessing`.
+
+        The method overrides art.estimators.estimator::BaseEstimator._apply_preprocessing_defences().
+        It requires all defenses to have a method `forward()`.
+        It converts numpy arrays to PyTorch tensors first, then chains a series of defenses by calling
+        defence.forward() which contains PyTorch operations. At the end, it converts PyTorch tensors
+        back to numpy arrays.
+
+        :param x: Samples.
+        :type x: Format as expected by the `model`
+        :param y: Target values.
+        :type y: Format as expected by the `model`
+        :param fit: `True` if the function is call before fit/training and `False` if the function is called before a
+                    predict operation.
+        :return: Tuple of `x` and `y` after applying the defences and standardisation.
+        :rtype: Format as expected by the `model`
+        """
+        import torch
+
+        if not hasattr(self, "preprocessing_defences") or \
+           self.preprocessing_defences is None or \
+           len(self.preprocessing_defences) == 0:
+            return x, y
+
+        if len(self.preprocessing_defences) == 1:
+            # Compatible with non-PyTorch defences if no chaining.
+            defence = self.preprocessing_defences[0]
+            x, y = defence(x, y)
+        else:
+            # Check if all defences are implemented in PyTorch.
+            for defence in self.preprocessing_defences:
+                if not isinstance(defence, PreprocessorPyTorch):
+                    raise NotImplementedError(f"{defence.__class__} is not PyTorch-specific.")
+
+            # Convert np arrays to torch tensors.
+            x = torch.tensor(x, device=self._device)
+            if y is not None:
+                y = torch.tensor(y, device=self._device)
+
+            with torch.no_grad():
+                for defence in self.preprocessing_defences:
+                    if fit:
+                        if defence.apply_fit:
+                            x, y = defence.forward(x, y)
+                    else:
+                        if defence.apply_predict:
+                            x, y = defence.forward(x, y)
+
+            # Convert torch tensors back to np arrays.
+            x = x.cpu().numpy()
+            if y is not None:
+                y = y.cpu().numpy()
+
+        return x, y
+
+    def _apply_preprocessing_defences_gradient(self, x, gradients, fit=False):
+        """
+        Apply the backward pass to the gradients through all preprocessing defences that have been applied to `x`
+        and `y` in the forward pass. This function is should only be called from function
+        `_apply_preprocessing_gradient`.
+
+        The method overrides art.estimators.estimator::LossGradientsMixin._apply_preprocessing_defences_gradient().
+        It requires all defenses to have a method estimate_forward().
+        It converts numpy arrays to PyTorch tensors first, then chains a series of defenses by calling
+        defence.estimate_forward() which contains differentiable estimate of the operations. At the end,
+        it converts PyTorch tensors back to numpy arrays.
+
+        :param x: Samples.
+        :type x: Format as expected by the `model`
+        :param gradients: Gradients before backward pass through preprocessing defences.
+        :type gradients: Format as expected by the `model`
+        :param fit: `True` if the gradients are computed during training.
+        :return: Gradients after backward pass through preprocessing defences.
+        :rtype: Format as expected by the `model`
+        """
+        import torch
+
+        if not hasattr(self, "preprocessing_defences") or \
+           self.preprocessing_defences is None or \
+           len(self.preprocessing_defences) == 0:
+            return gradients
+
+        if len(self.preprocessing_defences) == 1:
+            # Compatible with non-PyTorch defences if no chaining.
+            defence = self.preprocessing_defences[0]
+            gradients = defence.estimate_gradient(x, gradients)
+        else:
+            # Check if all defences are implemented in PyTorch.
+            for defence in self.preprocessing_defences:
+                if not isinstance(defence, PreprocessorPyTorch):
+                    raise NotImplementedError(f"{defence.__class__} is not PyTorch-specific.")
+
+            # Convert np arrays to torch tensors.
+            x = torch.tensor(x, device=self._device, requires_grad=True)
+            gradients = torch.tensor(gradients, device=self._device)
+            x_orig = x
+
+            for defence in self.preprocessing_defences:
+                if fit:
+                    if defence.apply_fit:
+                        x = defence.estimate_forward(x)
+                else:
+                    if defence.apply_predict:
+                        x = defence.estimate_forward(x)
+
+            x.backward(gradients)
+
+            # Convert torch tensors back to np arrays.
+            gradients = x_orig.grad.detach().cpu().numpy()
+            if gradients.shape != x_orig.shape:
+                raise ValueError("The input shape is {} while the gradient shape is {}".format(
+                    x.shape, gradients.shape))
+        return gradients

--- a/art/estimators/pytorch.py
+++ b/art/estimators/pytorch.py
@@ -112,9 +112,11 @@ class PyTorchEstimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimator):
         """
         import torch
 
-        if not hasattr(self, "preprocessing_defences") or \
-           self.preprocessing_defences is None or \
-           len(self.preprocessing_defences) == 0:
+        if (
+            not hasattr(self, "preprocessing_defences")
+            or self.preprocessing_defences is None
+            or len(self.preprocessing_defences) == 0
+        ):
             return x, y
 
         if len(self.preprocessing_defences) == 1:
@@ -170,9 +172,11 @@ class PyTorchEstimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimator):
         """
         import torch
 
-        if not hasattr(self, "preprocessing_defences") or \
-           self.preprocessing_defences is None or \
-           len(self.preprocessing_defences) == 0:
+        if (
+            not hasattr(self, "preprocessing_defences")
+            or self.preprocessing_defences is None
+            or len(self.preprocessing_defences) == 0
+        ):
             return gradients
 
         if len(self.preprocessing_defences) == 1:
@@ -203,6 +207,7 @@ class PyTorchEstimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimator):
             # Convert torch tensors back to np arrays.
             gradients = x_orig.grad.detach().cpu().numpy()
             if gradients.shape != x_orig.shape:
-                raise ValueError("The input shape is {} while the gradient shape is {}".format(
-                    x.shape, gradients.shape))
+                raise ValueError(
+                    "The input shape is {} while the gradient shape is {}".format(x.shape, gradients.shape)
+                )
         return gradients

--- a/art/estimators/pytorch.py
+++ b/art/estimators/pytorch.py
@@ -38,11 +38,32 @@ class PyTorchEstimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimator):
     Estimator class for PyTorch models.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, device_type: str = "gpu", **kwargs) -> None:
         """
         Estimator class for PyTorch models.
+
+        :param channels_first: Set channels first or last.
+        :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
+               maximum values allowed for features. If floats are provided, these will be used as the range of all
+               features. If arrays are provided, each value will be considered the bound for a feature, thus
+               the shape of clip values needs to match the total number of features.
+        :param preprocessing_defences: Preprocessing defence(s) to be applied by the classifier.
+        :param postprocessing_defences: Postprocessing defence(s) to be applied by the classifier.
+        :param preprocessing: Tuple of the form `(subtrahend, divisor)` of floats or `np.ndarray` of values to be
+               used for data preprocessing. The first value will be subtracted from the input. The input will then
+               be divided by the second one.
+        :param device_type: Type of device on which the classifier is run, either `gpu` or `cpu`.
         """
+        import torch
+
         super().__init__(**kwargs)
+
+        # Set device
+        if device_type == "cpu" or not torch.cuda.is_available():
+            self._device = torch.device("cpu")
+        else:
+            cuda_idx = torch.cuda.current_device()
+            self._device = torch.device("cuda:{}".format(cuda_idx))
 
     def predict(self, x: np.ndarray, batch_size: int = 128, **kwargs):
         """

--- a/art/estimators/tensorflow.py
+++ b/art/estimators/tensorflow.py
@@ -129,8 +129,8 @@ class TensorFlowV2Estimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimato
 
         The method overrides art.estimators.estimator::BaseEstimator._apply_preprocessing_defences().
         It requires all defenses to have a method `forward()`.
-        It converts numpy arrays to PyTorch tensors first, then chains a series of defenses by calling
-        defence.forward() which contains PyTorch operations. At the end, it converts PyTorch tensors
+        It converts numpy arrays to TensorFlow tensors first, then chains a series of defenses by calling
+        defence.forward() which contains TensorFlow operations. At the end, it converts TensorFlow tensors
         back to numpy arrays.
 
         :param x: Samples.
@@ -152,14 +152,14 @@ class TensorFlowV2Estimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimato
             return x, y
 
         if len(self.preprocessing_defences) == 1:
-            # Compatible with non-PyTorch defences if no chaining.
+            # Compatible with non-TensorFlow defences if no chaining.
             defence = self.preprocessing_defences[0]
             x, y = defence(x, y)
         else:
-            # Check if all defences are implemented in PyTorch.
+            # Check if all defences are implemented in TensorFlow.
             for defence in self.preprocessing_defences:
                 if not isinstance(defence, PreprocessorTensorFlowV2):
-                    raise NotImplementedError(f"{defence.__class__} is not PyTorch-specific.")
+                    raise NotImplementedError(f"{defence.__class__} is not TensorFlow-specific.")
 
             # Convert np arrays to torch tensors.
             x = tf.convert_to_tensor(x)
@@ -189,9 +189,9 @@ class TensorFlowV2Estimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimato
 
         The method overrides art.estimators.estimator::LossGradientsMixin._apply_preprocessing_defences_gradient().
         It requires all defenses to have a method estimate_forward().
-        It converts numpy arrays to PyTorch tensors first, then chains a series of defenses by calling
+        It converts numpy arrays to TensorFlow tensors first, then chains a series of defenses by calling
         defence.estimate_forward() which contains differentiable estimate of the operations. At the end,
-        it converts PyTorch tensors back to numpy arrays.
+        it converts TensorFlow tensors back to numpy arrays.
 
         :param x: Samples.
         :type x: Format as expected by the `model`
@@ -211,11 +211,11 @@ class TensorFlowV2Estimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimato
             return gradients
 
         if len(self.preprocessing_defences) == 1:
-            # Compatible with non-PyTorch defences if no chaining.
+            # Compatible with non-TensorFlow defences if no chaining.
             defence = self.preprocessing_defences[0]
             gradients = defence.estimate_gradient(x, gradients)
         else:
-            # Check if all defences are implemented in PyTorch.
+            # Check if all defences are implemented in TensorFlow.
             for defence in self.preprocessing_defences:
                 if not isinstance(defence, PreprocessorTensorFlowV2):
                     raise NotImplementedError(f"{defence.__class__} is not TensorFlowV2-specific.")

--- a/art/estimators/tensorflow.py
+++ b/art/estimators/tensorflow.py
@@ -19,15 +19,17 @@
 This module implements the abstract estimators `TensorFlowEstimator` and `TensorFlowV2Estimator` for TensorFlow models.
 """
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Tuple
 
 import numpy as np
 
+from art.utils import ART_NUMPY_DTYPE
 from art.estimators.estimator import (
     BaseEstimator,
     LossGradientsMixin,
     NeuralNetworkMixin,
 )
+from art.defences.preprocessor.preprocessor import PreprocessorTensorFlowV2
 
 if TYPE_CHECKING:
     from tensorflow.python.client.session import Session
@@ -119,3 +121,126 @@ class TensorFlowV2Estimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimato
         :param nb_epochs: Number of training epochs.
         """
         NeuralNetworkMixin.fit(self, x, y, batch_size=128, nb_epochs=20, **kwargs)
+
+    def _apply_preprocessing_defences(self, x, y, fit: bool = False) -> Tuple[Any, Any]:
+        """
+        Apply all preprocessing defences of the estimator on the raw inputs `x` and `y`. This function is should
+        only be called from function `_apply_preprocessing`.
+
+        The method overrides art.estimators.estimator::BaseEstimator._apply_preprocessing_defences().
+        It requires all defenses to have a method `forward()`.
+        It converts numpy arrays to PyTorch tensors first, then chains a series of defenses by calling
+        defence.forward() which contains PyTorch operations. At the end, it converts PyTorch tensors
+        back to numpy arrays.
+
+        :param x: Samples.
+        :type x: Format as expected by the `model`
+        :param y: Target values.
+        :type y: Format as expected by the `model`
+        :param fit: `True` if the function is call before fit/training and `False` if the function is called before a
+                    predict operation.
+        :return: Tuple of `x` and `y` after applying the defences and standardisation.
+        :rtype: Format as expected by the `model`
+        """
+        import tensorflow as tf
+
+        if (
+            not hasattr(self, "preprocessing_defences")
+            or self.preprocessing_defences is None
+            or len(self.preprocessing_defences) == 0
+        ):
+            return x, y
+
+        if len(self.preprocessing_defences) == 1:
+            # Compatible with non-PyTorch defences if no chaining.
+            defence = self.preprocessing_defences[0]
+            x, y = defence(x, y)
+        else:
+            # Check if all defences are implemented in PyTorch.
+            for defence in self.preprocessing_defences:
+                if not isinstance(defence, PreprocessorTensorFlowV2):
+                    raise NotImplementedError(f"{defence.__class__} is not PyTorch-specific.")
+
+            # Convert np arrays to torch tensors.
+            x = tf.convert_to_tensor(x)
+            if y is not None:
+                y = tf.convert_to_tensor(y)
+
+            for defence in self.preprocessing_defences:
+                if fit:
+                    if defence.apply_fit:
+                        x, y = defence.forward(x, y)
+                else:
+                    if defence.apply_predict:
+                        x, y = defence.forward(x, y)
+
+            # Convert torch tensors back to np arrays.
+            x = x.numpy()
+            if y is not None:
+                y = y.numpy()
+
+        return x, y
+
+    def _apply_preprocessing_defences_gradient(self, x, gradients, fit=False):
+        """
+        Apply the backward pass to the gradients through all preprocessing defences that have been applied to `x`
+        and `y` in the forward pass. This function is should only be called from function
+        `_apply_preprocessing_gradient`.
+
+        The method overrides art.estimators.estimator::LossGradientsMixin._apply_preprocessing_defences_gradient().
+        It requires all defenses to have a method estimate_forward().
+        It converts numpy arrays to PyTorch tensors first, then chains a series of defenses by calling
+        defence.estimate_forward() which contains differentiable estimate of the operations. At the end,
+        it converts PyTorch tensors back to numpy arrays.
+
+        :param x: Samples.
+        :type x: Format as expected by the `model`
+        :param gradients: Gradients before backward pass through preprocessing defences.
+        :type gradients: Format as expected by the `model`
+        :param fit: `True` if the gradients are computed during training.
+        :return: Gradients after backward pass through preprocessing defences.
+        :rtype: Format as expected by the `model`
+        """
+        import tensorflow as tf
+
+        if (
+            not hasattr(self, "preprocessing_defences")
+            or self.preprocessing_defences is None
+            or len(self.preprocessing_defences) == 0
+        ):
+            return gradients
+
+        if len(self.preprocessing_defences) == 1:
+            # Compatible with non-PyTorch defences if no chaining.
+            defence = self.preprocessing_defences[0]
+            gradients = defence.estimate_gradient(x, gradients)
+        else:
+            # Check if all defences are implemented in PyTorch.
+            for defence in self.preprocessing_defences:
+                if not isinstance(defence, PreprocessorTensorFlowV2):
+                    raise NotImplementedError(f"{defence.__class__} is not TensorFlowV2-specific.")
+
+            with tf.GradientTape() as tape:
+                # Convert np arrays to TensorFlow tensors.
+                x = tf.convert_to_tensor(x, dtype=ART_NUMPY_DTYPE)
+                tape.watch(x)
+                gradients = tf.convert_to_tensor(gradients, dtype=ART_NUMPY_DTYPE)
+                x_orig = x
+
+                for defence in self.preprocessing_defences:
+                    if fit:
+                        if defence.apply_fit:
+                            x = defence.estimate_forward(x)
+                    else:
+                        if defence.apply_predict:
+                            x = defence.estimate_forward(x)
+
+            x_grad = tape.gradient(target=x, sources=x_orig, output_gradients=gradients)
+
+            # Convert torch tensors back to np arrays.
+            gradients = x_grad.numpy()
+            if gradients.shape != x_orig.shape:
+                raise ValueError(
+                    "The input shape is {} while the gradient shape is {}".format(x.shape, gradients.shape)
+                )
+        return gradients

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -27,6 +27,8 @@ done
 pytest -q tests/defences/preprocessor/test_spatial_smoothing_pytorch.py  --mlFramework="pytorch" --durations=0
 if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor/test_spatial_smoothing_pytorch.py tests"; fi
 
+pytest -q tests/classifiersFrameworks/test_pytorch.py  --mlFramework="pytorch" --durations=0
+if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks/test_pytorch.py tests"; fi
 
 
 #NOTE: All the tests should be ran within this loop. All other tests are legacy tests that must be

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -30,6 +30,9 @@ if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor/test_spa
 pytest -q tests/classifiersFrameworks/test_pytorch.py  --mlFramework="pytorch" --durations=0
 if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks/test_pytorch.py tests"; fi
 
+pytest -q tests/classifiersFrameworks/test_tensorflow.py  --mlFramework="tensorflow" --durations=0
+if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks/test_tensorflow.py tests"; fi
+
 
 #NOTE: All the tests should be ran within this loop. All other tests are legacy tests that must be
 # made framework independent to be incorporated within this loop

--- a/tests/classifiersFrameworks/test_pytorch.py
+++ b/tests/classifiersFrameworks/test_pytorch.py
@@ -30,8 +30,9 @@ from tests.attacks.utils import backend_test_defended_images
 
 
 # A generic test for various preprocessing_defences, forward pass.
-def _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                         preprocessing_defences):
+def _test_preprocessing_defences_forward(
+    get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+):
     (x_train_mnist, y_train_mnist), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 
     classifier_, _ = image_dl_estimator(one_classifier=True)
@@ -39,8 +40,13 @@ def _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_esti
     clip_values = (0, 1)
     criterion = nn.CrossEntropyLoss()
     classifier = PyTorchClassifier(
-        clip_values=clip_values, model=classifier_.model, preprocessing_defences=preprocessing_defences,
-        loss=criterion, input_shape=(1, 28, 28), nb_classes=10, device_type=device_type,
+        clip_values=clip_values,
+        model=classifier_.model,
+        preprocessing_defences=preprocessing_defences,
+        loss=criterion,
+        input_shape=(1, 28, 28),
+        nb_classes=10,
+        device_type=device_type,
     )
 
     with torch.no_grad():
@@ -61,8 +67,9 @@ def _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_esti
 
 
 # A generic test for various preprocessing_defences, backward pass.
-def _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                          preprocessing_defences):
+def _test_preprocessing_defences_backward(
+    get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+):
     (x_train_mnist, y_train_mnist), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 
     classifier_, _ = image_dl_estimator(one_classifier=True)
@@ -70,8 +77,13 @@ def _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_est
     clip_values = (0, 1)
     criterion = nn.CrossEntropyLoss()
     classifier = PyTorchClassifier(
-        clip_values=clip_values, model=classifier_.model, preprocessing_defences=preprocessing_defences,
-        loss=criterion, input_shape=(1, 28, 28), nb_classes=10, device_type=device_type,
+        clip_values=clip_values,
+        model=classifier_.model,
+        preprocessing_defences=preprocessing_defences,
+        loss=criterion,
+        input_shape=(1, 28, 28),
+        nb_classes=10,
+        device_type=device_type,
     )
 
     # The efficient defence-chaining.
@@ -96,10 +108,12 @@ def _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_est
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
 def test_nodefence(get_default_mnist_subset, image_dl_estimator, device_type):
     preprocessing_defences = []
-    _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                         preprocessing_defences)
-    _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                          preprocessing_defences)
+    _test_preprocessing_defences_forward(
+        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    )
+    _test_preprocessing_defences_backward(
+        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    )
 
 
 @pytest.mark.only_with_platform("pytorch")
@@ -107,10 +121,12 @@ def test_nodefence(get_default_mnist_subset, image_dl_estimator, device_type):
 def test_defence_pytorch(get_default_mnist_subset, image_dl_estimator, device_type):
     smooth_3x3 = SpatialSmoothingPyTorch(window_size=3, channels_first=True, device_type=device_type)
     preprocessing_defences = [smooth_3x3]
-    _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                         preprocessing_defences)
-    _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                          preprocessing_defences)
+    _test_preprocessing_defences_forward(
+        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    )
+    _test_preprocessing_defences_backward(
+        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    )
 
 
 @pytest.mark.only_with_platform("pytorch")
@@ -118,10 +134,12 @@ def test_defence_pytorch(get_default_mnist_subset, image_dl_estimator, device_ty
 def test_defence_non_pytorch(get_default_mnist_subset, image_dl_estimator, device_type):
     smooth_3x3 = SpatialSmoothing(window_size=3, channels_first=True)
     preprocessing_defences = [smooth_3x3]
-    _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                         preprocessing_defences)
-    _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                          preprocessing_defences)
+    _test_preprocessing_defences_forward(
+        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    )
+    _test_preprocessing_defences_backward(
+        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    )
 
 
 @pytest.mark.xfail(reason="Preprocessing-defence chaining only supports defences implemented in PyTorch.")
@@ -131,10 +149,12 @@ def test_defences_pytorch_and_nonpytorch(get_default_mnist_subset, image_dl_esti
     smooth_3x3_nonpth = SpatialSmoothing(window_size=3, channels_first=True)
     smooth_3x3_pth = SpatialSmoothingPyTorch(window_size=3, channels_first=True, device_type=device_type)
     preprocessing_defences = [smooth_3x3_nonpth, smooth_3x3_pth]
-    _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                         preprocessing_defences)
-    _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                          preprocessing_defences)
+    _test_preprocessing_defences_forward(
+        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    )
+    _test_preprocessing_defences_backward(
+        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    )
 
 
 @pytest.mark.only_with_platform("pytorch")
@@ -144,10 +164,12 @@ def test_defences_chaining(get_default_mnist_subset, image_dl_estimator, device_
     smooth_5x5 = SpatialSmoothingPyTorch(window_size=5, channels_first=True, device_type=device_type)
     smooth_7x7 = SpatialSmoothingPyTorch(window_size=7, channels_first=True, device_type=device_type)
     preprocessing_defences = [smooth_3x3, smooth_5x5, smooth_7x7]
-    _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                         preprocessing_defences)
-    _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
-                                          preprocessing_defences)
+    _test_preprocessing_defences_forward(
+        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    )
+    _test_preprocessing_defences_backward(
+        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    )
 
 
 @pytest.mark.only_with_platform("pytorch")
@@ -163,8 +185,13 @@ def test_fgsm_defences(fix_get_mnist_subset, image_dl_estimator, device_type):
 
     criterion = nn.CrossEntropyLoss()
     classifier = PyTorchClassifier(
-        clip_values=clip_values, model=classifier_.model, preprocessing_defences=[smooth_3x3, smooth_5x5, smooth_7x7],
-        loss=criterion, input_shape=(1, 28, 28), nb_classes=10, device_type=device_type,
+        clip_values=clip_values,
+        model=classifier_.model,
+        preprocessing_defences=[smooth_3x3, smooth_5x5, smooth_7x7],
+        loss=criterion,
+        input_shape=(1, 28, 28),
+        nb_classes=10,
+        device_type=device_type,
     )
     assert len(classifier.preprocessing_defences) == 3
 

--- a/tests/classifiersFrameworks/test_pytorch.py
+++ b/tests/classifiersFrameworks/test_pytorch.py
@@ -30,11 +30,11 @@ from tests.attacks.utils import backend_test_defended_images
 
 
 # A generic test for various preprocessing_defences, forward pass.
-def _test_preprocessing_defences_forward(get_default_mnist_subset, get_image_classifier_list, device_type,
+def _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
                                          preprocessing_defences):
     (x_train_mnist, y_train_mnist), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 
-    classifier_, _ = get_image_classifier_list(one_classifier=True)
+    classifier_, _ = image_dl_estimator(one_classifier=True)
 
     clip_values = (0, 1)
     criterion = nn.CrossEntropyLoss()
@@ -61,11 +61,11 @@ def _test_preprocessing_defences_forward(get_default_mnist_subset, get_image_cla
 
 
 # A generic test for various preprocessing_defences, backward pass.
-def _test_preprocessing_defences_backward(get_default_mnist_subset, get_image_classifier_list, device_type,
+def _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
                                           preprocessing_defences):
     (x_train_mnist, y_train_mnist), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 
-    classifier_, _ = get_image_classifier_list(one_classifier=True)
+    classifier_, _ = image_dl_estimator(one_classifier=True)
 
     clip_values = (0, 1)
     criterion = nn.CrossEntropyLoss()
@@ -94,72 +94,72 @@ def _test_preprocessing_defences_backward(get_default_mnist_subset, get_image_cl
 
 @pytest.mark.only_with_platform("pytorch")
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_nodefence(get_default_mnist_subset, get_image_classifier_list, device_type):
+def test_nodefence(get_default_mnist_subset, image_dl_estimator, device_type):
     preprocessing_defences = []
-    _test_preprocessing_defences_forward(get_default_mnist_subset, get_image_classifier_list, device_type,
+    _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
                                          preprocessing_defences)
-    _test_preprocessing_defences_backward(get_default_mnist_subset, get_image_classifier_list, device_type,
+    _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
                                           preprocessing_defences)
 
 
 @pytest.mark.only_with_platform("pytorch")
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_defence_pytorch(get_default_mnist_subset, get_image_classifier_list, device_type):
+def test_defence_pytorch(get_default_mnist_subset, image_dl_estimator, device_type):
     smooth_3x3 = SpatialSmoothingPyTorch(window_size=3, channels_first=True, device_type=device_type)
     preprocessing_defences = [smooth_3x3]
-    _test_preprocessing_defences_forward(get_default_mnist_subset, get_image_classifier_list, device_type,
+    _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
                                          preprocessing_defences)
-    _test_preprocessing_defences_backward(get_default_mnist_subset, get_image_classifier_list, device_type,
+    _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
                                           preprocessing_defences)
 
 
 @pytest.mark.only_with_platform("pytorch")
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_defence_non_pytorch(get_default_mnist_subset, get_image_classifier_list, device_type):
+def test_defence_non_pytorch(get_default_mnist_subset, image_dl_estimator, device_type):
     smooth_3x3 = SpatialSmoothing(window_size=3, channels_first=True)
     preprocessing_defences = [smooth_3x3]
-    _test_preprocessing_defences_forward(get_default_mnist_subset, get_image_classifier_list, device_type,
+    _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
                                          preprocessing_defences)
-    _test_preprocessing_defences_backward(get_default_mnist_subset, get_image_classifier_list, device_type,
+    _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
                                           preprocessing_defences)
 
 
 @pytest.mark.xfail(reason="Preprocessing-defence chaining only supports defences implemented in PyTorch.")
 @pytest.mark.only_with_platform("pytorch")
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_defences_pytorch_and_nonpytorch(get_default_mnist_subset, get_image_classifier_list, device_type):
+def test_defences_pytorch_and_nonpytorch(get_default_mnist_subset, image_dl_estimator, device_type):
     smooth_3x3_nonpth = SpatialSmoothing(window_size=3, channels_first=True)
     smooth_3x3_pth = SpatialSmoothingPyTorch(window_size=3, channels_first=True, device_type=device_type)
     preprocessing_defences = [smooth_3x3_nonpth, smooth_3x3_pth]
-    _test_preprocessing_defences_forward(get_default_mnist_subset, get_image_classifier_list, device_type,
+    _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
                                          preprocessing_defences)
-    _test_preprocessing_defences_backward(get_default_mnist_subset, get_image_classifier_list, device_type,
+    _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
                                           preprocessing_defences)
 
 
 @pytest.mark.only_with_platform("pytorch")
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_defences_chaining(get_default_mnist_subset, get_image_classifier_list, device_type):
+def test_defences_chaining(get_default_mnist_subset, image_dl_estimator, device_type):
     smooth_3x3 = SpatialSmoothingPyTorch(window_size=3, channels_first=True, device_type=device_type)
     smooth_5x5 = SpatialSmoothingPyTorch(window_size=5, channels_first=True, device_type=device_type)
     smooth_7x7 = SpatialSmoothingPyTorch(window_size=7, channels_first=True, device_type=device_type)
     preprocessing_defences = [smooth_3x3, smooth_5x5, smooth_7x7]
-    _test_preprocessing_defences_forward(get_default_mnist_subset, get_image_classifier_list, device_type,
+    _test_preprocessing_defences_forward(get_default_mnist_subset, image_dl_estimator, device_type,
                                          preprocessing_defences)
-    _test_preprocessing_defences_backward(get_default_mnist_subset, get_image_classifier_list, device_type,
+    _test_preprocessing_defences_backward(get_default_mnist_subset, image_dl_estimator, device_type,
                                           preprocessing_defences)
 
 
 @pytest.mark.only_with_platform("pytorch")
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_fgsm_defences(fix_get_mnist_subset, get_image_classifier_list, device_type):
+def test_fgsm_defences(fix_get_mnist_subset, image_dl_estimator, device_type):
     (x_train_mnist, y_train_mnist, x_test_mnist, y_test_mnist) = fix_get_mnist_subset
 
     clip_values = (0, 1)
     smooth_3x3 = SpatialSmoothingPyTorch(window_size=3, channels_first=True, device_type=device_type)
     smooth_5x5 = SpatialSmoothingPyTorch(window_size=5, channels_first=True, device_type=device_type)
     smooth_7x7 = SpatialSmoothingPyTorch(window_size=7, channels_first=True, device_type=device_type)
-    classifier_, _ = get_image_classifier_list(one_classifier=True)
+    classifier_, _ = image_dl_estimator(one_classifier=True)
 
     criterion = nn.CrossEntropyLoss()
     classifier = PyTorchClassifier(

--- a/tests/classifiersFrameworks/test_tensorflow.py
+++ b/tests/classifiersFrameworks/test_tensorflow.py
@@ -17,12 +17,12 @@
 # SOFTWARE.
 import numpy as np
 import pytest
-import torch
-import torch.nn as nn
 
-from art.estimators.classification.pytorch import PyTorchClassifier
+import tensorflow as tf
+
+from art.estimators.classification.tensorflow import TensorFlowV2Classifier
 from art.defences.preprocessor.spatial_smoothing import SpatialSmoothing
-from art.defences.preprocessor.spatial_smoothing_pytorch import SpatialSmoothingPyTorch
+from art.defences.preprocessor.spatial_smoothing_tensorflow import SpatialSmoothingTensorFlowV2
 from art.attacks.evasion import FastGradientMethod
 
 from tests.attacks.utils import backend_test_defended_images
@@ -45,28 +45,25 @@ def _test_preprocessing_defences_forward(
     classifier_, _ = image_dl_estimator(one_classifier=True)
 
     clip_values = (0, 1)
-    criterion = nn.CrossEntropyLoss()
-    classifier = PyTorchClassifier(
+    loss_object = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
+    classifier = TensorFlowV2Classifier(
         clip_values=clip_values,
         model=classifier_.model,
         preprocessing_defences=preprocessing_defences,
-        loss=criterion,
-        input_shape=(1, 28, 28),
+        loss_object=loss_object,
+        input_shape=(28, 28, 1),
         nb_classes=10,
-        device_type=device_type,
     )
 
-    with torch.no_grad():
-        predictions_classifier = classifier.predict(x_test_mnist)
+    predictions_classifier = classifier.predict(x_test_mnist)
 
     # Apply the same defences by hand
     x_test_defense = x_test_mnist
     for defence in preprocessing_defences:
         x_test_defense, _ = defence(x_test_defense, y_test_mnist)
 
-    x_test_defense = torch.tensor(x_test_defense)
-    with torch.no_grad():
-        predictions_check = classifier_.model(x_test_defense)
+    x_test_defense = tf.convert_to_tensor(x_test_defense)
+    predictions_check = classifier_.model(x_test_defense)
     predictions_check = predictions_check.cpu().numpy()
 
     # Check that the prediction results match
@@ -82,15 +79,14 @@ def _test_preprocessing_defences_backward(
     classifier_, _ = image_dl_estimator(one_classifier=True)
 
     clip_values = (0, 1)
-    criterion = nn.CrossEntropyLoss()
-    classifier = PyTorchClassifier(
+    loss_object = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
+    classifier = TensorFlowV2Classifier(
         clip_values=clip_values,
         model=classifier_.model,
         preprocessing_defences=preprocessing_defences,
-        loss=criterion,
-        input_shape=(1, 28, 28),
+        loss_object=loss_object,
+        input_shape=(28, 28, 1),
         nb_classes=10,
-        device_type=device_type,
     )
 
     # The efficient defence-chaining.
@@ -111,10 +107,10 @@ def _test_preprocessing_defences_backward(
     np.testing.assert_array_almost_equal(gradients_in_chain, gradients, decimal=4)
 
 
-@pytest.mark.only_with_platform("pytorch")
-@pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_nodefence(get_default_mnist_subset, image_dl_estimator, device_type):
+@pytest.mark.only_with_platform("tensorflow")
+def test_nodefence(get_default_mnist_subset, image_dl_estimator):
     preprocessing_defences = []
+    device_type = None
     _test_preprocessing_defences_forward(
         get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
     )
@@ -123,11 +119,11 @@ def test_nodefence(get_default_mnist_subset, image_dl_estimator, device_type):
     )
 
 
-@pytest.mark.only_with_platform("pytorch")
-@pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_defence_pytorch(get_default_mnist_subset, image_dl_estimator, device_type):
-    smooth_3x3 = SpatialSmoothingPyTorch(window_size=3, channels_first=True, device_type=device_type)
+@pytest.mark.only_with_platform("tensorflow")
+def test_defence_tensorflow(get_default_mnist_subset, image_dl_estimator):
+    smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
     preprocessing_defences = [smooth_3x3]
+    device_type = None
     _test_preprocessing_defences_forward(
         get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
     )
@@ -136,11 +132,11 @@ def test_defence_pytorch(get_default_mnist_subset, image_dl_estimator, device_ty
     )
 
 
-@pytest.mark.only_with_platform("pytorch")
-@pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_defence_non_pytorch(get_default_mnist_subset, image_dl_estimator, device_type):
-    smooth_3x3 = SpatialSmoothing(window_size=3, channels_first=True)
+@pytest.mark.only_with_platform("tensorflow")
+def test_defence_non_tensorflow(get_default_mnist_subset, image_dl_estimator):
+    smooth_3x3 = SpatialSmoothing(window_size=3, channels_first=False)
     preprocessing_defences = [smooth_3x3]
+    device_type = None
     _test_preprocessing_defences_forward(
         get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
     )
@@ -149,13 +145,13 @@ def test_defence_non_pytorch(get_default_mnist_subset, image_dl_estimator, devic
     )
 
 
-@pytest.mark.xfail(reason="Preprocessing-defence chaining only supports defences implemented in PyTorch.")
-@pytest.mark.only_with_platform("pytorch")
-@pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_defences_pytorch_and_nonpytorch(get_default_mnist_subset, image_dl_estimator, device_type):
-    smooth_3x3_nonpth = SpatialSmoothing(window_size=3, channels_first=True)
-    smooth_3x3_pth = SpatialSmoothingPyTorch(window_size=3, channels_first=True, device_type=device_type)
+@pytest.mark.xfail(reason="Preprocessing-defence chaining only supports defences implemented in TensorFlow v2.")
+@pytest.mark.only_with_platform("tensorflow")
+def test_defences_tensorflow_and_nontensorflow(get_default_mnist_subset, image_dl_estimator, device_type):
+    smooth_3x3_nonpth = SpatialSmoothing(window_size=3, channels_first=False)
+    smooth_3x3_pth = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
     preprocessing_defences = [smooth_3x3_nonpth, smooth_3x3_pth]
+    device_type = None
     _test_preprocessing_defences_forward(
         get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
     )
@@ -164,13 +160,13 @@ def test_defences_pytorch_and_nonpytorch(get_default_mnist_subset, image_dl_esti
     )
 
 
-@pytest.mark.only_with_platform("pytorch")
-@pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_defences_chaining(get_default_mnist_subset, image_dl_estimator, device_type):
-    smooth_3x3 = SpatialSmoothingPyTorch(window_size=3, channels_first=True, device_type=device_type)
-    smooth_5x5 = SpatialSmoothingPyTorch(window_size=5, channels_first=True, device_type=device_type)
-    smooth_7x7 = SpatialSmoothingPyTorch(window_size=7, channels_first=True, device_type=device_type)
+@pytest.mark.only_with_platform("tensorflow")
+def test_defences_chaining(get_default_mnist_subset, image_dl_estimator):
+    smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
+    smooth_5x5 = SpatialSmoothingTensorFlowV2(window_size=5, channels_first=False)
+    smooth_7x7 = SpatialSmoothingTensorFlowV2(window_size=7, channels_first=False)
     preprocessing_defences = [smooth_3x3, smooth_5x5, smooth_7x7]
+    device_type = None
     _test_preprocessing_defences_forward(
         get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
     )
@@ -179,26 +175,24 @@ def test_defences_chaining(get_default_mnist_subset, image_dl_estimator, device_
     )
 
 
-@pytest.mark.only_with_platform("pytorch")
-@pytest.mark.parametrize("device_type", ["cpu", "gpu"])
-def test_fgsm_defences(fix_get_mnist_subset, image_dl_estimator, device_type):
+@pytest.mark.only_with_platform("tensorflow")
+def test_fgsm_defences(fix_get_mnist_subset, image_dl_estimator):
     (x_train_mnist, y_train_mnist, x_test_mnist, y_test_mnist) = fix_get_mnist_subset
 
     clip_values = (0, 1)
-    smooth_3x3 = SpatialSmoothingPyTorch(window_size=3, channels_first=True, device_type=device_type)
-    smooth_5x5 = SpatialSmoothingPyTorch(window_size=5, channels_first=True, device_type=device_type)
-    smooth_7x7 = SpatialSmoothingPyTorch(window_size=7, channels_first=True, device_type=device_type)
+    smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
+    smooth_5x5 = SpatialSmoothingTensorFlowV2(window_size=5, channels_first=False)
+    smooth_7x7 = SpatialSmoothingTensorFlowV2(window_size=7, channels_first=False)
     classifier_, _ = image_dl_estimator(one_classifier=True)
 
-    criterion = nn.CrossEntropyLoss()
-    classifier = PyTorchClassifier(
+    loss_object = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
+    classifier = TensorFlowV2Classifier(
         clip_values=clip_values,
         model=classifier_.model,
         preprocessing_defences=[smooth_3x3, smooth_5x5, smooth_7x7],
-        loss=criterion,
-        input_shape=(1, 28, 28),
+        loss_object=loss_object,
+        input_shape=(28, 28, 1),
         nb_classes=10,
-        device_type=device_type,
     )
     assert len(classifier.preprocessing_defences) == 3
 

--- a/tests/classifiersFrameworks/test_tensorflow.py
+++ b/tests/classifiersFrameworks/test_tensorflow.py
@@ -150,7 +150,9 @@ def test_defence_non_tensorflow(get_default_mnist_subset, image_dl_estimator, is
 
 @pytest.mark.xfail(reason="Preprocessing-defence chaining only supports defences implemented in TensorFlow v2.")
 @pytest.mark.only_with_platform("tensorflow")
-def test_defences_tensorflow_and_nontensorflow(get_default_mnist_subset, image_dl_estimator, device_type, is_tf_version_2):
+def test_defences_tensorflow_and_nontensorflow(
+    get_default_mnist_subset, image_dl_estimator, device_type, is_tf_version_2
+):
     if is_tf_version_2:
         smooth_3x3_nonpth = SpatialSmoothing(window_size=3, channels_first=False)
         smooth_3x3_pth = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)

--- a/tests/classifiersFrameworks/test_tensorflow.py
+++ b/tests/classifiersFrameworks/test_tensorflow.py
@@ -108,93 +108,99 @@ def _test_preprocessing_defences_backward(
 
 
 @pytest.mark.only_with_platform("tensorflow")
-def test_nodefence(get_default_mnist_subset, image_dl_estimator):
-    preprocessing_defences = []
-    device_type = None
-    _test_preprocessing_defences_forward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-    )
-    _test_preprocessing_defences_backward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-    )
+def test_nodefence(get_default_mnist_subset, image_dl_estimator, is_tf_version_2):
+    if is_tf_version_2:
+        preprocessing_defences = []
+        device_type = None
+        _test_preprocessing_defences_forward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
+        _test_preprocessing_defences_backward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
 
 
 @pytest.mark.only_with_platform("tensorflow")
-def test_defence_tensorflow(get_default_mnist_subset, image_dl_estimator):
-    smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
-    preprocessing_defences = [smooth_3x3]
-    device_type = None
-    _test_preprocessing_defences_forward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-    )
-    _test_preprocessing_defences_backward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-    )
+def test_defence_tensorflow(get_default_mnist_subset, image_dl_estimator, is_tf_version_2):
+    if is_tf_version_2:
+        smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
+        preprocessing_defences = [smooth_3x3]
+        device_type = None
+        _test_preprocessing_defences_forward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
+        _test_preprocessing_defences_backward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
 
 
 @pytest.mark.only_with_platform("tensorflow")
-def test_defence_non_tensorflow(get_default_mnist_subset, image_dl_estimator):
-    smooth_3x3 = SpatialSmoothing(window_size=3, channels_first=False)
-    preprocessing_defences = [smooth_3x3]
-    device_type = None
-    _test_preprocessing_defences_forward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-    )
-    _test_preprocessing_defences_backward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-    )
+def test_defence_non_tensorflow(get_default_mnist_subset, image_dl_estimator, is_tf_version_2):
+    if is_tf_version_2:
+        smooth_3x3 = SpatialSmoothing(window_size=3, channels_first=False)
+        preprocessing_defences = [smooth_3x3]
+        device_type = None
+        _test_preprocessing_defences_forward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
+        _test_preprocessing_defences_backward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
 
 
 @pytest.mark.xfail(reason="Preprocessing-defence chaining only supports defences implemented in TensorFlow v2.")
 @pytest.mark.only_with_platform("tensorflow")
-def test_defences_tensorflow_and_nontensorflow(get_default_mnist_subset, image_dl_estimator, device_type):
-    smooth_3x3_nonpth = SpatialSmoothing(window_size=3, channels_first=False)
-    smooth_3x3_pth = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
-    preprocessing_defences = [smooth_3x3_nonpth, smooth_3x3_pth]
-    device_type = None
-    _test_preprocessing_defences_forward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-    )
-    _test_preprocessing_defences_backward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-    )
+def test_defences_tensorflow_and_nontensorflow(get_default_mnist_subset, image_dl_estimator, device_type, is_tf_version_2):
+    if is_tf_version_2:
+        smooth_3x3_nonpth = SpatialSmoothing(window_size=3, channels_first=False)
+        smooth_3x3_pth = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
+        preprocessing_defences = [smooth_3x3_nonpth, smooth_3x3_pth]
+        device_type = None
+        _test_preprocessing_defences_forward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
+        _test_preprocessing_defences_backward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
 
 
 @pytest.mark.only_with_platform("tensorflow")
-def test_defences_chaining(get_default_mnist_subset, image_dl_estimator):
-    smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
-    smooth_5x5 = SpatialSmoothingTensorFlowV2(window_size=5, channels_first=False)
-    smooth_7x7 = SpatialSmoothingTensorFlowV2(window_size=7, channels_first=False)
-    preprocessing_defences = [smooth_3x3, smooth_5x5, smooth_7x7]
-    device_type = None
-    _test_preprocessing_defences_forward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-    )
-    _test_preprocessing_defences_backward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-    )
+def test_defences_chaining(get_default_mnist_subset, image_dl_estimator, is_tf_version_2):
+    if is_tf_version_2:
+        smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
+        smooth_5x5 = SpatialSmoothingTensorFlowV2(window_size=5, channels_first=False)
+        smooth_7x7 = SpatialSmoothingTensorFlowV2(window_size=7, channels_first=False)
+        preprocessing_defences = [smooth_3x3, smooth_5x5, smooth_7x7]
+        device_type = None
+        _test_preprocessing_defences_forward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
+        _test_preprocessing_defences_backward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
 
 
 @pytest.mark.only_with_platform("tensorflow")
-def test_fgsm_defences(fix_get_mnist_subset, image_dl_estimator):
-    (x_train_mnist, y_train_mnist, x_test_mnist, y_test_mnist) = fix_get_mnist_subset
+def test_fgsm_defences(fix_get_mnist_subset, image_dl_estimator, is_tf_version_2):
+    if is_tf_version_2:
+        (x_train_mnist, y_train_mnist, x_test_mnist, y_test_mnist) = fix_get_mnist_subset
 
-    clip_values = (0, 1)
-    smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
-    smooth_5x5 = SpatialSmoothingTensorFlowV2(window_size=5, channels_first=False)
-    smooth_7x7 = SpatialSmoothingTensorFlowV2(window_size=7, channels_first=False)
-    classifier_, _ = image_dl_estimator(one_classifier=True)
+        clip_values = (0, 1)
+        smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
+        smooth_5x5 = SpatialSmoothingTensorFlowV2(window_size=5, channels_first=False)
+        smooth_7x7 = SpatialSmoothingTensorFlowV2(window_size=7, channels_first=False)
+        classifier_, _ = image_dl_estimator(one_classifier=True)
 
-    loss_object = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
-    classifier = TensorFlowV2Classifier(
-        clip_values=clip_values,
-        model=classifier_.model,
-        preprocessing_defences=[smooth_3x3, smooth_5x5, smooth_7x7],
-        loss_object=loss_object,
-        input_shape=(28, 28, 1),
-        nb_classes=10,
-    )
-    assert len(classifier.preprocessing_defences) == 3
+        loss_object = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
+        classifier = TensorFlowV2Classifier(
+            clip_values=clip_values,
+            model=classifier_.model,
+            preprocessing_defences=[smooth_3x3, smooth_5x5, smooth_7x7],
+            loss_object=loss_object,
+            input_shape=(28, 28, 1),
+            nb_classes=10,
+        )
+        assert len(classifier.preprocessing_defences) == 3
 
-    attack = FastGradientMethod(classifier, eps=1, batch_size=128)
-    backend_test_defended_images(attack, fix_get_mnist_subset)
+        attack = FastGradientMethod(classifier, eps=1, batch_size=128)
+        backend_test_defended_images(attack, fix_get_mnist_subset)


### PR DESCRIPTION
# Description

This pull request extends the framework-specific defences introduced in #510 to support TensorFlow v2.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
