### PR TITLE
Dev 1.5.0 462 Separate TensorFlow 1.x and TensorFlow 2.x tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN pip3 install keras==2.3.1
 #FROM tensorflow/tensorflow:1.15.2
 #RUN pip3 install keras==2.2.5
 
-RUN pip3 install numpy==1.19.1 scipy==1.4.1 matplotlib==3.3.1 scikit-learn==0.22.2 six==1.15.0 Pillow==7.2.0
+RUN pip3 install numpy==1.19.1 scipy==1.4.1 matplotlib==3.3.1 scikit-learn==0.22.2 six==1.15.0 Pillow==7.2.0 pytest-cov==2.10.1
 RUN pip3 install tqdm==4.48.2 statsmodels==0.11.1 pydub==0.24.1 resampy==0.2.2 ffmpeg-python==0.2.0 cma==3.0.3 mypy==0.770
 RUN pip3 install ffmpeg-python==0.2.0
 RUN pip3 install pandas==1.1.1

--- a/conftest.py
+++ b/conftest.py
@@ -193,13 +193,11 @@ def image_iterator(framework, is_tf_version_2, get_default_mnist_subset, default
             )
             return keras_gen.flow(x_train_mnist, y_train_mnist, batch_size=default_batch_size)
 
-        if framework == "tensorflow":
-            import tensorflow as tf
-            if not is_tf_version_2:
-                x_tensor = tf.convert_to_tensor(x_train_mnist.reshape(10, 100, 28, 28, 1))
-                y_tensor = tf.convert_to_tensor(y_train_mnist.reshape(10, 100, 10))
-                dataset = tf.data.Dataset.from_tensor_slices((x_tensor, y_tensor))
-                return dataset.make_initializable_iterator()
+        if framework == "tensorflow1":
+            x_tensor = tf.convert_to_tensor(x_train_mnist.reshape(10, 100, 28, 28, 1))
+            y_tensor = tf.convert_to_tensor(y_train_mnist.reshape(10, 100, 10))
+            dataset = tf.data.Dataset.from_tensor_slices((x_tensor, y_tensor))
+            return dataset.make_initializable_iterator()
 
         if framework == "pytorch":
             import torch

--- a/conftest.py
+++ b/conftest.py
@@ -297,7 +297,7 @@ def store_expected_values(request):
 
 
 @pytest.fixture
-def expected_values(framework, request, is_tf_version_2):
+def expected_values(framework, request):
     """
     Retrieves the expected values that were stored using the store_expected_values fixture
     :param request:
@@ -307,11 +307,6 @@ def expected_values(framework, request, is_tf_version_2):
     file_name = request.node.location[0].split("/")[-1][:-3] + ".json"
 
     framework_name = framework
-    if framework == "tensorflow":
-        if is_tf_version_2:
-            framework_name = "tensorflow2"
-        else:
-            framework_name = "tensorflow1"
     if framework_name is not "":
         framework_name = "_" + framework_name
 

--- a/conftest.py
+++ b/conftest.py
@@ -24,6 +24,7 @@ import tempfile
 import numpy as np
 import pytest
 import requests
+import tensorflow as tf
 import warnings
 
 from art.data_generators import PyTorchDataGenerator, TensorFlowDataGenerator, KerasDataGenerator, MXDataGenerator
@@ -38,7 +39,7 @@ from tests.utils import ARTTestFixtureNotImplemented, get_attack_classifier_pt
 
 logger = logging.getLogger(__name__)
 
-deep_learning_frameworks = ["keras", "tensorflow", "pytorch", "kerastf", "mxnet"]
+deep_learning_frameworks = ["keras", "tensorflow1", "tensorflow2", "pytorch", "kerastf", "mxnet"]
 non_deep_learning_frameworks = ["scikitlearn"]
 
 art_supported_frameworks = []
@@ -48,6 +49,11 @@ art_supported_frameworks.extend(non_deep_learning_frameworks)
 master_seed(1234)
 
 default_framework = "tensorflow"
+
+if tf.__version__[0] == "2":
+    default_framework = "tensorflow2"
+else:
+    default_framework = "tensorflow1"
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -717,7 +717,7 @@ def only_with_platform(request, framework):
 # ART test fixture to skip test for specific mlFramework values
 # eg: @pytest.mark.skipMlFramework("tensorflow","scikitlearn")
 @pytest.fixture(autouse=True)
-def skip_by_platform(request, framework):
+def skip_by_framework(request, framework):
     if request.node.get_closest_marker("skipMlFramework"):
         framework_to_skip_list = list(request.node.get_closest_marker("skipMlFramework").args)
         if "dl_frameworks" in framework_to_skip_list:
@@ -725,6 +725,10 @@ def skip_by_platform(request, framework):
 
         if "non_dl_frameworks" in framework_to_skip_list:
             framework_to_skip_list.extend(non_deep_learning_frameworks)
+
+        if "tensorflow" in framework_to_skip_list:
+            framework_to_skip_list.append("tensorflow1")
+            framework_to_skip_list.append("tensorflow2")
 
         if framework in framework_to_skip_list:
             pytest.skip("skipped on this platform: {}".format(framework))

--- a/conftest.py
+++ b/conftest.py
@@ -611,17 +611,6 @@ def framework(request):
 def default_batch_size():
     yield 16
 
-
-# @pytest.fixture(scope="session")
-# def is_tf_version_2():
-#     import tensorflow as tf
-#
-#     if tf.__version__[0] == "2":
-#         yield True
-#     else:
-#         yield False
-
-
 @pytest.fixture(scope="session")
 def load_iris_dataset():
     logging.info("Loading Iris dataset")

--- a/conftest.py
+++ b/conftest.py
@@ -259,7 +259,7 @@ def image_data_generator(framework, get_default_mnist_subset, image_iterator, de
 
 
 @pytest.fixture
-def store_expected_values(request, is_tf_version_2):
+def store_expected_values(request):
     """
     Stores expected values to be retrieved by the expected_values fixture
     Note1: Numpy arrays MUST be converted to list before being stored as json
@@ -272,11 +272,6 @@ def store_expected_values(request, is_tf_version_2):
     def _store_expected_values(values_to_store, framework=""):
 
         framework_name = framework
-        if framework == "tensorflow":
-            if is_tf_version_2:
-                framework_name = "tensorflow2"
-            else:
-                framework_name = "tensorflow1"
         if framework_name is not "":
             framework_name = "_" + framework_name
 

--- a/conftest.py
+++ b/conftest.py
@@ -625,14 +625,14 @@ def default_batch_size():
     yield 16
 
 
-@pytest.fixture(scope="session")
-def is_tf_version_2():
-    import tensorflow as tf
-
-    if tf.__version__[0] == "2":
-        yield True
-    else:
-        yield False
+# @pytest.fixture(scope="session")
+# def is_tf_version_2():
+#     import tensorflow as tf
+#
+#     if tf.__version__[0] == "2":
+#         yield True
+#     else:
+#         yield False
 
 
 @pytest.fixture(scope="session")

--- a/conftest.py
+++ b/conftest.py
@@ -597,14 +597,21 @@ def create_test_image(create_test_dir):
 
 @pytest.fixture(scope="session")
 def framework(request):
-    mlFramework = request.config.getoption("--mlFramework")
-    if mlFramework not in art_supported_frameworks:
+    ml_framework = request.config.getoption("--mlFramework")
+    if ml_framework == "tensorflow":
+        import tensorflow as tf
+        if tf.__version__[0] == "2":
+            ml_framework = "tensorflow2"
+        else:
+            ml_framework = "tensorflow1"
+
+    if ml_framework not in art_supported_frameworks:
         raise Exception("mlFramework value {0} is unsupported. Please use one of these valid values: {1}".format(
-            mlFramework, " ".join(art_supported_frameworks)))
+            ml_framework, " ".join(art_supported_frameworks)))
     # if utils_test.is_valid_framework(mlFramework):
     #     raise Exception("The mlFramework specified was incorrect. Valid options available
     #     are {0}".format(art_supported_frameworks))
-    return mlFramework
+    return ml_framework
 
 
 @pytest.fixture(scope="session")

--- a/conftest.py
+++ b/conftest.py
@@ -488,7 +488,7 @@ def image_dl_estimator(framework, get_image_classifier_mx_instance):
                         raise ARTTestFixtureNotImplemented(
                             "This combination of loss function options is currently not supported.",
                             image_dl_estimator.__name__, framework)
-        if framework == "tensorflow":
+        if framework == "tensorflow1" or framework == "tensorflow2":
             if wildcard is False and functional is False:
                 classifier, sess = get_image_classifier_tf(**kwargs)
                 return classifier, sess

--- a/conftest.py
+++ b/conftest.py
@@ -703,7 +703,8 @@ def only_with_platform(request, framework):
 
 
 # ART test fixture to skip test for specific mlFramework values
-# eg: @pytest.mark.skipMlFramework("tensorflow","scikitlearn")
+# eg: @pytest.mark.skipMlFramework("tensorflow", "keras", "pytorch", "scikitlearn",
+# "mxnet", "kerastf", "non_dl_frameworks", "dl_frameworks")
 @pytest.fixture(autouse=True)
 def skip_by_framework(request, framework):
     if request.node.get_closest_marker("skipMlFramework"):

--- a/conftest.py
+++ b/conftest.py
@@ -176,7 +176,7 @@ def setup_tear_down_framework(framework):
 
 
 @pytest.fixture
-def image_iterator(framework, is_tf_version_2, get_default_mnist_subset, default_batch_size):
+def image_iterator(framework, get_default_mnist_subset, default_batch_size):
     (x_train_mnist, y_train_mnist), (_, _) = get_default_mnist_subset
 
     def _get_image_iterator():
@@ -219,7 +219,7 @@ def image_iterator(framework, is_tf_version_2, get_default_mnist_subset, default
 
 
 @pytest.fixture
-def image_data_generator(framework, is_tf_version_2, get_default_mnist_subset, image_iterator, default_batch_size):
+def image_data_generator(framework, get_default_mnist_subset, image_iterator, default_batch_size):
     def _image_data_generator(**kwargs):
         (x_train_mnist, y_train_mnist), (_, _) = get_default_mnist_subset
 
@@ -233,13 +233,12 @@ def image_data_generator(framework, is_tf_version_2, get_default_mnist_subset, i
                 batch_size=default_batch_size,
             )
 
-        if framework == "tensorflow":
-            if not is_tf_version_2:
-                data_generator = TensorFlowDataGenerator(
-                    sess=kwargs["sess"], iterator=image_it, iterator_type="initializable", iterator_arg={},
-                    size=x_train_mnist.shape[0],
-                    batch_size=default_batch_size,
-                )
+        if framework == "tensorflow1":
+            data_generator = TensorFlowDataGenerator(
+                sess=kwargs["sess"], iterator=image_it, iterator_type="initializable", iterator_arg={},
+                size=x_train_mnist.shape[0],
+                batch_size=default_batch_size,
+            )
 
         if framework == "pytorch":
             data_generator = PyTorchDataGenerator(iterator=image_it, size=x_train_mnist.shape[0],

--- a/conftest.py
+++ b/conftest.py
@@ -149,17 +149,11 @@ def estimator_for_attack(framework):
 @pytest.fixture(autouse=True)
 def setup_tear_down_framework(framework):
     # Ran before each test
-    if framework == "keras":
-        pass
-    if framework == "tensorflow":
+    if framework == "tensorflow1" or framework == "tensorflow2":
         import tensorflow as tf
 
         if tf.__version__[0] != "2":
             tf.reset_default_graph()
-    if framework == "pytorch":
-        pass
-    if framework == "scikitlearn":
-        pass
     yield True
 
     # Ran after each test
@@ -167,12 +161,6 @@ def setup_tear_down_framework(framework):
         import keras
 
         keras.backend.clear_session()
-    if framework == "tensorflow":
-        pass
-    if framework == "pytorch":
-        pass
-    if framework == "scikitlearn":
-        pass
 
 
 @pytest.fixture
@@ -564,7 +552,7 @@ def tabular_dl_estimator(framework):
                 kr_classifier = get_tabular_classifier_kr()
                 classifier = KerasClassifier(model=kr_classifier.model, use_logits=False, channels_first=True)
 
-        if framework == "tensorflow":
+        if framework == "tensorflow1" or framework == "tensorflow2":
             if clipped:
                 classifier, _ = get_tabular_classifier_tf()
 

--- a/conftest.py
+++ b/conftest.py
@@ -611,6 +611,7 @@ def framework(request):
 def default_batch_size():
     yield 16
 
+
 @pytest.fixture(scope="session")
 def load_iris_dataset():
     logging.info("Loading Iris dataset")

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ kornia==0.4.0
 pytest==5.4.1
 pytest-pep8==1.0.6
 pytest-mock==3.3.1
+pytest-cov==2.10.1
 codecov==2.1.9
 requests==2.24.0
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,15 +6,6 @@ export TF_CPP_MIN_LOG_LEVEL="3"
 
 # --------------------------------------------------------------------------------------------------------------- TESTS
 
-
-#mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
-#for mlFramework in "${mlFrameworkList[@]}"; do
-#  echo "#######################################################################"
-#  echo "############## Running tests with framework $mlFramework ##############"
-#  echo "#######################################################################"
-#
-#done
-
 mlFrameworkList=("tensorflow" "scikitlearn")
 for mlFramework in "${mlFrameworkList[@]}"; do
   echo "#######################################################################"
@@ -24,24 +15,7 @@ for mlFramework in "${mlFrameworkList[@]}"; do
   #TODO FIX Failing with Keras at test_membership_inference.test_black_box_keras_loss
   pytest -q -vv tests/attacks/inference/test_membership_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
-
-#  #TODO FIX Failing with Pytorch at test_shadow_attack.test_generate
-#  pytest -q -vv tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
 done
-
-#
-#mlFrameworkList=("tensorflow")
-#for mlFramework in "${mlFrameworkList[@]}"; do
-#  echo "#######################################################################"
-#  echo "############## Running tests with framework $mlFramework ##############"
-#  echo "#######################################################################"
-#
-##  #TODO FIX Failing with Pytorch at test_shadow_attack.test_generate
-##  pytest -q -vv tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-##  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
-#
-#done
 
 #NOTE: All the tests should be ran within this loop. All other tests are legacy tests that must be
 # made framework independent to be incorporated within this loop
@@ -59,20 +33,6 @@ for mlFramework in "${mlFrameworkList[@]}"; do
 
   pytest -q -vv -s tests/attacks/evasion/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
-
-#  pytest -q -vv tests/attacks/evasion/test_auto_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  pytest -q -vv tests/attacks/evasion/test_auto_projected_gradient_descent.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  pytest -q -vv tests/attacks/evasion/test_boundary.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  pytest -q -vv tests/attacks/evasion/test_dpatch.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  pytest -q -vv tests/attacks/evasion/test_fast_gradient.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  pytest -q -vv tests/attacks/evasion/test_feature_adversaries.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  pytest -q -vv tests/attacks/evasion/test_frame_saliency.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  pytest -q -vv tests/attacks/evasion/test_imperceptible_asr_pytorch.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  pytest -q -vv tests/attacks/evasion/test_square_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
-#
-#  pytest -q -vv -s tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
 
   pytest -q -vv tests/attacks/inference/test_model_inversion.py --mlFramework=$mlFramework --skip_travis=True --durations=0
   pytest -q -vv tests/attacks/inference/test_attribute_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,24 +7,33 @@ export TF_CPP_MIN_LOG_LEVEL="3"
 # --------------------------------------------------------------------------------------------------------------- TESTS
 
 
-#mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
-mlFrameworkList=("keras")
+mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
 for mlFramework in "${mlFrameworkList[@]}"; do
   echo "#######################################################################"
   echo "############## Running tests with framework $mlFramework ##############"
   echo "#######################################################################"
-  pytest -q -vv tests/attacks/inference/ --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
+  pytest -q -vv tests/defences/preprocessor --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor tests"; fi
+
+  pytest -q -vv tests/utils --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed utils tests"; fi
+
+  pytest -q -vv tests/attacks/evasion/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
+
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed all framework tests"; fi
 done
 
-#mlFrameworkList=("tensorflow" "scikitlearn")
-#for mlFramework in "${mlFrameworkList[@]}"; do
-#  echo "#######################################################################"
-#  echo "############## Running tests with framework $mlFramework ##############"
-#  echo "#######################################################################"
-#  pytest -q -vv tests/attacks/inference/ --mlFramework=$mlFramework --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
-#done
+mlFrameworkList=("tensorflow" "scikitlearn")
+for mlFramework in "${mlFrameworkList[@]}"; do
+  echo "#######################################################################"
+  echo "############## Running tests with framework $mlFramework ##############"
+  echo "#######################################################################"
+
+  #FIX Failing with Keras at test_membership_inference.test_black_box_keras_loss
+  pytest -q -vv tests/attacks/inference/test_membership_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
+done
 #
 #mlFrameworkList=("tensorflow")
 #for mlFramework in "${mlFrameworkList[@]}"; do
@@ -50,6 +59,10 @@ done
 #  echo "############## Running tests with framework $mlFramework ##############"
 #  echo "#######################################################################"
 #
+#  pytest -q -vv tests/attacks/inference/test_model_inversion.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+#  pytest -q -vv tests/attacks/inference/test_attribute_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
+
 #  pytest -q -vv tests/classifiersFrameworks/  --mlFramework=$mlFramework --skip_travis=True --durations=0
 #  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks tests"; fi
 #

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -24,19 +24,24 @@ for mlFramework in "${mlFrameworkList[@]}"; do
   #TODO FIX Failing with Keras at test_membership_inference.test_black_box_keras_loss
   pytest -q -vv tests/attacks/inference/test_membership_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
-done
-#
-mlFrameworkList=("tensorflow")
-for mlFramework in "${mlFrameworkList[@]}"; do
-  echo "#######################################################################"
-  echo "############## Running tests with framework $mlFramework ##############"
-  echo "#######################################################################"
 
   #TODO FIX Failing with Pytorch at test_shadow_attack.test_generate
   pytest -q -vv tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
-
 done
+
+#
+#mlFrameworkList=("tensorflow")
+#for mlFramework in "${mlFrameworkList[@]}"; do
+#  echo "#######################################################################"
+#  echo "############## Running tests with framework $mlFramework ##############"
+#  echo "#######################################################################"
+#
+##  #TODO FIX Failing with Pytorch at test_shadow_attack.test_generate
+##  pytest -q -vv tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+##  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
+#
+#done
 
 #NOTE: All the tests should be ran within this loop. All other tests are legacy tests that must be
 # made framework independent to be incorporated within this loop

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,7 +7,7 @@ export TF_CPP_MIN_LOG_LEVEL="3"
 # --------------------------------------------------------------------------------------------------------------- TESTS
 
 
-mlFrameworkList=("tensorflow" "scikitlearn")
+mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
 for mlFramework in "${mlFrameworkList[@]}"; do
   echo "#######################################################################"
   echo "############## Running tests with framework $mlFramework ##############"
@@ -16,45 +16,54 @@ for mlFramework in "${mlFrameworkList[@]}"; do
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
 done
 
-mlFrameworkList=("tensorflow")
-for mlFramework in "${mlFrameworkList[@]}"; do
-  echo "#######################################################################"
-  echo "############## Running tests with framework $mlFramework ##############"
-  echo "#######################################################################"
-  pytest -q -vv tests/defences/preprocessor --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor tests"; fi
-
-  pytest -q -vv tests/utils --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed utils tests"; fi
-
-  pytest -q -vv tests/attacks/evasion/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
-
-done
-
-#NOTE: All the tests should be ran within this loop. All other tests are legacy tests that must be
-# made framework independent to be incorporated within this loop
-mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
-for mlFramework in "${mlFrameworkList[@]}"; do
-  echo "#######################################################################"
-  echo "############## Running tests with framework $mlFramework ##############"
-  echo "#######################################################################"
-
-  pytest -q -vv tests/classifiersFrameworks/  --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks tests"; fi
-
-  pytest -q -vv tests/defences/preprocessor/test_spatial_smoothing_pytorch.py  --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor/test_spatial_smoothing_pytorch.py tests"; fi
-
-  pytest -q -vv -s tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
-
-  pytest -q -vv tests/estimators/classification/test_deeplearning_common.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification/test_deeplearning_common.py $mlFramework"; fi
-
-  pytest -q -vv tests/estimators/classification/test_deeplearning_specific.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification tests for framework $mlFramework"; fi
-done
+#mlFrameworkList=("tensorflow" "scikitlearn")
+#for mlFramework in "${mlFrameworkList[@]}"; do
+#  echo "#######################################################################"
+#  echo "############## Running tests with framework $mlFramework ##############"
+#  echo "#######################################################################"
+#  pytest -q -vv tests/attacks/inference/ --mlFramework=$mlFramework --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
+#done
+#
+#mlFrameworkList=("tensorflow")
+#for mlFramework in "${mlFrameworkList[@]}"; do
+#  echo "#######################################################################"
+#  echo "############## Running tests with framework $mlFramework ##############"
+#  echo "#######################################################################"
+#  pytest -q -vv tests/defences/preprocessor --mlFramework=$mlFramework --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor tests"; fi
+#
+#  pytest -q -vv tests/utils --mlFramework=$mlFramework --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed utils tests"; fi
+#
+#  pytest -q -vv tests/attacks/evasion/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
+#
+#done
+#
+##NOTE: All the tests should be ran within this loop. All other tests are legacy tests that must be
+## made framework independent to be incorporated within this loop
+#mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
+#for mlFramework in "${mlFrameworkList[@]}"; do
+#  echo "#######################################################################"
+#  echo "############## Running tests with framework $mlFramework ##############"
+#  echo "#######################################################################"
+#
+#  pytest -q -vv tests/classifiersFrameworks/  --mlFramework=$mlFramework --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks tests"; fi
+#
+#  pytest -q -vv tests/defences/preprocessor/test_spatial_smoothing_pytorch.py  --mlFramework=$mlFramework --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor/test_spatial_smoothing_pytorch.py tests"; fi
+#
+#  pytest -q -vv -s tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
+#
+#  pytest -q -vv tests/estimators/classification/test_deeplearning_common.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification/test_deeplearning_common.py $mlFramework"; fi
+#
+#  pytest -q -vv tests/estimators/classification/test_deeplearning_specific.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification tests for framework $mlFramework"; fi
+#done
 
 
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,7 +13,7 @@ for mlFramework in "${mlFrameworkList[@]}"; do
   echo "#######################################################################"
 
   #TODO FIX Failing with Keras at test_membership_inference.test_black_box_keras_loss
-  pytest -q -vv tests/attacks/inference/test_membership_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+  pytest --cov-report=xml --cov=art --cov-append -q -vv tests/attacks/inference/test_membership_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
 done
 
@@ -25,29 +25,29 @@ for mlFramework in "${mlFrameworkList[@]}"; do
   echo "############## Running tests with framework $mlFramework ##############"
   echo "#######################################################################"
 
-  pytest -q -vv tests/defences/preprocessor --mlFramework=$mlFramework --skip_travis=True --durations=0
+  pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/defences/preprocessor --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor tests"; fi
 
-  pytest -q -vv tests/utils --mlFramework=$mlFramework --skip_travis=True --durations=0
+  pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/utils --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed utils tests"; fi
 
-  pytest -q -vv -s tests/attacks/evasion/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  pytest --cov-report=xml --cov=art --cov-append  -q -vv -s tests/attacks/evasion/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
 
-  pytest -q -vv tests/attacks/inference/test_model_inversion.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-  pytest -q -vv tests/attacks/inference/test_attribute_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+  pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/attacks/inference/test_model_inversion.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+  pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/attacks/inference/test_attribute_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
 
-  pytest -q -vv tests/classifiersFrameworks/  --mlFramework=$mlFramework --skip_travis=True --durations=0
+  pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/classifiersFrameworks/  --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks tests"; fi
 
-  pytest -q -vv tests/defences/preprocessor/test_spatial_smoothing_pytorch.py  --mlFramework=$mlFramework --skip_travis=True --durations=0
+  pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/defences/preprocessor/test_spatial_smoothing_pytorch.py  --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor/test_spatial_smoothing_pytorch.py tests"; fi
 
-  pytest -q -vv tests/estimators/classification/test_deeplearning_common.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+  pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/estimators/classification/test_deeplearning_common.py --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification/test_deeplearning_common.py $mlFramework"; fi
 
-  pytest -q -vv tests/estimators/classification/test_deeplearning_specific.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+  pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/estimators/classification/test_deeplearning_specific.py --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification tests for framework $mlFramework"; fi
 done
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,17 +6,6 @@ export TF_CPP_MIN_LOG_LEVEL="3"
 
 # --------------------------------------------------------------------------------------------------------------- TESTS
 
-mlFrameworkList=("tensorflow" "scikitlearn")
-for mlFramework in "${mlFrameworkList[@]}"; do
-  echo "#######################################################################"
-  echo "############## Running tests with framework $mlFramework ##############"
-  echo "#######################################################################"
-
-  #TODO FIX Failing with Keras at test_membership_inference.test_black_box_keras_loss
-  pytest --cov-report=xml --cov=art --cov-append -q -vv tests/attacks/inference/test_membership_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
-done
-
 #NOTE: All the tests should be ran within this loop. All other tests are legacy tests that must be
 # made framework independent to be incorporated within this loop
 mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
@@ -34,10 +23,8 @@ for mlFramework in "${mlFrameworkList[@]}"; do
   pytest --cov-report=xml --cov=art --cov-append  -q -vv -s tests/attacks/evasion/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
 
-  pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/attacks/inference/test_model_inversion.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference/model_inversion tests"; fi
-  pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/attacks/inference/test_attribute_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference/attribute_inference tests"; fi
+  pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/attacks/inference/ --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference"; fi
 
   pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/classifiersFrameworks/  --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks tests"; fi

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,22 +7,13 @@ export TF_CPP_MIN_LOG_LEVEL="3"
 # --------------------------------------------------------------------------------------------------------------- TESTS
 
 
-mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
-for mlFramework in "${mlFrameworkList[@]}"; do
-  echo "#######################################################################"
-  echo "############## Running tests with framework $mlFramework ##############"
-  echo "#######################################################################"
-  pytest -q -vv tests/defences/preprocessor --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor tests"; fi
-
-  pytest -q -vv tests/utils --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed utils tests"; fi
-
-  pytest -q -vv tests/attacks/evasion/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
-
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed all framework tests"; fi
-done
+#mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
+#for mlFramework in "${mlFrameworkList[@]}"; do
+#  echo "#######################################################################"
+#  echo "############## Running tests with framework $mlFramework ##############"
+#  echo "#######################################################################"
+#
+#done
 
 mlFrameworkList=("tensorflow" "scikitlearn")
 for mlFramework in "${mlFrameworkList[@]}"; do
@@ -30,54 +21,68 @@ for mlFramework in "${mlFrameworkList[@]}"; do
   echo "############## Running tests with framework $mlFramework ##############"
   echo "#######################################################################"
 
-  #FIX Failing with Keras at test_membership_inference.test_black_box_keras_loss
+  #TODO FIX Failing with Keras at test_membership_inference.test_black_box_keras_loss
   pytest -q -vv tests/attacks/inference/test_membership_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
 done
 #
-#mlFrameworkList=("tensorflow")
-#for mlFramework in "${mlFrameworkList[@]}"; do
-#  echo "#######################################################################"
-#  echo "############## Running tests with framework $mlFramework ##############"
-#  echo "#######################################################################"
-#  pytest -q -vv tests/defences/preprocessor --mlFramework=$mlFramework --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor tests"; fi
-#
-#  pytest -q -vv tests/utils --mlFramework=$mlFramework --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed utils tests"; fi
-#
-#  pytest -q -vv tests/attacks/evasion/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
-#
-#done
-#
-##NOTE: All the tests should be ran within this loop. All other tests are legacy tests that must be
-## made framework independent to be incorporated within this loop
-#mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
-#for mlFramework in "${mlFrameworkList[@]}"; do
-#  echo "#######################################################################"
-#  echo "############## Running tests with framework $mlFramework ##############"
-#  echo "#######################################################################"
-#
-#  pytest -q -vv tests/attacks/inference/test_model_inversion.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-#  pytest -q -vv tests/attacks/inference/test_attribute_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
+mlFrameworkList=("tensorflow")
+for mlFramework in "${mlFrameworkList[@]}"; do
+  echo "#######################################################################"
+  echo "############## Running tests with framework $mlFramework ##############"
+  echo "#######################################################################"
 
-#  pytest -q -vv tests/classifiersFrameworks/  --mlFramework=$mlFramework --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks tests"; fi
-#
-#  pytest -q -vv tests/defences/preprocessor/test_spatial_smoothing_pytorch.py  --mlFramework=$mlFramework --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor/test_spatial_smoothing_pytorch.py tests"; fi
-#
-#  pytest -q -vv -s tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
-#
-#  pytest -q -vv tests/estimators/classification/test_deeplearning_common.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification/test_deeplearning_common.py $mlFramework"; fi
-#
-#  pytest -q -vv tests/estimators/classification/test_deeplearning_specific.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification tests for framework $mlFramework"; fi
-#done
+  #TODO FIX Failing with Pytorch at test_shadow_attack.test_generate
+  pytest -q -vv tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
+
+done
+
+#NOTE: All the tests should be ran within this loop. All other tests are legacy tests that must be
+# made framework independent to be incorporated within this loop
+mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
+for mlFramework in "${mlFrameworkList[@]}"; do
+  echo "#######################################################################"
+  echo "############## Running tests with framework $mlFramework ##############"
+  echo "#######################################################################"
+
+
+  pytest -q -vv tests/defences/preprocessor --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor tests"; fi
+
+  pytest -q -vv tests/utils --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed utils tests"; fi
+
+  pytest -q -vv tests/attacks/evasion/test_auto_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  pytest -q -vv tests/attacks/evasion/test_auto_projected_gradient_descent.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  pytest -q -vv tests/attacks/evasion/test_boundary.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  pytest -q -vv tests/attacks/evasion/test_dpatch.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  pytest -q -vv tests/attacks/evasion/test_fast_gradient.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  pytest -q -vv tests/attacks/evasion/test_feature_adversaries.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  pytest -q -vv tests/attacks/evasion/test_frame_saliency.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  pytest -q -vv tests/attacks/evasion/test_imperceptible_asr_pytorch.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  pytest -q -vv tests/attacks/evasion/test_square_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
+
+  pytest -q -vv tests/attacks/inference/test_model_inversion.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+  pytest -q -vv tests/attacks/inference/test_attribute_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
+
+  pytest -q -vv tests/classifiersFrameworks/  --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks tests"; fi
+
+  pytest -q -vv tests/defences/preprocessor/test_spatial_smoothing_pytorch.py  --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor/test_spatial_smoothing_pytorch.py tests"; fi
+
+  pytest -q -vv -s tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
+
+  pytest -q -vv tests/estimators/classification/test_deeplearning_common.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification/test_deeplearning_common.py $mlFramework"; fi
+
+  pytest -q -vv tests/estimators/classification/test_deeplearning_specific.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification tests for framework $mlFramework"; fi
+done
 
 
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -154,7 +154,7 @@ run_test () {
   echo "######################################################################"
   echo ${test}
   echo "######################################################################"
-  coverage run --append -m unittest -v ${test}
+#  coverage run --append -m unittest -v ${test}
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed $test"; fi
 }
 
@@ -165,7 +165,7 @@ for tests_module in "${tests_modules[@]}"; do
   done
 done
 
-bash <(curl -s https://codecov.io/bash)
+#bash <(curl -s https://codecov.io/bash)
 
 
 exit ${exit_code}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,7 +7,8 @@ export TF_CPP_MIN_LOG_LEVEL="3"
 # --------------------------------------------------------------------------------------------------------------- TESTS
 
 
-mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
+#mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
+mlFrameworkList=("keras")
 for mlFramework in "${mlFrameworkList[@]}"; do
   echo "#######################################################################"
   echo "############## Running tests with framework $mlFramework ##############"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -145,26 +145,26 @@ tests_modules=("attacks" \
 
 # --------------------------------------------------------------------------------------------------- CODE TO RUN TESTS
 
-run_test () {
-  test=$1
-  test_file_name="$(echo ${test} | rev | cut -d'/' -f1 | rev)"
-
-  echo $'\n\n'
-  echo "######################################################################"
-  echo ${test}
-  echo "######################################################################"
-  coverage run --append -m unittest -v ${test}
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed $test"; fi
-}
-
-for tests_module in "${tests_modules[@]}"; do
-  tests="$tests_module[@]"
-  for test in "${!tests}"; do
-     run_test ${test}
-  done
-done
-
-bash <(curl -s https://codecov.io/bash)
+#run_test () {
+#  test=$1
+#  test_file_name="$(echo ${test} | rev | cut -d'/' -f1 | rev)"
+#
+#  echo $'\n\n'
+#  echo "######################################################################"
+#  echo ${test}
+#  echo "######################################################################"
+#  coverage run --append -m unittest -v ${test}
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed $test"; fi
+#}
+#
+#for tests_module in "${tests_modules[@]}"; do
+#  tests="$tests_module[@]"
+#  for test in "${!tests}"; do
+#     run_test ${test}
+#  done
+#done
+#
+#bash <(curl -s https://codecov.io/bash)
 
 
 exit ${exit_code}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -146,26 +146,26 @@ tests_modules=("attacks" \
 
 # --------------------------------------------------------------------------------------------------- CODE TO RUN TESTS
 
-#run_test () {
-#  test=$1
-#  test_file_name="$(echo ${test} | rev | cut -d'/' -f1 | rev)"
-#
-#  echo $'\n\n'
-#  echo "######################################################################"
-#  echo ${test}
-#  echo "######################################################################"
-#  coverage run --append -m unittest -v ${test}
-#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed $test"; fi
-#}
-#
-#for tests_module in "${tests_modules[@]}"; do
-#  tests="$tests_module[@]"
-#  for test in "${!tests}"; do
-#     run_test ${test}
-#  done
-#done
-#
-#bash <(curl -s https://codecov.io/bash)
+run_test () {
+  test=$1
+  test_file_name="$(echo ${test} | rev | cut -d'/' -f1 | rev)"
+
+  echo $'\n\n'
+  echo "######################################################################"
+  echo ${test}
+  echo "######################################################################"
+  coverage run --append -m unittest -v ${test}
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed $test"; fi
+}
+
+for tests_module in "${tests_modules[@]}"; do
+  tests="$tests_module[@]"
+  for test in "${!tests}"; do
+     run_test ${test}
+  done
+done
+
+bash <(curl -s https://codecov.io/bash)
 
 
 exit ${exit_code}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -25,9 +25,9 @@ for mlFramework in "${mlFrameworkList[@]}"; do
   pytest -q -vv tests/attacks/inference/test_membership_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
 
-  #TODO FIX Failing with Pytorch at test_shadow_attack.test_generate
-  pytest -q -vv tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
+#  #TODO FIX Failing with Pytorch at test_shadow_attack.test_generate
+#  pytest -q -vv tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
 done
 
 #
@@ -51,23 +51,28 @@ for mlFramework in "${mlFrameworkList[@]}"; do
   echo "############## Running tests with framework $mlFramework ##############"
   echo "#######################################################################"
 
-
   pytest -q -vv tests/defences/preprocessor --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor tests"; fi
 
   pytest -q -vv tests/utils --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed utils tests"; fi
 
-  pytest -q -vv tests/attacks/evasion/test_auto_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  pytest -q -vv tests/attacks/evasion/test_auto_projected_gradient_descent.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  pytest -q -vv tests/attacks/evasion/test_boundary.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  pytest -q -vv tests/attacks/evasion/test_dpatch.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  pytest -q -vv tests/attacks/evasion/test_fast_gradient.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  pytest -q -vv tests/attacks/evasion/test_feature_adversaries.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  pytest -q -vv tests/attacks/evasion/test_frame_saliency.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  pytest -q -vv tests/attacks/evasion/test_imperceptible_asr_pytorch.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  pytest -q -vv tests/attacks/evasion/test_square_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
+  pytest -q -vv -s tests/attacks/evasion/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
+
+#  pytest -q -vv tests/attacks/evasion/test_auto_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  pytest -q -vv tests/attacks/evasion/test_auto_projected_gradient_descent.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  pytest -q -vv tests/attacks/evasion/test_boundary.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  pytest -q -vv tests/attacks/evasion/test_dpatch.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  pytest -q -vv tests/attacks/evasion/test_fast_gradient.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  pytest -q -vv tests/attacks/evasion/test_feature_adversaries.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  pytest -q -vv tests/attacks/evasion/test_frame_saliency.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  pytest -q -vv tests/attacks/evasion/test_imperceptible_asr_pytorch.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  pytest -q -vv tests/attacks/evasion/test_square_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion tests"; fi
+#
+#  pytest -q -vv -s tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
+#  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
 
   pytest -q -vv tests/attacks/inference/test_model_inversion.py --mlFramework=$mlFramework --skip_travis=True --durations=0
   pytest -q -vv tests/attacks/inference/test_attribute_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
@@ -78,9 +83,6 @@ for mlFramework in "${mlFrameworkList[@]}"; do
 
   pytest -q -vv tests/defences/preprocessor/test_spatial_smoothing_pytorch.py  --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor/test_spatial_smoothing_pytorch.py tests"; fi
-
-  pytest -q -vv -s tests/attacks/evasion/test_shadow_attack.py --mlFramework=$mlFramework  --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
 
   pytest -q -vv tests/estimators/classification/test_deeplearning_common.py --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification/test_deeplearning_common.py $mlFramework"; fi

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,14 +9,18 @@ export TF_CPP_MIN_LOG_LEVEL="3"
 
 mlFrameworkList=("tensorflow" "scikitlearn")
 for mlFramework in "${mlFrameworkList[@]}"; do
-  echo "Running tests with framework $mlFramework"
+  echo "#######################################################################"
+  echo "############## Running tests with framework $mlFramework ##############"
+  echo "#######################################################################"
   pytest -q -vv tests/attacks/inference/ --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
 done
 
 mlFrameworkList=("tensorflow")
 for mlFramework in "${mlFrameworkList[@]}"; do
-  echo "Running tests with framework $mlFramework"
+  echo "#######################################################################"
+  echo "############## Running tests with framework $mlFramework ##############"
+  echo "#######################################################################"
   pytest -q -vv tests/defences/preprocessor --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor tests"; fi
 
@@ -32,7 +36,9 @@ done
 # made framework independent to be incorporated within this loop
 mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
 for mlFramework in "${mlFrameworkList[@]}"; do
-  echo "Running tests with framework $mlFramework"
+  echo "#######################################################################"
+  echo "############## Running tests with framework $mlFramework ##############"
+  echo "#######################################################################"
 
   pytest -q -vv tests/classifiersFrameworks/  --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks tests"; fi

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -35,8 +35,9 @@ for mlFramework in "${mlFrameworkList[@]}"; do
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
 
   pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/attacks/inference/test_model_inversion.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference/model_inversion tests"; fi
   pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/attacks/inference/test_attribute_inference.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference tests"; fi
+  if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference/attribute_inference tests"; fi
 
   pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/classifiersFrameworks/  --mlFramework=$mlFramework --skip_travis=True --durations=0
   if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks tests"; fi

--- a/tests/attacks/evasion/test_auto_projected_gradient_descent.py
+++ b/tests/attacks/evasion/test_auto_projected_gradient_descent.py
@@ -39,6 +39,7 @@ def fix_get_mnist_subset(get_mnist_dataset):
 
 
 @pytest.mark.framework_agnostic
+@pytest.mark.skipMlFramework("tensorflow1", "keras", "pytorch", "non_dl_frameworks", "mxnet", "kerastf")
 def test_generate(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:
         classifier = image_dl_estimator_for_attack(AutoProjectedGradientDescent)

--- a/tests/attacks/evasion/test_auto_projected_gradient_descent.py
+++ b/tests/attacks/evasion/test_auto_projected_gradient_descent.py
@@ -39,29 +39,28 @@ def fix_get_mnist_subset(get_mnist_dataset):
 
 
 @pytest.mark.framework_agnostic
-def test_generate(art_warning, is_tf_version_2, fix_get_mnist_subset, image_dl_estimator_for_attack):
+def test_generate(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:
-        if is_tf_version_2:
-            classifier = image_dl_estimator_for_attack(AutoProjectedGradientDescent)
+        classifier = image_dl_estimator_for_attack(AutoProjectedGradientDescent)
 
-            attack = AutoProjectedGradientDescent(
-                estimator=classifier,
-                norm=np.inf,
-                eps=0.3,
-                eps_step=0.1,
-                max_iter=5,
-                targeted=False,
-                nb_random_init=1,
-                batch_size=32,
-                loss_type="cross_entropy",
-            )
+        attack = AutoProjectedGradientDescent(
+            estimator=classifier,
+            norm=np.inf,
+            eps=0.3,
+            eps_step=0.1,
+            max_iter=5,
+            targeted=False,
+            nb_random_init=1,
+            batch_size=32,
+            loss_type="cross_entropy",
+        )
 
-            (x_train_mnist, y_train_mnist, x_test_mnist, y_test_mnist) = fix_get_mnist_subset
+        (x_train_mnist, y_train_mnist, x_test_mnist, y_test_mnist) = fix_get_mnist_subset
 
-            x_train_mnist_adv = attack.generate(x=x_train_mnist, y=y_train_mnist)
+        x_train_mnist_adv = attack.generate(x=x_train_mnist, y=y_train_mnist)
 
-            assert np.mean(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(0.0329, abs=0.005)
-            assert np.max(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(0.3, abs=0.01)
+        assert np.mean(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(0.0329, abs=0.005)
+        assert np.max(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(0.3, abs=0.01)
     except ARTTestException as e:
         art_warning(e)
 

--- a/tests/attacks/evasion/test_shadow_attack.py
+++ b/tests/attacks/evasion/test_shadow_attack.py
@@ -58,7 +58,7 @@ def test_generate(art_warning, fix_get_mnist_subset, image_dl_estimator_for_atta
 
         x_train_mnist_adv = attack.generate(x=x_train_mnist[0:1], y=y_train_mnist[0:1])
 
-        assert np.max(np.abs(x_train_mnist_adv - x_train_mnist[0:1])) == pytest.approx(0.34966960549354553, 0.06)
+        assert np.max(np.abs(x_train_mnist_adv - x_train_mnist[0:1])) == pytest.approx(0.38116083, 0.06)
     except ARTTestException as e:
         art_warning(e)
 

--- a/tests/attacks/inference/test_model_inversion.py
+++ b/tests/attacks/inference/test_model_inversion.py
@@ -62,6 +62,7 @@ def backend_check_inferred_values(attack, mnist_dataset, classifier):
 
     np.testing.assert_array_less(diff_noisy, diff_inferred)
 
+
 @pytest.mark.framework_agnostic
 def test_miface(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:
@@ -88,6 +89,3 @@ def test_classifier_type_check_fail(art_warning):
     except ARTTestException as e:
         art_warning(e)
 
-
-if __name__ == "__main__":
-    pytest.cmdline.main("-q {} --mlFramework=tensorflow --durations=0".format(__file__).split(" "))

--- a/tests/attacks/inference/test_model_inversion.py
+++ b/tests/attacks/inference/test_model_inversion.py
@@ -63,7 +63,6 @@ def backend_check_inferred_values(attack, mnist_dataset, classifier):
     np.testing.assert_array_less(diff_noisy, diff_inferred)
 
 
-@pytest.mark.framework_agnostic
 def test_miface(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:
         classifier = image_dl_estimator_for_attack(MIFace)

--- a/tests/attacks/inference/test_model_inversion.py
+++ b/tests/attacks/inference/test_model_inversion.py
@@ -88,4 +88,3 @@ def test_classifier_type_check_fail(art_warning):
         backend_test_classifier_type_check_fail(MIFace, [BaseEstimator, ClassifierMixin, ClassGradientsMixin])
     except ARTTestException as e:
         art_warning(e)
-

--- a/tests/attacks/inference/test_model_inversion.py
+++ b/tests/attacks/inference/test_model_inversion.py
@@ -62,7 +62,7 @@ def backend_check_inferred_values(attack, mnist_dataset, classifier):
 
     np.testing.assert_array_less(diff_noisy, diff_inferred)
 
-
+@pytest.mark.framework_agnostic
 def test_miface(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:
         classifier = image_dl_estimator_for_attack(MIFace)

--- a/tests/classifiersFrameworks/test_pytorch.py
+++ b/tests/classifiersFrameworks/test_pytorch.py
@@ -39,7 +39,7 @@ def fix_get_mnist_subset(get_mnist_dataset):
 
 # A generic test for various preprocessing_defences, forward pass.
 def _test_preprocessing_defences_forward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
 ):
     (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 
@@ -76,7 +76,7 @@ def _test_preprocessing_defences_forward(
 
 # A generic test for various preprocessing_defences, backward pass.
 def _test_preprocessing_defences_backward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
 ):
     (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 

--- a/tests/classifiersFrameworks/test_tensorflow.py
+++ b/tests/classifiersFrameworks/test_tensorflow.py
@@ -108,35 +108,33 @@ def _test_preprocessing_defences_backward(
     np.testing.assert_array_almost_equal(gradients_in_chain, gradients, decimal=4)
 
 
-@pytest.mark.only_with_platform("tensorflow")
-def test_nodefence(art_warning, get_default_mnist_subset, image_dl_estimator, is_tf_version_2):
+@pytest.mark.only_with_platform("tensorflow2")
+def test_nodefence(art_warning, get_default_mnist_subset, image_dl_estimator):
     try:
-        if is_tf_version_2:
-            preprocessing_defences = []
-            device_type = None
-            _test_preprocessing_defences_forward(
-                get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-            )
-            _test_preprocessing_defences_backward(
-                get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-            )
+        preprocessing_defences = []
+        device_type = None
+        _test_preprocessing_defences_forward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
+        _test_preprocessing_defences_backward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
     except ARTTestException as e:
         art_warning(e)
 
 
-@pytest.mark.only_with_platform("tensorflow")
-def test_defence_tensorflow(art_warning, get_default_mnist_subset, image_dl_estimator, is_tf_version_2):
+@pytest.mark.only_with_platform("tensorflow2")
+def test_defence_tensorflow(art_warning, get_default_mnist_subset, image_dl_estimator):
     try:
-        if is_tf_version_2:
-            smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
-            preprocessing_defences = [smooth_3x3]
-            device_type = None
-            _test_preprocessing_defences_forward(
-                get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-            )
-            _test_preprocessing_defences_backward(
-                get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-            )
+        smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
+        preprocessing_defences = [smooth_3x3]
+        device_type = None
+        _test_preprocessing_defences_forward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
+        _test_preprocessing_defences_backward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
     except ARTTestException as e:
         art_warning(e)
 

--- a/tests/classifiersFrameworks/test_tensorflow.py
+++ b/tests/classifiersFrameworks/test_tensorflow.py
@@ -192,28 +192,27 @@ def test_defences_chaining(art_warning, get_default_mnist_subset, image_dl_estim
         art_warning(e)
 
 
-@pytest.mark.only_with_platform("tensorflow")
-def test_fgsm_defences(art_warning, fix_get_mnist_subset, image_dl_estimator, is_tf_version_2):
+@pytest.mark.only_with_platform("tensorflow2")
+def test_fgsm_defences(art_warning, fix_get_mnist_subset, image_dl_estimator):
     try:
-        if is_tf_version_2:
-            clip_values = (0, 1)
-            smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
-            smooth_5x5 = SpatialSmoothingTensorFlowV2(window_size=5, channels_first=False)
-            smooth_7x7 = SpatialSmoothingTensorFlowV2(window_size=7, channels_first=False)
-            classifier_, _ = image_dl_estimator()
+        clip_values = (0, 1)
+        smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
+        smooth_5x5 = SpatialSmoothingTensorFlowV2(window_size=5, channels_first=False)
+        smooth_7x7 = SpatialSmoothingTensorFlowV2(window_size=7, channels_first=False)
+        classifier_, _ = image_dl_estimator()
 
-            loss_object = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
-            classifier = TensorFlowV2Classifier(
-                clip_values=clip_values,
-                model=classifier_.model,
-                preprocessing_defences=[smooth_3x3, smooth_5x5, smooth_7x7],
-                loss_object=loss_object,
-                input_shape=(28, 28, 1),
-                nb_classes=10,
-            )
-            assert len(classifier.preprocessing_defences) == 3
+        loss_object = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
+        classifier = TensorFlowV2Classifier(
+            clip_values=clip_values,
+            model=classifier_.model,
+            preprocessing_defences=[smooth_3x3, smooth_5x5, smooth_7x7],
+            loss_object=loss_object,
+            input_shape=(28, 28, 1),
+            nb_classes=10,
+        )
+        assert len(classifier.preprocessing_defences) == 3
 
-            attack = FastGradientMethod(classifier, eps=1, batch_size=128)
-            backend_test_defended_images(attack, fix_get_mnist_subset)
+        attack = FastGradientMethod(classifier, eps=1, batch_size=128)
+        backend_test_defended_images(attack, fix_get_mnist_subset)
     except ARTTestException as e:
         art_warning(e)

--- a/tests/classifiersFrameworks/test_tensorflow.py
+++ b/tests/classifiersFrameworks/test_tensorflow.py
@@ -139,58 +139,55 @@ def test_defence_tensorflow(art_warning, get_default_mnist_subset, image_dl_esti
         art_warning(e)
 
 
-@pytest.mark.only_with_platform("tensorflow")
-def test_defence_non_tensorflow(art_warning, get_default_mnist_subset, image_dl_estimator, is_tf_version_2):
+@pytest.mark.only_with_platform("tensorflow2")
+def test_defence_non_tensorflow(art_warning, get_default_mnist_subset, image_dl_estimator):
     try:
-        if is_tf_version_2:
-            smooth_3x3 = SpatialSmoothing(window_size=3, channels_first=False)
-            preprocessing_defences = [smooth_3x3]
-            device_type = None
-            _test_preprocessing_defences_forward(
-                get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-            )
-            _test_preprocessing_defences_backward(
-                get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-            )
+        smooth_3x3 = SpatialSmoothing(window_size=3, channels_first=False)
+        preprocessing_defences = [smooth_3x3]
+        device_type = None
+        _test_preprocessing_defences_forward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
+        _test_preprocessing_defences_backward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
     except ARTTestException as e:
         art_warning(e)
 
 
 @pytest.mark.xfail(reason="Preprocessing-defence chaining only supports defences implemented in TensorFlow v2.")
-@pytest.mark.only_with_platform("tensorflow")
+@pytest.mark.only_with_platform("tensorflow2")
 def test_defences_tensorflow_and_nontensorflow(art_warning, get_default_mnist_subset, image_dl_estimator,
-                                               device_type, is_tf_version_2):
+                                               device_type):
     try:
-        if is_tf_version_2:
-            smooth_3x3_nonpth = SpatialSmoothing(window_size=3, channels_first=False)
-            smooth_3x3_pth = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
-            preprocessing_defences = [smooth_3x3_nonpth, smooth_3x3_pth]
-            device_type = None
-            _test_preprocessing_defences_forward(
-                get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-            )
-            _test_preprocessing_defences_backward(
-                get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-            )
+        smooth_3x3_nonpth = SpatialSmoothing(window_size=3, channels_first=False)
+        smooth_3x3_pth = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
+        preprocessing_defences = [smooth_3x3_nonpth, smooth_3x3_pth]
+        device_type = None
+        _test_preprocessing_defences_forward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
+        _test_preprocessing_defences_backward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
     except ARTTestException as e:
         art_warning(e)
 
 
-@pytest.mark.only_with_platform("tensorflow")
-def test_defences_chaining(art_warning, get_default_mnist_subset, image_dl_estimator, is_tf_version_2):
+@pytest.mark.only_with_platform("tensorflow2")
+def test_defences_chaining(art_warning, get_default_mnist_subset, image_dl_estimator):
     try:
-        if is_tf_version_2:
-            smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
-            smooth_5x5 = SpatialSmoothingTensorFlowV2(window_size=5, channels_first=False)
-            smooth_7x7 = SpatialSmoothingTensorFlowV2(window_size=7, channels_first=False)
-            preprocessing_defences = [smooth_3x3, smooth_5x5, smooth_7x7]
-            device_type = None
-            _test_preprocessing_defences_forward(
-                get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-            )
-            _test_preprocessing_defences_backward(
-                get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
-            )
+        smooth_3x3 = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)
+        smooth_5x5 = SpatialSmoothingTensorFlowV2(window_size=5, channels_first=False)
+        smooth_7x7 = SpatialSmoothingTensorFlowV2(window_size=7, channels_first=False)
+        preprocessing_defences = [smooth_3x3, smooth_5x5, smooth_7x7]
+        device_type = None
+        _test_preprocessing_defences_forward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
+        _test_preprocessing_defences_backward(
+            get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+        )
     except ARTTestException as e:
         art_warning(e)
 

--- a/tests/classifiersFrameworks/test_tensorflow.py
+++ b/tests/classifiersFrameworks/test_tensorflow.py
@@ -39,7 +39,7 @@ def fix_get_mnist_subset(get_mnist_dataset):
 
 # A generic test for various preprocessing_defences, forward pass.
 def _test_preprocessing_defences_forward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
 ):
     (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 
@@ -73,7 +73,7 @@ def _test_preprocessing_defences_forward(
 
 # A generic test for various preprocessing_defences, backward pass.
 def _test_preprocessing_defences_backward(
-        get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
+    get_default_mnist_subset, image_dl_estimator, device_type, preprocessing_defences
 ):
     (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 
@@ -157,8 +157,7 @@ def test_defence_non_tensorflow(art_warning, get_default_mnist_subset, image_dl_
 
 @pytest.mark.xfail(reason="Preprocessing-defence chaining only supports defences implemented in TensorFlow v2.")
 @pytest.mark.only_with_platform("tensorflow2")
-def test_defences_tensorflow_and_nontensorflow(art_warning, get_default_mnist_subset, image_dl_estimator,
-                                               device_type):
+def test_defences_tensorflow_and_nontensorflow(art_warning, get_default_mnist_subset, image_dl_estimator, device_type):
     try:
         smooth_3x3_nonpth = SpatialSmoothing(window_size=3, channels_first=False)
         smooth_3x3_pth = SpatialSmoothingTensorFlowV2(window_size=3, channels_first=False)

--- a/tests/defences/preprocessor/conftest.py
+++ b/tests/defences/preprocessor/conftest.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def image_batch(channels_first):
+    """
+    Image fixture of shape NHWC and NCHW.
+    """
+    test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((2, 3, 4, 6))
+    if not channels_first:
+        test_input = np.transpose(test_input, (0, 2, 3, 1))
+    test_output = test_input.copy()
+    return test_input, test_output
+
+
+@pytest.fixture
+def video_batch(channels_first):
+    """
+    Video fixture of shape NFHWC and NCFHW.
+    """
+    test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((1, 3, 2, 4, 6))
+    if not channels_first:
+        test_input = np.transpose(test_input, (0, 2, 3, 4, 1))
+    test_output = test_input.copy()
+    return test_input, test_output
+
+
+@pytest.fixture
+def tabular_batch():
+    """
+    Create tabular data fixture of shape (batch_size, features).
+    """
+    return np.zeros((2, 4))

--- a/tests/defences/preprocessor/conftest.py
+++ b/tests/defences/preprocessor/conftest.py
@@ -19,6 +19,7 @@ def image_batch_small():
     """Create image fixture of shape (batch_size, channels, width, height)."""
     return np.zeros((2, 1, 4, 4))
 
+
 @pytest.fixture
 def video_batch(channels_first):
     """

--- a/tests/defences/preprocessor/conftest.py
+++ b/tests/defences/preprocessor/conftest.py
@@ -15,6 +15,11 @@ def image_batch(channels_first):
 
 
 @pytest.fixture
+def image_batch_small():
+    """Create image fixture of shape (batch_size, channels, width, height)."""
+    return np.zeros((2, 1, 4, 4))
+
+@pytest.fixture
 def video_batch(channels_first):
     """
     Video fixture of shape NFHWC and NCFHW.

--- a/tests/defences/preprocessor/test_jpeg_compression.py
+++ b/tests/defences/preprocessor/test_jpeg_compression.py
@@ -74,12 +74,6 @@ def video_batch(request, channels_first):
     return test_input, test_output
 
 
-@pytest.fixture
-def tabular_batch():
-    """Create tabular data fixture of shape (batch_size, features)."""
-    return np.zeros((2, 4))
-
-
 @pytest.mark.framework_agnostic
 @pytest.mark.parametrize("channels_first", [True, False])
 def test_jpeg_compression_image_data(art_warning, image_batch, channels_first, framework):

--- a/tests/defences/preprocessor/test_mp3_compression.py
+++ b/tests/defences/preprocessor/test_mp3_compression.py
@@ -60,12 +60,6 @@ def audio_batch(request, channels_first):
     return test_input, test_output, audio_input.sample_rate
 
 
-@pytest.fixture
-def image_batch():
-    """Create image fixture of shape (batch_size, channels, width, height)."""
-    return np.zeros((2, 1, 4, 4))
-
-
 def test_sample_rate_error(art_warning):
     try:
         exc_msg = "Sample rate be must a positive integer."
@@ -75,9 +69,9 @@ def test_sample_rate_error(art_warning):
         art_warning(e)
 
 
-def test_non_temporal_data_error(art_warning, image_batch):
+def test_non_temporal_data_error(art_warning, image_batch_small):
     try:
-        test_input = image_batch
+        test_input = image_batch_small
         mp3compression = Mp3Compression(sample_rate=16000)
 
         exc_msg = "Mp3 compression can only be applied to temporal data across at least one channel."

--- a/tests/defences/preprocessor/test_resample.py
+++ b/tests/defences/preprocessor/test_resample.py
@@ -39,12 +39,6 @@ def audio_batch(request):
     return test_input, test_output, sample_rate_orig, sample_rate_new
 
 
-@pytest.fixture
-def image_batch():
-    """Create image fixture of shape (batch_size, channels, width, height)."""
-    return np.zeros((2, 1, 4, 4))
-
-
 @pytest.mark.framework_agnostic
 def test_sample_rate_original_error(art_warning):
     try:
@@ -66,9 +60,9 @@ def test_sample_rate_new_error(art_warning):
 
 
 @pytest.mark.framework_agnostic
-def test_non_temporal_data_error(art_warning, image_batch):
+def test_non_temporal_data_error(art_warning, image_batch_small):
     try:
-        test_input = image_batch
+        test_input = image_batch_small
         resample = Resample(16000, 16000)
 
         exc_msg = "Resampling can only be applied to temporal data across at least one channel."

--- a/tests/defences/preprocessor/test_spatial_smoothing.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing.py
@@ -29,36 +29,36 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
-def image_batch(channels_first):
-    """
-    Image fixture of shape NHWC and NCHW.
-    """
-    test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((2, 3, 4, 6))
-    if not channels_first:
-        test_input = np.transpose(test_input, (0, 2, 3, 1))
-    test_output = test_input.copy()
-    return test_input, test_output
-
-
-@pytest.fixture
-def video_batch(channels_first):
-    """
-    Video fixture of shape NFHWC and NCFHW.
-    """
-    test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((1, 3, 2, 4, 6))
-    if not channels_first:
-        test_input = np.transpose(test_input, (0, 2, 3, 4, 1))
-    test_output = test_input.copy()
-    return test_input, test_output
-
-
-@pytest.fixture
-def tabular_batch():
-    """
-    Create tabular data fixture of shape (batch_size, features).
-    """
-    return np.zeros((2, 4))
+# @pytest.fixture
+# def image_batch(channels_first):
+#     """
+#     Image fixture of shape NHWC and NCHW.
+#     """
+#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((2, 3, 4, 6))
+#     if not channels_first:
+#         test_input = np.transpose(test_input, (0, 2, 3, 1))
+#     test_output = test_input.copy()
+#     return test_input, test_output
+#
+#
+# @pytest.fixture
+# def video_batch(channels_first):
+#     """
+#     Video fixture of shape NFHWC and NCFHW.
+#     """
+#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((1, 3, 2, 4, 6))
+#     if not channels_first:
+#         test_input = np.transpose(test_input, (0, 2, 3, 4, 1))
+#     test_output = test_input.copy()
+#     return test_input, test_output
+#
+#
+# @pytest.fixture
+# def tabular_batch():
+#     """
+#     Create tabular data fixture of shape (batch_size, features).
+#     """
+#     return np.zeros((2, 4))
 
 
 @pytest.mark.framework_agnostic

--- a/tests/defences/preprocessor/test_spatial_smoothing.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing.py
@@ -29,38 +29,6 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-# @pytest.fixture
-# def image_batch(channels_first):
-#     """
-#     Image fixture of shape NHWC and NCHW.
-#     """
-#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((2, 3, 4, 6))
-#     if not channels_first:
-#         test_input = np.transpose(test_input, (0, 2, 3, 1))
-#     test_output = test_input.copy()
-#     return test_input, test_output
-#
-#
-# @pytest.fixture
-# def video_batch(channels_first):
-#     """
-#     Video fixture of shape NFHWC and NCFHW.
-#     """
-#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((1, 3, 2, 4, 6))
-#     if not channels_first:
-#         test_input = np.transpose(test_input, (0, 2, 3, 4, 1))
-#     test_output = test_input.copy()
-#     return test_input, test_output
-#
-#
-# @pytest.fixture
-# def tabular_batch():
-#     """
-#     Create tabular data fixture of shape (batch_size, features).
-#     """
-#     return np.zeros((2, 4))
-
-
 @pytest.mark.framework_agnostic
 def test_spatial_smoothing_median_filter_call(art_warning):
     try:

--- a/tests/defences/preprocessor/test_spatial_smoothing_pytorch.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_pytorch.py
@@ -101,7 +101,7 @@ def test_spatial_smoothing_median_filter_call_expected_behavior(art_warning):
             10,
             marks=pytest.mark.xfail(
                 reason="Window size of 10 fails, because PyTorch requires that Padding size should be less than "
-                       "the corresponding input dimension."
+                "the corresponding input dimension."
             ),
         ),
     ],

--- a/tests/defences/preprocessor/test_spatial_smoothing_pytorch.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_pytorch.py
@@ -29,39 +29,6 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-# # TODO these fixtures are duplicates from test_spatial_smoothing needs refactoring
-# @pytest.fixture
-# def image_batch(channels_first):
-#     """
-#     Image fixture of shape NHWC and NCHW.
-#     """
-#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((2, 3, 4, 6))
-#     if not channels_first:
-#         test_input = np.transpose(test_input, (0, 2, 3, 1))
-#     test_output = test_input.copy()
-#     return test_input, test_output
-#
-#
-# @pytest.fixture
-# def video_batch(channels_first):
-#     """
-#     Video fixture of shape NFHWC and NCFHW.
-#     """
-#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((1, 3, 2, 4, 6))
-#     if not channels_first:
-#         test_input = np.transpose(test_input, (0, 2, 3, 4, 1))
-#     test_output = test_input.copy()
-#     return test_input, test_output
-#
-#
-# @pytest.fixture
-# def tabular_batch():
-#     """
-#     Create tabular data fixture of shape (batch_size, features).
-#     """
-#     return np.zeros((2, 4))
-
-
 @pytest.mark.xfail(
     reason="""a) SciPy's "reflect" padding mode is not supported in PyTorch. The "reflect" model in PyTorch maps
     to the "mirror" mode in SciPy; b) torch.median() takes the smaller value when the window size is even."""

--- a/tests/defences/preprocessor/test_spatial_smoothing_pytorch.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_pytorch.py
@@ -29,37 +29,37 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-# TODO these fixtures are duplicates from test_spatial_smoothing needs refactoring
-@pytest.fixture
-def image_batch(channels_first):
-    """
-    Image fixture of shape NHWC and NCHW.
-    """
-    test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((2, 3, 4, 6))
-    if not channels_first:
-        test_input = np.transpose(test_input, (0, 2, 3, 1))
-    test_output = test_input.copy()
-    return test_input, test_output
-
-
-@pytest.fixture
-def video_batch(channels_first):
-    """
-    Video fixture of shape NFHWC and NCFHW.
-    """
-    test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((1, 3, 2, 4, 6))
-    if not channels_first:
-        test_input = np.transpose(test_input, (0, 2, 3, 4, 1))
-    test_output = test_input.copy()
-    return test_input, test_output
-
-
-@pytest.fixture
-def tabular_batch():
-    """
-    Create tabular data fixture of shape (batch_size, features).
-    """
-    return np.zeros((2, 4))
+# # TODO these fixtures are duplicates from test_spatial_smoothing needs refactoring
+# @pytest.fixture
+# def image_batch(channels_first):
+#     """
+#     Image fixture of shape NHWC and NCHW.
+#     """
+#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((2, 3, 4, 6))
+#     if not channels_first:
+#         test_input = np.transpose(test_input, (0, 2, 3, 1))
+#     test_output = test_input.copy()
+#     return test_input, test_output
+#
+#
+# @pytest.fixture
+# def video_batch(channels_first):
+#     """
+#     Video fixture of shape NFHWC and NCFHW.
+#     """
+#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((1, 3, 2, 4, 6))
+#     if not channels_first:
+#         test_input = np.transpose(test_input, (0, 2, 3, 4, 1))
+#     test_output = test_input.copy()
+#     return test_input, test_output
+#
+#
+# @pytest.fixture
+# def tabular_batch():
+#     """
+#     Create tabular data fixture of shape (batch_size, features).
+#     """
+#     return np.zeros((2, 4))
 
 
 @pytest.mark.xfail(

--- a/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
@@ -75,16 +75,15 @@ def test_spatial_smoothing_median_filter_call(art_warning):
         art_warning(e)
 
 
-@pytest.mark.only_with_platform("tensorflow")
-def test_spatial_smoothing_median_filter_call_expected_behavior(art_warning, is_tf_version_2):
+@pytest.mark.only_with_platform("tensorflow2")
+def test_spatial_smoothing_median_filter_call_expected_behavior(art_warning):
     try:
-        if is_tf_version_2:
-            test_input = np.array([[[[1], [2]], [[3], [4]]]])
-            test_output = np.array([[[[2], [2]], [[2], [2]]]])
-            print(test_input.shape)
-            spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=False, window_size=2)
+        test_input = np.array([[[[1], [2]], [[3], [4]]]])
+        test_output = np.array([[[[2], [2]], [[2], [2]]]])
+        print(test_input.shape)
+        spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=False, window_size=2)
 
-            assert_array_equal(spatial_smoothing(test_input)[0], test_output)
+        assert_array_equal(spatial_smoothing(test_input)[0], test_output)
     except ARTTestException as e:
         art_warning(e)
 

--- a/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
@@ -160,13 +160,12 @@ def test_window_size_error(art_warning):
         art_warning(e)
 
 
-@pytest.mark.only_with_platform("tensorflow")
-def test_triple_clip_values_error(art_warning, is_tf_version_2):
+@pytest.mark.only_with_platform("tensorflow2")
+def test_triple_clip_values_error(art_warning):
     try:
-        if is_tf_version_2:
-            exc_msg = "'clip_values' should be a tuple of 2 floats or arrays containing the allowed data range."
-            with pytest.raises(ValueError, match=exc_msg):
-                SpatialSmoothingTensorFlowV2(clip_values=(0, 1, 2))
+        exc_msg = "'clip_values' should be a tuple of 2 floats or arrays containing the allowed data range."
+        with pytest.raises(ValueError, match=exc_msg):
+            SpatialSmoothingTensorFlowV2(clip_values=(0, 1, 2))
     except ARTTestException as e:
         art_warning(e)
 

--- a/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
@@ -29,37 +29,37 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-# TODO these fixtures are duplicates from test_spatial_smoothing needs refactoring
-@pytest.fixture
-def image_batch(channels_first):
-    """
-    Image fixture of shape NHWC and NCHW.
-    """
-    test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((2, 3, 4, 6))
-    if not channels_first:
-        test_input = np.transpose(test_input, (0, 2, 3, 1))
-    test_output = test_input.copy()
-    return test_input, test_output
-
-
-@pytest.fixture
-def video_batch(channels_first):
-    """
-    Video fixture of shape NFHWC and NCFHW.
-    """
-    test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((1, 3, 2, 4, 6))
-    if not channels_first:
-        test_input = np.transpose(test_input, (0, 2, 3, 4, 1))
-    test_output = test_input.copy()
-    return test_input, test_output
-
-
-@pytest.fixture
-def tabular_batch():
-    """
-    Create tabular data fixture of shape (batch_size, features).
-    """
-    return np.zeros((2, 4))
+# # TODO these fixtures are duplicates from test_spatial_smoothing needs refactoring
+# @pytest.fixture
+# def image_batch(channels_first):
+#     """
+#     Image fixture of shape NHWC and NCHW.
+#     """
+#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((2, 3, 4, 6))
+#     if not channels_first:
+#         test_input = np.transpose(test_input, (0, 2, 3, 1))
+#     test_output = test_input.copy()
+#     return test_input, test_output
+#
+#
+# @pytest.fixture
+# def video_batch(channels_first):
+#     """
+#     Video fixture of shape NFHWC and NCFHW.
+#     """
+#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((1, 3, 2, 4, 6))
+#     if not channels_first:
+#         test_input = np.transpose(test_input, (0, 2, 3, 4, 1))
+#     test_output = test_input.copy()
+#     return test_input, test_output
+#
+#
+# @pytest.fixture
+# def tabular_batch():
+#     """
+#     Create tabular data fixture of shape (batch_size, features).
+#     """
+#     return np.zeros((2, 4))
 
 
 @pytest.mark.xfail()

--- a/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
@@ -170,12 +170,11 @@ def test_triple_clip_values_error(art_warning):
         art_warning(e)
 
 
-@pytest.mark.only_with_platform("tensorflow")
-def test_relation_clip_values_error(art_warning, is_tf_version_2):
+@pytest.mark.only_with_platform("tensorflow2")
+def test_relation_clip_values_error(art_warning):
     try:
-        if is_tf_version_2:
-            exc_msg = "Invalid 'clip_values': min >= max."
-            with pytest.raises(ValueError, match=exc_msg):
-                SpatialSmoothingTensorFlowV2(clip_values=(1, 0))
+        exc_msg = "Invalid 'clip_values': min >= max."
+        with pytest.raises(ValueError, match=exc_msg):
+            SpatialSmoothingTensorFlowV2(clip_values=(1, 0))
     except ARTTestException as e:
         art_warning(e)

--- a/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
@@ -103,52 +103,49 @@ def test_spatial_smoothing_median_filter_call_expected_behavior(art_warning):
         ),
     ],
 )
-@pytest.mark.only_with_platform("tensorflow")
-def test_spatial_smoothing_image_data(art_warning, image_batch, channels_first, window_size, is_tf_version_2):
+@pytest.mark.only_with_platform("tensorflow2")
+def test_spatial_smoothing_image_data(art_warning, image_batch, channels_first, window_size):
     try:
-        if is_tf_version_2:
-            test_input, test_output = image_batch
+        test_input, test_output = image_batch
 
-            if channels_first:
-                exc_msg = "Only channels last input data is supported"
-                with pytest.raises(ValueError, match=exc_msg):
-                    _ = SpatialSmoothingTensorFlowV2(channels_first=channels_first, window_size=window_size)
-            else:
-                spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=channels_first,
-                                                                 window_size=window_size)
-                assert_array_equal(spatial_smoothing(test_input)[0], test_output)
-    except ARTTestException as e:
-        art_warning(e)
-
-
-@pytest.mark.only_with_platform("tensorflow")
-@pytest.mark.parametrize("channels_first", [True, False])
-def test_spatial_smoothing_video_data(art_warning, video_batch, channels_first, is_tf_version_2):
-    try:
-        if is_tf_version_2:
-            test_input, test_output = video_batch
-
-            if channels_first:
-                exc_msg = "Only channels last input data is supported"
-                with pytest.raises(ValueError, match=exc_msg):
-                    _ = SpatialSmoothingTensorFlowV2(channels_first=channels_first, window_size=2)
-            else:
-                spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=channels_first, window_size=2)
-                assert_array_equal(spatial_smoothing(test_input)[0], test_output)
-    except ARTTestException as e:
-        art_warning(e)
-
-
-@pytest.mark.only_with_platform("tensorflow")
-def test_non_spatial_data_error(art_warning, tabular_batch, is_tf_version_2):
-    try:
-        if is_tf_version_2:
-            test_input = tabular_batch
-            spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=False)
-
-            exc_msg = "Unrecognized input dimension. Spatial smoothing can only be applied to image"
+        if channels_first:
+            exc_msg = "Only channels last input data is supported"
             with pytest.raises(ValueError, match=exc_msg):
-                spatial_smoothing(test_input)
+                _ = SpatialSmoothingTensorFlowV2(channels_first=channels_first, window_size=window_size)
+        else:
+            spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=channels_first,
+                                                             window_size=window_size)
+            assert_array_equal(spatial_smoothing(test_input)[0], test_output)
+    except ARTTestException as e:
+        art_warning(e)
+
+
+@pytest.mark.only_with_platform("tensorflow2")
+@pytest.mark.parametrize("channels_first", [True, False])
+def test_spatial_smoothing_video_data(art_warning, video_batch, channels_first):
+    try:
+        test_input, test_output = video_batch
+
+        if channels_first:
+            exc_msg = "Only channels last input data is supported"
+            with pytest.raises(ValueError, match=exc_msg):
+                _ = SpatialSmoothingTensorFlowV2(channels_first=channels_first, window_size=2)
+        else:
+            spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=channels_first, window_size=2)
+            assert_array_equal(spatial_smoothing(test_input)[0], test_output)
+    except ARTTestException as e:
+        art_warning(e)
+
+
+@pytest.mark.only_with_platform("tensorflow")
+def test_non_spatial_data_error(art_warning, tabular_batch):
+    try:
+        test_input = tabular_batch
+        spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=False)
+
+        exc_msg = "Unrecognized input dimension. Spatial smoothing can only be applied to image"
+        with pytest.raises(ValueError, match=exc_msg):
+            spatial_smoothing(test_input)
     except ARTTestException as e:
         art_warning(e)
 

--- a/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
@@ -63,15 +63,14 @@ def tabular_batch():
 
 
 @pytest.mark.xfail()
-@pytest.mark.only_with_platform("tensorflow")
-def test_spatial_smoothing_median_filter_call(art_warning, is_tf_version_2):
+@pytest.mark.only_with_platform("tensorflow2")
+def test_spatial_smoothing_median_filter_call(art_warning):
     try:
-        if is_tf_version_2:
-            test_input = np.array([[[[1], [2]], [[3], [4]]]])
-            test_output = np.array([[[[1], [2]], [[3], [3]]]])
-            spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=False, window_size=2)
+        test_input = np.array([[[[1], [2]], [[3], [4]]]])
+        test_output = np.array([[[[1], [2]], [[3], [3]]]])
+        spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=False, window_size=2)
 
-            assert_array_equal(spatial_smoothing(test_input)[0], test_output)
+        assert_array_equal(spatial_smoothing(test_input)[0], test_output)
     except ARTTestException as e:
         art_warning(e)
 

--- a/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
@@ -29,39 +29,6 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-# # TODO these fixtures are duplicates from test_spatial_smoothing needs refactoring
-# @pytest.fixture
-# def image_batch(channels_first):
-#     """
-#     Image fixture of shape NHWC and NCHW.
-#     """
-#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((2, 3, 4, 6))
-#     if not channels_first:
-#         test_input = np.transpose(test_input, (0, 2, 3, 1))
-#     test_output = test_input.copy()
-#     return test_input, test_output
-#
-#
-# @pytest.fixture
-# def video_batch(channels_first):
-#     """
-#     Video fixture of shape NFHWC and NCFHW.
-#     """
-#     test_input = np.repeat(np.array(range(6)).reshape(6, 1), 24, axis=1).reshape((1, 3, 2, 4, 6))
-#     if not channels_first:
-#         test_input = np.transpose(test_input, (0, 2, 3, 4, 1))
-#     test_output = test_input.copy()
-#     return test_input, test_output
-#
-#
-# @pytest.fixture
-# def tabular_batch():
-#     """
-#     Create tabular data fixture of shape (batch_size, features).
-#     """
-#     return np.zeros((2, 4))
-
-
 @pytest.mark.xfail()
 @pytest.mark.only_with_platform("tensorflow2")
 def test_spatial_smoothing_median_filter_call(art_warning):

--- a/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
@@ -150,13 +150,12 @@ def test_non_spatial_data_error(art_warning, tabular_batch):
         art_warning(e)
 
 
-@pytest.mark.only_with_platform("tensorflow")
-def test_window_size_error(art_warning, is_tf_version_2):
+@pytest.mark.only_with_platform("tensorflow2")
+def test_window_size_error(art_warning):
     try:
-        if is_tf_version_2:
-            exc_msg = "Sliding window size must be a positive integer."
-            with pytest.raises(ValueError, match=exc_msg):
-                SpatialSmoothingTensorFlowV2(window_size=0)
+        exc_msg = "Sliding window size must be a positive integer."
+        with pytest.raises(ValueError, match=exc_msg):
+            SpatialSmoothingTensorFlowV2(window_size=0)
     except ARTTestException as e:
         art_warning(e)
 

--- a/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
@@ -98,7 +98,7 @@ def test_spatial_smoothing_median_filter_call_expected_behavior(art_warning):
             10,
             marks=pytest.mark.xfail(
                 reason="Window size of 10 fails, because TensorFlow requires that Padding size should be less than "
-                       "the corresponding input dimension."
+                "the corresponding input dimension."
             ),
         ),
     ],
@@ -113,8 +113,7 @@ def test_spatial_smoothing_image_data(art_warning, image_batch, channels_first, 
             with pytest.raises(ValueError, match=exc_msg):
                 _ = SpatialSmoothingTensorFlowV2(channels_first=channels_first, window_size=window_size)
         else:
-            spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=channels_first,
-                                                             window_size=window_size)
+            spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=channels_first, window_size=window_size)
             assert_array_equal(spatial_smoothing(test_input)[0], test_output)
     except ARTTestException as e:
         art_warning(e)

--- a/tests/defences/preprocessor/test_video_compression.py
+++ b/tests/defences/preprocessor/test_video_compression.py
@@ -42,12 +42,6 @@ def video_batch(channels_first):
     return test_input, test_output
 
 
-@pytest.fixture
-def image_batch():
-    """Create image fixture of shape (batch_size, channels, width, height)."""
-    return np.zeros((2, 1, 4, 4))
-
-
 @pytest.mark.parametrize("channels_first", [True, False])
 @pytest.mark.skipMlFramework("keras", "pytorch", "scikitlearn")
 def test_video_compresssion(art_warning, video_batch, channels_first):
@@ -81,9 +75,9 @@ def test_constant_rate_factor_error(art_warning, constant_rate_factor):
         art_warning(e)
 
 
-def test_non_spatio_temporal_data_error(art_warning, image_batch):
+def test_non_spatio_temporal_data_error(art_warning, image_batch_small):
     try:
-        test_input = image_batch
+        test_input = image_batch_small
         video_compression = VideoCompression(video_format="")
 
         exc_msg = "Video compression can only be applied to spatio-temporal data."

--- a/tests/estimators/classification/test_deeplearning_common.py
+++ b/tests/estimators/classification/test_deeplearning_common.py
@@ -22,17 +22,12 @@ def is_keras_2_3():
     return False
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
-def test_layers(art_warning, get_default_mnist_subset, framework, is_tf_version_2, image_dl_estimator):
+@pytest.mark.skipMlFramework("non_dl_frameworks", "tensorflow2")
+def test_layers(art_warning, get_default_mnist_subset, framework, image_dl_estimator):
     try:
         classifier, _ = image_dl_estimator(from_logits=True)
 
         (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
-
-        if framework == "tensorflow" and is_tf_version_2:
-            raise ARTTestFixtureNotImplemented(
-                "fw_agnostic_backend_test_layers not implemented", test_layers.__name__, framework
-            )
 
         batch_size = 128
         for i, name in enumerate(classifier.layer_names):

--- a/tests/estimators/classification/test_deeplearning_common.py
+++ b/tests/estimators/classification/test_deeplearning_common.py
@@ -16,12 +16,6 @@ from tests.utils import ARTTestException, ARTTestFixtureNotImplemented
 logger = logging.getLogger(__name__)
 
 
-def is_keras_2_3():
-    if int(keras.__version__.split(".")[0]) == 2 and int(keras.__version__.split(".")[1]) >= 3:
-        return True
-    return False
-
-
 @pytest.mark.skipMlFramework("non_dl_frameworks", "tensorflow2")
 def test_layers(art_warning, get_default_mnist_subset, framework, image_dl_estimator):
     try:
@@ -76,13 +70,10 @@ def test_fit(art_warning, get_default_mnist_subset, default_batch_size, image_dl
 
 
 @pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skipif(keras.__version__.startswith("2.2"), reason="requires Keras 2.3.0 or higher")
 def test_predict(art_warning, framework, get_default_mnist_subset, image_dl_estimator,
                  expected_values, store_expected_values):
     try:
-        if framework == "keras" and is_keras_2_3() is False:
-            # Keras 2.2 does not support creating classifiers with logits=True so skipping this test
-            return
-
         (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 
         classifier, _ = image_dl_estimator(from_logits=True)
@@ -283,6 +274,7 @@ def test_fit_image_generator(art_warning, framework, image_dl_estimator,
 
 
 @pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skipif(keras.__version__.startswith("2.2"), reason="requires Keras 2.3.0 or higher")
 def test_loss_gradient(art_warning,
                        framework,
                        get_default_mnist_subset,
@@ -292,10 +284,6 @@ def test_loss_gradient(art_warning,
                        store_expected_values,
                        ):
     try:
-        if framework == "keras" and is_keras_2_3() is False:
-            # Keras 2.2 does not support creating classifiers with logits=True so skipping this test d
-            return
-
         (expected_gradients_1, expected_gradients_2) = expected_values()
 
         (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
@@ -396,13 +384,10 @@ def test_save(art_warning, image_dl_estimator, get_default_mnist_subset, tmp_pat
 
 
 @pytest.mark.skipMlFramework("mxnet", "non_dl_frameworks")
+@pytest.mark.skipif(keras.__version__.startswith("2.2"), reason="requires Keras 2.3.0 or higher")
 def test_class_gradient(art_warning, framework, image_dl_estimator, get_default_mnist_subset, mnist_shape,
                         store_expected_values, expected_values):
     try:
-        if framework == "keras" and is_keras_2_3() is False:
-            # Keras 2.2 does not support creating classifiers with logits=True so skipping this test
-            return
-
         (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 
         classifier, _ = image_dl_estimator(from_logits=True)

--- a/tests/estimators/classification/test_deeplearning_common.py
+++ b/tests/estimators/classification/test_deeplearning_common.py
@@ -285,7 +285,6 @@ def test_fit_image_generator(art_warning, framework, image_dl_estimator,
 @pytest.mark.skipMlFramework("non_dl_frameworks")
 def test_loss_gradient(art_warning,
                        framework,
-                       is_tf_version_2,
                        get_default_mnist_subset,
                        image_dl_estimator,
                        expected_values,

--- a/tests/estimators/classification/test_deeplearning_common.py
+++ b/tests/estimators/classification/test_deeplearning_common.py
@@ -256,13 +256,10 @@ def test_defences_predict(art_warning, get_default_mnist_subset, image_dl_estima
 
 # Note: because mxnet only supports 1 concurrent version of a model if we fit that model, all expected values will
 # change for all other tests using that fitted model
-@pytest.mark.skipMlFramework("mxnet", "non_dl_frameworks")
-def test_fit_image_generator(art_warning, framework, is_tf_version_2, image_dl_estimator,
+@pytest.mark.skipMlFramework("mxnet", "non_dl_frameworks", "tensorflow2")
+def test_fit_image_generator(art_warning, framework, image_dl_estimator,
                              image_data_generator, get_default_mnist_subset):
     try:
-        if framework == "tensorflow" and is_tf_version_2:
-            return
-
         classifier, sess = image_dl_estimator(from_logits=True)
         (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 

--- a/tests/estimators/classification/test_deeplearning_common.py
+++ b/tests/estimators/classification/test_deeplearning_common.py
@@ -71,8 +71,9 @@ def test_fit(art_warning, get_default_mnist_subset, default_batch_size, image_dl
 
 @pytest.mark.skipMlFramework("non_dl_frameworks")
 @pytest.mark.skipif(keras.__version__.startswith("2.2"), reason="requires Keras 2.3.0 or higher")
-def test_predict(art_warning, framework, get_default_mnist_subset, image_dl_estimator,
-                 expected_values, store_expected_values):
+def test_predict(
+    art_warning, framework, get_default_mnist_subset, image_dl_estimator, expected_values, store_expected_values
+):
     try:
         (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 
@@ -113,16 +114,16 @@ def test_shapes(art_warning, get_default_mnist_subset, image_dl_estimator):
     ["categorical_crossentropy", "categorical_hinge", "sparse_categorical_crossentropy", "kullback_leibler_divergence"],
 )
 def test_loss_functions(
-        art_warning,
-        image_dl_estimator,
-        get_default_mnist_subset,
-        loss_name,
-        supported_losses_proba,
-        supported_losses_logit,
-        store_expected_values,
-        supported_losses_types,
-        from_logits,
-        expected_values,
+    art_warning,
+    image_dl_estimator,
+    get_default_mnist_subset,
+    loss_name,
+    supported_losses_proba,
+    supported_losses_logit,
+    store_expected_values,
+    supported_losses_types,
+    from_logits,
+    expected_values,
 ):
     # prediction and class_gradient should be independent of logits/probabilities and of loss function
 
@@ -248,8 +249,9 @@ def test_defences_predict(art_warning, get_default_mnist_subset, image_dl_estima
 # Note: because mxnet only supports 1 concurrent version of a model if we fit that model, all expected values will
 # change for all other tests using that fitted model
 @pytest.mark.skipMlFramework("mxnet", "non_dl_frameworks", "tensorflow2")
-def test_fit_image_generator(art_warning, framework, image_dl_estimator,
-                             image_data_generator, get_default_mnist_subset):
+def test_fit_image_generator(
+    art_warning, framework, image_dl_estimator, image_data_generator, get_default_mnist_subset
+):
     try:
         classifier, sess = image_dl_estimator(from_logits=True)
         (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
@@ -275,14 +277,15 @@ def test_fit_image_generator(art_warning, framework, image_dl_estimator,
 
 @pytest.mark.skipMlFramework("non_dl_frameworks")
 @pytest.mark.skipif(keras.__version__.startswith("2.2"), reason="requires Keras 2.3.0 or higher")
-def test_loss_gradient(art_warning,
-                       framework,
-                       get_default_mnist_subset,
-                       image_dl_estimator,
-                       expected_values,
-                       mnist_shape,
-                       store_expected_values,
-                       ):
+def test_loss_gradient(
+    art_warning,
+    framework,
+    get_default_mnist_subset,
+    image_dl_estimator,
+    expected_values,
+    mnist_shape,
+    store_expected_values,
+):
     try:
         (expected_gradients_1, expected_gradients_2) = expected_values()
 
@@ -385,8 +388,15 @@ def test_save(art_warning, image_dl_estimator, get_default_mnist_subset, tmp_pat
 
 @pytest.mark.skipMlFramework("mxnet", "non_dl_frameworks")
 @pytest.mark.skipif(keras.__version__.startswith("2.2"), reason="requires Keras 2.3.0 or higher")
-def test_class_gradient(art_warning, framework, image_dl_estimator, get_default_mnist_subset, mnist_shape,
-                        store_expected_values, expected_values):
+def test_class_gradient(
+    art_warning,
+    framework,
+    image_dl_estimator,
+    get_default_mnist_subset,
+    mnist_shape,
+    store_expected_values,
+    expected_values,
+):
     try:
         (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
 

--- a/tests/estimators/classification/test_deeplearning_specific.py
+++ b/tests/estimators/classification/test_deeplearning_specific.py
@@ -49,6 +49,7 @@ class Model(nn.Module):
 @pytest.mark.only_with_platform("pytorch")
 def test_device(art_warning):
     try:
+
         class Flatten(nn.Module):
             def forward(self, x):
                 n, _, _, _ = x.size()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -96,13 +96,13 @@ class TestBase(unittest.TestCase):
 
         # Check that the test data has not been modified, only catches changes in attack.generate if self has been used
         np.testing.assert_array_almost_equal(
-            self._x_train_mnist_original[0: self.n_train], self.x_train_mnist, decimal=3
+            self._x_train_mnist_original[0 : self.n_train], self.x_train_mnist, decimal=3
         )
         np.testing.assert_array_almost_equal(
-            self._y_train_mnist_original[0: self.n_train], self.y_train_mnist, decimal=3
+            self._y_train_mnist_original[0 : self.n_train], self.y_train_mnist, decimal=3
         )
-        np.testing.assert_array_almost_equal(self._x_test_mnist_original[0: self.n_test], self.x_test_mnist, decimal=3)
-        np.testing.assert_array_almost_equal(self._y_test_mnist_original[0: self.n_test], self.y_test_mnist, decimal=3)
+        np.testing.assert_array_almost_equal(self._x_test_mnist_original[0 : self.n_test], self.x_test_mnist, decimal=3)
+        np.testing.assert_array_almost_equal(self._y_test_mnist_original[0 : self.n_test], self.y_test_mnist, decimal=3)
 
         np.testing.assert_array_almost_equal(self._x_train_iris_original, self.x_train_iris, decimal=3)
         np.testing.assert_array_almost_equal(self._y_train_iris_original, self.y_train_iris, decimal=3)
@@ -400,7 +400,7 @@ def get_image_classifier_tf_v2(from_logits=False):
 
 
 def get_image_classifier_kr(
-        loss_name="categorical_crossentropy", loss_type="function_losses", from_logits=False, load_init=True
+    loss_name="categorical_crossentropy", loss_type="function_losses", from_logits=False, load_init=True
 ):
     """
     Standard Keras classifier for unit testing
@@ -979,7 +979,7 @@ def get_classifier_bb(defences=None):
     # define black-box classifier
     def predict(x):
         with open(
-                os.path.join(os.path.dirname(os.path.dirname(__file__)), "utils/data/mnist", "api_output.txt")
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), "utils/data/mnist", "api_output.txt")
         ) as json_file:
             predictions = json.load(json_file)
         return to_categorical(predictions["values"][: len(x)], nb_classes=10)
@@ -1046,9 +1046,9 @@ def get_gan_inverse_gan_ft():
         sess = tf.Session()
         sess.run(tf.global_variables_initializer())
 
-        gan = TensorFlowGenerator(input_ph=z_ph, model=gen_tf, sess=sess, )
+        gan = TensorFlowGenerator(input_ph=z_ph, model=gen_tf, sess=sess,)
 
-        inverse_gan = TensorFlowEncoder(input_ph=image_to_enc_ph, model=enc_tf, sess=sess, )
+        inverse_gan = TensorFlowEncoder(input_ph=image_to_enc_ph, model=enc_tf, sess=sess,)
         return gan, inverse_gan, sess
 
 


### PR DESCRIPTION
# Description
This PR addresses issue #462 which main purpose involves removing all duplicated boilerplate within the tests dealing with identifying which version of Tensorflow is currently being ran and treating TF1 and TF2 as two separate frameworks. This means we can avail of all the pytest functionality we already created for managing frameworks

Fixes #462 

## Type of change

Please check all relevant options.

- [X] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
