### PR TITLE
Support string type for infinity norm in attacks

### DIFF
--- a/art/attacks/evasion/auto_attack.py
+++ b/art/attacks/evasion/auto_attack.py
@@ -53,7 +53,7 @@ class AutoAttack(EvasionAttack):
     def __init__(
         self,
         estimator: ClassifierGradients,
-        norm: Union[int, float] = np.inf,
+        norm: Union[int, float, str] = np.inf,
         eps: float = 0.3,
         eps_step: float = 0.1,
         attacks: Optional[List[EvasionAttack]] = None,
@@ -65,7 +65,7 @@ class AutoAttack(EvasionAttack):
         Create a :class:`.ProjectedGradientDescent` instance.
 
         :param estimator: An trained estimator.
-        :param norm: The norm of the adversarial perturbation. Possible values: np.inf, 1 or 2.
+        :param norm: The norm of the adversarial perturbation. Possible values: "inf", np.inf, 1 or 2.
         :param eps: Maximum perturbation that the attacker can introduce.
         :param eps_step: Attack step size (input variation) at each iteration.
         :param attacks: The list of `art.attacks.EvasionAttack` attacks to be used for AutoAttack. If it is `None` or
@@ -206,8 +206,9 @@ class AutoAttack(EvasionAttack):
 
         # Check and update successful examples
         rel_acc = 1e-4
+        order = np.inf if self.norm == "inf" else self.norm
         norm_is_smaller_eps = (1 - rel_acc) * np.linalg.norm(
-            (x_robust_adv - x_robust).reshape((x_robust_adv.shape[0], -1)), axis=1, ord=self.norm
+            (x_robust_adv - x_robust).reshape((x_robust_adv.shape[0], -1)), axis=1, ord=order
         ) <= self.eps
 
         if attack.targeted:
@@ -227,8 +228,8 @@ class AutoAttack(EvasionAttack):
         return x, sample_is_robust
 
     def _check_params(self) -> None:
-        if self.norm not in [1, 2, np.inf]:
-            raise ValueError("The argument norm has to be either 1, 2, or np.inf.")
+        if self.norm not in [1, 2, np.inf, "inf"]:
+            raise ValueError("The argument norm has to be either 1, 2, np.inf, \"inf\".")
 
         if not isinstance(self.eps, (int, float)) or self.eps <= 0.0:
             raise ValueError("The argument eps has to be either of type int or float and larger than zero.")

--- a/art/attacks/evasion/auto_projected_gradient_descent.py
+++ b/art/attacks/evasion/auto_projected_gradient_descent.py
@@ -53,7 +53,7 @@ class AutoProjectedGradientDescent(EvasionAttack):
     def __init__(
         self,
         estimator: BaseEstimator,
-        norm: Union[float, int] = np.inf,
+        norm: Union[int, float, str] = np.inf,
         eps: float = 0.3,
         eps_step: float = 0.1,
         max_iter: int = 100,
@@ -66,7 +66,7 @@ class AutoProjectedGradientDescent(EvasionAttack):
         Create a :class:`.AutoProjectedGradientDescent` instance.
 
         :param estimator: An trained estimator.
-        :param norm: The norm of the adversarial perturbation. Possible values: np.inf, 1 or 2.
+        :param norm: The norm of the adversarial perturbation. Possible values: "inf", np.inf, 1 or 2.
         :param eps: Maximum perturbation that the attacker can introduce.
         :param eps_step: Attack step size (input variation) at each iteration.
         :param max_iter: The maximum number of iterations.
@@ -429,7 +429,7 @@ class AutoProjectedGradientDescent(EvasionAttack):
                     grad = self.estimator.loss_gradient(x_k, y_batch) * (1 - 2 * int(self.targeted))
 
                     # Apply norm bound
-                    if self.norm == np.inf:
+                    if self.norm in [np.inf, "inf"]:
                         grad = np.sign(grad)
                     elif self.norm == 1:
                         ind = tuple(range(1, len(x_k.shape)))
@@ -532,8 +532,8 @@ class AutoProjectedGradientDescent(EvasionAttack):
         return x_adv
 
     def _check_params(self) -> None:
-        if self.norm not in [1, 2, np.inf]:
-            raise ValueError("The argument norm has to be either 1, 2, or np.inf.")
+        if self.norm not in [1, 2, np.inf, "inf"]:
+            raise ValueError("The argument norm has to be either 1, 2, np.inf, or \"inf\".")
 
         if not isinstance(self.eps, (int, float)) or self.eps <= 0.0:
             raise ValueError("The argument eps has to be either of type int or float and larger than zero.")

--- a/art/attacks/evasion/fast_gradient.py
+++ b/art/attacks/evasion/fast_gradient.py
@@ -250,8 +250,8 @@ class FastGradientMethod(EvasionAttack):
 
     def _check_params(self) -> None:
         # Check if order of the norm is acceptable given current implementation
-        if self.norm not in ["inf", np.inf, int(1), int(2)]:
-            raise ValueError("Norm order must be either \"inf\", `np.inf`, 1, or 2.")
+        if self.norm not in [1, 2, np.inf, "inf"]:
+            raise ValueError("Norm order must be either 1, 2, `np.inf` or \"inf\".")
 
         if self.eps <= 0:
             raise ValueError("The perturbation size `eps` has to be positive.")

--- a/art/attacks/evasion/fast_gradient.py
+++ b/art/attacks/evasion/fast_gradient.py
@@ -24,7 +24,7 @@ Method attack and extends it to other norms, therefore it is called the Fast Gra
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
@@ -69,7 +69,7 @@ class FastGradientMethod(EvasionAttack):
     def __init__(
         self,
         estimator: ClassifierGradients,
-        norm: int = np.inf,
+        norm: Union[int, float, str] = np.inf,
         eps: float = 0.3,
         eps_step: float = 0.1,
         targeted: bool = False,
@@ -81,7 +81,7 @@ class FastGradientMethod(EvasionAttack):
         Create a :class:`.FastGradientMethod` instance.
 
         :param estimator: A trained classifier.
-        :param norm: The norm of the adversarial perturbation. Possible values: np.inf, 1 or 2.
+        :param norm: The norm of the adversarial perturbation. Possible values: "inf", np.inf, 1 or 2.
         :param eps: Attack step size (input variation).
         :param eps_step: Step size of input variation for minimal perturbation computation.
         :param targeted: Indicates whether the attack is targeted (True) or untargeted (False)
@@ -250,8 +250,8 @@ class FastGradientMethod(EvasionAttack):
 
     def _check_params(self) -> None:
         # Check if order of the norm is acceptable given current implementation
-        if self.norm not in [np.inf, int(1), int(2)]:
-            raise ValueError("Norm order must be either `np.inf`, 1, or 2.")
+        if self.norm not in ["inf", np.inf, int(1), int(2)]:
+            raise ValueError("Norm order must be either \"inf\", `np.inf`, 1, or 2.")
 
         if self.eps <= 0:
             raise ValueError("The perturbation size `eps` has to be positive.")
@@ -282,7 +282,7 @@ class FastGradientMethod(EvasionAttack):
         grad = self.estimator.loss_gradient(batch, batch_labels) * (1 - 2 * int(self.targeted))
 
         # Apply norm bound
-        if self.norm == np.inf:
+        if self.norm in [np.inf, "inf"]:
             grad = np.sign(grad)
         elif self.norm == 1:
             ind = tuple(range(1, len(batch.shape)))

--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -65,7 +65,7 @@ class HopSkipJump(EvasionAttack):
         self,
         classifier: "Classifier",
         targeted: bool = False,
-        norm: int = 2,
+        norm: Union[int, float, str] = 2,
         max_iter: int = 50,
         max_eval: int = 10000,
         init_eval: int = 100,
@@ -76,7 +76,7 @@ class HopSkipJump(EvasionAttack):
 
         :param classifier: A trained classifier.
         :param targeted: Should the attack target one specific class.
-        :param norm: Order of the norm. Possible values: np.inf or 2.
+        :param norm: Order of the norm. Possible values: "inf", np.inf or 2.
         :param max_iter: Maximum number of iterations.
         :param max_eval: Maximum number of evaluations for estimating gradient.
         :param init_eval: Initial number of evaluations for estimating gradient.
@@ -368,7 +368,7 @@ class HopSkipJump(EvasionAttack):
         current_sample: np.ndarray,
         original_sample: np.ndarray,
         target: int,
-        norm: int,
+        norm: Union[int, float, str],
         clip_min: float,
         clip_max: float,
         threshold: Optional[float] = None,
@@ -379,7 +379,7 @@ class HopSkipJump(EvasionAttack):
         :param current_sample: Current adversarial example.
         :param original_sample: The original input.
         :param target: The target label.
-        :param norm: Order of the norm. Possible values: np.inf or 2.
+        :param norm: Order of the norm. Possible values: "inf", np.inf or 2.
         :param clip_min: Minimum value of an example.
         :param clip_max: Maximum value of an example.
         :param threshold: The upper threshold in binary search.
@@ -523,14 +523,16 @@ class HopSkipJump(EvasionAttack):
         return result
 
     @staticmethod
-    def _interpolate(current_sample: np.ndarray, original_sample: np.ndarray, alpha: float, norm: int) -> np.ndarray:
+    def _interpolate(
+        current_sample: np.ndarray, original_sample: np.ndarray, alpha: float, norm: Union[int, float, str]
+    ) -> np.ndarray:
         """
         Interpolate a new sample based on the original and the current samples.
 
         :param current_sample: Current adversarial example.
         :param original_sample: The original input.
         :param alpha: The coefficient of interpolation.
-        :param norm: Order of the norm. Possible values: np.inf or 2.
+        :param norm: Order of the norm. Possible values: "inf", np.inf or 2.
         :return: An adversarial example.
         """
         if norm == 2:
@@ -542,8 +544,8 @@ class HopSkipJump(EvasionAttack):
 
     def _check_params(self) -> None:
         # Check if order of the norm is acceptable given current implementation
-        if self.norm not in [np.inf, int(2)]:
-            raise ValueError("Norm order must be either `np.inf` or 2.")
+        if self.norm not in ["inf", np.inf, int(2)]:
+            raise ValueError('Norm order must be either "inf", `np.inf` or 2.')
 
         if not isinstance(self.max_iter, (int, np.int)) or self.max_iter < 0:
             raise ValueError("The number of iterations must be a non-negative integer.")

--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -544,8 +544,8 @@ class HopSkipJump(EvasionAttack):
 
     def _check_params(self) -> None:
         # Check if order of the norm is acceptable given current implementation
-        if self.norm not in ["inf", np.inf, int(2)]:
-            raise ValueError('Norm order must be either "inf", `np.inf` or 2.')
+        if self.norm not in [2, np.inf, "inf"]:
+            raise ValueError('Norm order must be either 2, `np.inf` or \"inf\".')
 
         if not isinstance(self.max_iter, (int, np.int)) or self.max_iter < 0:
             raise ValueError("The number of iterations must be a non-negative integer.")

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
@@ -73,7 +73,7 @@ class ProjectedGradientDescent(EvasionAttack):
     def __init__(
         self,
         estimator,
-        norm: int = np.inf,
+        norm: Union[int, float, str] = np.inf,
         eps: float = 0.3,
         eps_step: float = 0.1,
         max_iter: int = 100,
@@ -86,7 +86,7 @@ class ProjectedGradientDescent(EvasionAttack):
         Create a :class:`.ProjectedGradientDescent` instance.
 
         :param estimator: An trained estimator.
-        :param norm: The norm of the adversarial perturbation supporting np.inf, 1 or 2.
+        :param norm: The norm of the adversarial perturbation supporting "inf", np.inf, 1 or 2.
         :param eps: Maximum perturbation that the attacker can introduce.
         :param eps_step: Attack step size (input variation) at each iteration.
         :param random_eps: When True, epsilon is drawn randomly from truncated normal distribution. The literature
@@ -178,8 +178,8 @@ class ProjectedGradientDescent(EvasionAttack):
 
     def _check_params(self) -> None:
         # Check if order of the norm is acceptable given current implementation
-        if self.norm not in [np.inf, int(1), int(2)]:
-            raise ValueError("Norm order must be either `np.inf`, 1, or 2.")
+        if self.norm not in ["inf", np.inf, int(1), int(2)]:
+            raise ValueError("Norm order must be either \"inf\", `np.inf`, 1, or 2.")
 
         if self.eps <= 0:
             raise ValueError("The perturbation size `eps` has to be positive.")
@@ -199,7 +199,7 @@ class ProjectedGradientDescent(EvasionAttack):
         if self.batch_size <= 0:
             raise ValueError("The batch size `batch_size` has to be positive.")
 
-        if self.norm == np.inf and self.eps_step > self.eps:
+        if self.norm in ["inf", np.inf] and self.eps_step > self.eps:
             raise ValueError("The iteration step `eps_step` has to be smaller than the total attack `eps`.")
 
         if self.max_iter <= 0:

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
@@ -178,8 +178,8 @@ class ProjectedGradientDescent(EvasionAttack):
 
     def _check_params(self) -> None:
         # Check if order of the norm is acceptable given current implementation
-        if self.norm not in ["inf", np.inf, int(1), int(2)]:
-            raise ValueError("Norm order must be either \"inf\", `np.inf`, 1, or 2.")
+        if self.norm not in [1, 2, np.inf, "inf"]:
+            raise ValueError("Norm order must be either 1, 2, `np.inf` or \"inf\".")
 
         if self.eps <= 0:
             raise ValueError("The perturbation size `eps` has to be positive.")

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
@@ -26,7 +26,7 @@ al. for adversarial training.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 from scipy.stats import truncnorm
@@ -63,7 +63,7 @@ class ProjectedGradientDescentCommon(FastGradientMethod):
     def __init__(
         self,
         estimator: ClassifierGradients,
-        norm: int = np.inf,
+        norm: Union[int, float, str] = np.inf,
         eps: float = 0.3,
         eps_step: float = 0.1,
         max_iter: int = 100,
@@ -76,7 +76,7 @@ class ProjectedGradientDescentCommon(FastGradientMethod):
         Create a :class:`.ProjectedGradientDescentCommon` instance.
 
         :param estimator: A trained classifier.
-        :param norm: The norm of the adversarial perturbation supporting np.inf, 1 or 2.
+        :param norm: The norm of the adversarial perturbation supporting "inf", np.inf, 1 or 2.
         :param eps: Maximum perturbation that the attacker can introduce.
         :param eps_step: Attack step size (input variation) at each iteration.
         :param random_eps: When True, epsilon is drawn randomly from truncated normal distribution. The literature
@@ -202,41 +202,32 @@ class ProjectedGradientDescentNumpy(ProjectedGradientDescentCommon):
 
     def __init__(
         self,
-        estimator,
-        norm=np.inf,
-        eps=0.3,
-        eps_step=0.1,
-        max_iter=100,
-        targeted=False,
-        num_random_init=0,
-        batch_size=32,
-        random_eps=False,
-    ):
+        estimator: ClassifierGradients,
+        norm: Union[int, float, str] = np.inf,
+        eps: float = 0.3,
+        eps_step: float = 0.1,
+        max_iter: int = 100,
+        targeted: bool = False,
+        num_random_init: int = 0,
+        batch_size: int = 32,
+        random_eps: bool = False,
+    ) -> None:
         """
         Create a :class:`.ProjectedGradientDescentNumpy` instance.
 
         :param estimator: An trained estimator.
-        :type estimator: :class:`.BaseEstimator`
-        :param norm: The norm of the adversarial perturbation supporting np.inf, 1 or 2.
-        :type norm: `int`
+        :param norm: The norm of the adversarial perturbation supporting "inf", np.inf, 1 or 2.
         :param eps: Maximum perturbation that the attacker can introduce.
-        :type eps: `float`
         :param eps_step: Attack step size (input variation) at each iteration.
-        :type eps_step: `float`
         :param random_eps: When True, epsilon is drawn randomly from truncated normal distribution. The literature
                            suggests this for FGSM based training to generalize across different epsilons. eps_step
                            is modified to preserve the ratio of eps / eps_step. The effectiveness of this method with
                            PGD is untested (https://arxiv.org/pdf/1611.01236.pdf).
-        :type random_eps: `bool`
         :param max_iter: The maximum number of iterations.
-        :type max_iter: `int`
         :param targeted: Indicates whether the attack is targeted (True) or untargeted (False)
-        :type targeted: `bool`
         :param num_random_init: Number of random initialisations within the epsilon ball. For num_random_init=0 starting
                                 at the original input.
-        :type num_random_init: `int`
         :param batch_size: Size of the batch on which adversarial samples are generated.
-        :type batch_size: `int`
         """
         super(ProjectedGradientDescentNumpy, self).__init__(
             estimator=estimator,

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
@@ -26,7 +26,7 @@ al. for adversarial training.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 
 import numpy as np
 
@@ -54,7 +54,7 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
     def __init__(
         self,
         estimator,
-        norm: int = np.inf,
+        norm: Union[int, float, str] = np.inf,
         eps: float = 0.3,
         eps_step: float = 0.1,
         max_iter: int = 100,
@@ -68,7 +68,7 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
 
         :param estimator: An trained estimator.
         :type estimator: :class:`.BaseEstimator`
-        :param norm: The norm of the adversarial perturbation. Possible values: np.inf, 1 or 2.
+        :param norm: The norm of the adversarial perturbation. Possible values: "inf", np.inf, 1 or 2.
         :param eps: Maximum perturbation that the attacker can introduce.
         :param eps_step: Attack step size (input variation) at each iteration.
         :param random_eps: When True, epsilon is drawn randomly from truncated normal distribution. The literature
@@ -242,7 +242,7 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
         grad = self.estimator.loss_gradient_framework(x, y) * (1 - 2 * int(self.targeted))
 
         # Apply norm bound
-        if self.norm == np.inf:
+        if self.norm in ["inf", np.inf]:
             grad = grad.sign()
 
         elif self.norm == 1:
@@ -348,13 +348,13 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
 
         return x_adv
 
-    def _projection(self, values: "torch.Tensor", eps: float, norm_p: int) -> "torch.Tensor":
+    def _projection(self, values: "torch.Tensor", eps: float, norm_p: Union[int, float, str]) -> "torch.Tensor":
         """
         Project `values` on the L_p norm ball of size `eps`.
 
         :param values: Values to clip.
         :param eps: Maximum norm allowed.
-        :param norm_p: L_p norm to use for clipping supporting 1, 2 and `np.Inf`.
+        :param norm_p: L_p norm to use for clipping supporting 1, 2, `np.Inf` and "inf".
         :return: Values of `values` after projection.
         """
         import torch  # lgtm [py/repeated-import]
@@ -375,7 +375,7 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
                 eps / (torch.norm(values_tmp, p=1, dim=1) + tol),
             ).unsqueeze_(-1)
 
-        elif norm_p == np.inf:
+        elif norm_p in [np.inf, "inf"]:
             values_tmp = values_tmp.sign() * torch.min(
                 values_tmp.abs(), torch.tensor([eps], dtype=torch.float32).to(self.estimator.device)
             )

--- a/art/attacks/evasion/square_attack.py
+++ b/art/attacks/evasion/square_attack.py
@@ -53,7 +53,7 @@ class SquareAttack(EvasionAttack):
     def __init__(
         self,
         estimator: ClassifierGradients,
-        norm: Union[float, int] = np.inf,
+        norm: Union[int, float, str] = np.inf,
         max_iter: int = 100,
         eps: float = 0.3,
         p_init: float = 0.8,
@@ -130,7 +130,7 @@ class SquareAttack(EvasionAttack):
             y_robust = y[sample_is_robust]
             sample_logits_diff_init = self._get_logits_diff(x_robust, y_robust)
 
-            if self.norm == np.inf:
+            if self.norm in [np.inf, "inf"]:
 
                 if self.estimator.channels_first:
                     size = (x_robust.shape[0], channels, 1, width)
@@ -440,8 +440,8 @@ class SquareAttack(EvasionAttack):
         return x_adv
 
     def _check_params(self) -> None:
-        if self.norm not in [1, 2, np.inf]:
-            raise ValueError("The argument norm has to be either 1, 2, or np.inf.")
+        if self.norm not in [1, 2, np.inf, "inf"]:
+            raise ValueError("The argument norm has to be either 1, 2, np.inf, or \"inf\".")
 
         if not isinstance(self.max_iter, int) or self.max_iter <= 0:
             raise ValueError("The argument max_iter has to be of type int and larger than zero.")

--- a/art/attacks/evasion/targeted_universal_perturbation.py
+++ b/art/attacks/evasion/targeted_universal_perturbation.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import random
 import types
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import numpy as np
 
@@ -64,7 +64,7 @@ class TargetedUniversalPerturbation(EvasionAttack):
         delta: float = 0.2,
         max_iter: int = 20,
         eps: float = 10.0,
-        norm: int = np.inf,
+        norm: Union[int, float, str] = np.inf,
     ):
         """
         :param classifier: A trained classifier.
@@ -74,7 +74,7 @@ class TargetedUniversalPerturbation(EvasionAttack):
         :param delta: desired accuracy
         :param max_iter: The maximum number of iterations for computing universal perturbation.
         :param eps: Attack step size (input variation)
-        :param norm: The norm of the adversarial perturbation. Possible values: np.inf, 2
+        :param norm: The norm of the adversarial perturbation. Possible values: "inf", np.inf, 2
         """
         super(TargetedUniversalPerturbation, self).__init__(estimator=classifier)
 

--- a/art/attacks/evasion/universal_perturbation.py
+++ b/art/attacks/evasion/universal_perturbation.py
@@ -83,7 +83,7 @@ class UniversalPerturbation(EvasionAttack):
         delta: float = 0.2,
         max_iter: int = 20,
         eps: float = 10.0,
-        norm: int = np.inf,
+        norm: Union[int, float, str] = np.inf,
         batch_size: int = 32,
     ) -> None:
         """
@@ -95,7 +95,7 @@ class UniversalPerturbation(EvasionAttack):
         :param delta: desired accuracy
         :param max_iter: The maximum number of iterations for computing universal perturbation.
         :param eps: Attack step size (input variation).
-        :param norm: The norm of the adversarial perturbation. Possible values: np.inf, 2.
+        :param norm: The norm of the adversarial perturbation. Possible values: "inf", np.inf, 2.
         :param batch_size: Batch size for model evaluations in UniversalPerturbation.
         """
         super(UniversalPerturbation, self).__init__(estimator=classifier)

--- a/art/utils.py
+++ b/art/utils.py
@@ -162,7 +162,7 @@ def deprecated_keyword_arg(identifier: str, end_version: str, *, reason: str = "
 # ----------------------------------------------------------------------------------------------------- MATH OPERATIONS
 
 
-def projection(values: np.ndarray, eps: float, norm_p: Union[int, str]) -> np.ndarray:
+def projection(values: np.ndarray, eps: float, norm_p: Union[int, float, str]) -> np.ndarray:
     """
     Project `values` on the L_p norm ball of size `eps`.
 

--- a/art/utils.py
+++ b/art/utils.py
@@ -162,13 +162,13 @@ def deprecated_keyword_arg(identifier: str, end_version: str, *, reason: str = "
 # ----------------------------------------------------------------------------------------------------- MATH OPERATIONS
 
 
-def projection(values: np.ndarray, eps: float, norm_p: Union[int, float]) -> np.ndarray:
+def projection(values: np.ndarray, eps: float, norm_p: Union[int, str]) -> np.ndarray:
     """
     Project `values` on the L_p norm ball of size `eps`.
 
     :param values: Array of perturbations to clip.
     :param eps: Maximum norm allowed.
-    :param norm_p: L_p norm to use for clipping. Only 1, 2 and `np.Inf` supported for now.
+    :param norm_p: L_p norm to use for clipping. Only 1, 2, `np.Inf` and "inf" supported for now.
     :return: Values of `values` after projection.
     """
     # Pick a small scalar to avoid division by 0
@@ -183,23 +183,24 @@ def projection(values: np.ndarray, eps: float, norm_p: Union[int, float]) -> np.
         values_tmp = values_tmp * np.expand_dims(
             np.minimum(1.0, eps / (np.linalg.norm(values_tmp, axis=1, ord=1) + tol)), axis=1,
         )
-    elif norm_p == np.inf:
+    elif norm_p in [np.inf, "inf"]:
         values_tmp = np.sign(values_tmp) * np.minimum(abs(values_tmp), eps)
     else:
-        raise NotImplementedError("Values of `norm_p` different from 1, 2 and `np.inf` are currently not supported.")
+        raise NotImplementedError("Values of `norm_p` different from 1, 2, `np.inf` and \"inf\" are currently not "
+                                  "supported.")
 
     values = values_tmp.reshape(values.shape)
     return values
 
 
-def random_sphere(nb_points: int, nb_dims: int, radius: float, norm: Union[int, float]) -> np.ndarray:
+def random_sphere(nb_points: int, nb_dims: int, radius: float, norm: Union[int, float, str]) -> np.ndarray:
     """
     Generate randomly `m x n`-dimension points with radius `radius` and centered around 0.
 
     :param nb_points: Number of random data points.
     :param nb_dims: Dimensionality of the sphere.
     :param radius: Radius of the sphere.
-    :param norm: Current support: 1, 2, np.inf.
+    :param norm: Current support: 1, 2, np.inf, "inf".
     :return: The generated random sphere.
     """
     if norm == 1:
@@ -215,7 +216,7 @@ def random_sphere(nb_points: int, nb_dims: int, radius: float, norm: Union[int, 
         s_2 = np.sum(a_tmp ** 2, axis=1)
         base = gammainc(nb_dims / 2.0, s_2 / 2.0) ** (1 / nb_dims) * radius / np.sqrt(s_2)
         res = a_tmp * (np.tile(base, (nb_dims, 1))).T
-    elif norm == np.inf:
+    elif norm in [np.inf, "inf"]:
         res = np.random.uniform(float(-radius), float(radius), (nb_points, nb_dims))
     else:
         raise NotImplementedError("Norm {} not supported".format(norm))


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request add support for string type to define infinity norms in attacks.

Fixes #465 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
