### PR TITLE
Add verbose argument to all attacks and defences

### DIFF
--- a/art/attacks/evasion/adversarial_patch/adversarial_patch.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch.py
@@ -56,6 +56,7 @@ class AdversarialPatch(EvasionAttack):
         "learning_rate",
         "max_iter",
         "batch_size",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, NeuralNetworkMixin, ClassifierMixin)
@@ -70,6 +71,7 @@ class AdversarialPatch(EvasionAttack):
         max_iter: int = 500,
         batch_size: int = 16,
         patch_shape: Optional[Tuple[int, int, int]] = None,
+        verbose: bool = True,
     ):
         """
         Create an instance of the :class:`.AdversarialPatch`.
@@ -87,6 +89,7 @@ class AdversarialPatch(EvasionAttack):
         :param patch_shape: The shape of the adversarial patch as a tuple of shape (width, height, nb_channels).
                             Currently only supported for `TensorFlowV2Classifier`. For classifiers of other frameworks
                             the `patch_shape` is set to the shape of the input samples.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=classifier)
         if self.estimator.clip_values is None:
@@ -103,6 +106,7 @@ class AdversarialPatch(EvasionAttack):
                 max_iter=max_iter,
                 batch_size=batch_size,
                 patch_shape=patch_shape,
+                verbose=verbose,
             )
         else:
             self._attack = AdversarialPatchNumpy(
@@ -113,6 +117,7 @@ class AdversarialPatch(EvasionAttack):
                 learning_rate=learning_rate,
                 max_iter=max_iter,
                 batch_size=batch_size,
+                verbose=verbose,
             )
         self._check_params()
 
@@ -184,3 +189,6 @@ class AdversarialPatch(EvasionAttack):
             raise ValueError("The batch size must be of type int.")
         if not self._attack.batch_size > 0:
             raise ValueError("The batch size must be greater than 0.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch.py
@@ -190,5 +190,5 @@ class AdversarialPatch(EvasionAttack):
         if not self._attack.batch_size > 0:
             raise ValueError("The batch size must be greater than 0.")
 
-        if not isinstance(self.verbose, bool):
+        if not isinstance(self._attack.verbose, bool):
             raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
@@ -57,6 +57,7 @@ class AdversarialPatchNumpy(EvasionAttack):
         "learning_rate",
         "max_iter",
         "batch_size",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, NeuralNetworkMixin, ClassifierMixin)
@@ -72,6 +73,7 @@ class AdversarialPatchNumpy(EvasionAttack):
         max_iter: int = 500,
         clip_patch: Union[list, tuple, None] = None,
         batch_size: int = 16,
+        verbose: bool = True,
     ) -> None:
         """
         Create an instance of the :class:`.AdversarialPatchNumpy`.
@@ -89,6 +91,7 @@ class AdversarialPatchNumpy(EvasionAttack):
         :param clip_patch: The minimum and maximum values for each channel in the form
                [(float, float), (float, float), (float, float)].
         :param batch_size: The size of the training batch.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=classifier)
 
@@ -100,6 +103,7 @@ class AdversarialPatchNumpy(EvasionAttack):
         self.max_iter = max_iter
         self.batch_size = batch_size
         self.clip_patch = clip_patch
+        self.verbose = verbose
         self._check_params()
 
         if len(self.estimator.input_shape) not in [3, 4]:
@@ -162,7 +166,7 @@ class AdversarialPatchNumpy(EvasionAttack):
 
         y_target = check_and_transform_label_format(labels=y, nb_classes=self.estimator.nb_classes)
 
-        for _ in trange(self.max_iter, desc="Adversarial Patch Numpy"):
+        for _ in trange(self.max_iter, desc="Adversarial Patch Numpy", disable=not self.verbose):
             patched_images, patch_mask_transformed, transforms = self._augment_images_with_random_patch(x, self.patch)
 
             num_batches = int(math.ceil(x.shape[0] / self.batch_size))
@@ -233,6 +237,9 @@ class AdversarialPatchNumpy(EvasionAttack):
             raise ValueError("The batch size must be of type int.")
         if self.batch_size <= 0:
             raise ValueError("The batch size must be greater than 0.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")
 
     def _get_circular_patch_mask(self, sharpness: int = 40) -> np.ndarray:
         """

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
@@ -58,6 +58,7 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
         "max_iter",
         "batch_size",
         "patch_shape",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, NeuralNetworkMixin, ClassifierMixin)
@@ -72,6 +73,7 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
         max_iter: int = 500,
         batch_size: int = 16,
         patch_shape: Optional[Tuple[int, int, int]] = None,
+        verbose: bool = True,
     ):
         """
         Create an instance of the :class:`.AdversarialPatchTensorFlowV2`.
@@ -87,6 +89,7 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
         :param max_iter: The number of optimization steps.
         :param batch_size: The size of the training batch.
         :param patch_shape: The shape of the adversarial patch as a tuple of shape HWC (width, height, nb_channels).
+        :param verbose: Show progress bars.
         """
         import tensorflow as tf  # lgtm [py/repeated-import]
 
@@ -102,6 +105,7 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
         else:
             self.patch_shape = patch_shape
         self.image_shape = classifier.input_shape
+        self.verbose = verbose
         self._check_params()
 
         if self.estimator.channels_first:
@@ -352,7 +356,7 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
                 .repeat(math.ceil(x.shape[0] / self.batch_size))
             )
 
-        for _ in trange(self.max_iter, desc="Adversarial Patch TensorFlow v2"):
+        for _ in trange(self.max_iter, desc="Adversarial Patch TensorFlow v2", disable=not self.verbose):
             for images, target in dataset:
                 _ = self._train_step(images=images, target=target)
 

--- a/art/attacks/evasion/boundary.py
+++ b/art/attacks/evasion/boundary.py
@@ -59,6 +59,7 @@ class BoundaryAttack(EvasionAttack):
         "sample_size",
         "init_size",
         "batch_size",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, ClassifierMixin)
@@ -74,6 +75,7 @@ class BoundaryAttack(EvasionAttack):
         num_trial: int = 25,
         sample_size: int = 20,
         init_size: int = 100,
+        verbose: bool = True,
     ) -> None:
         """
         Create a boundary attack instance.
@@ -87,6 +89,7 @@ class BoundaryAttack(EvasionAttack):
         :param num_trial: Maximum number of trials per iteration.
         :param sample_size: Number of samples per trial.
         :param init_size: Maximum number of trials for initial generation of adversarial examples.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=estimator)
 
@@ -99,6 +102,7 @@ class BoundaryAttack(EvasionAttack):
         self.sample_size = sample_size
         self.init_size = init_size
         self.batch_size = 1
+        self.verbose = verbose
         self._check_params()
 
     def generate(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
@@ -140,7 +144,7 @@ class BoundaryAttack(EvasionAttack):
         x_adv = x.astype(ART_NUMPY_DTYPE)
 
         # Generate the adversarial samples
-        for ind, val in enumerate(tqdm(x_adv, desc="Boundary attack")):
+        for ind, val in enumerate(tqdm(x_adv, desc="Boundary attack", disable=not self.verbose)):
             if self.targeted:
                 x_adv[ind] = self._perturb(
                     x=val,
@@ -398,3 +402,6 @@ class BoundaryAttack(EvasionAttack):
 
         if self.step_adapt <= 0 or self.step_adapt >= 1:
             raise ValueError("The adaptation factor must be in the range (0, 1).")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/deepfool.py
+++ b/art/attacks/evasion/deepfool.py
@@ -218,3 +218,6 @@ class DeepFool(EvasionAttack):
 
         if self.batch_size <= 0:
             raise ValueError("The batch size `batch_size` has to be positive.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/dpatch.py
+++ b/art/attacks/evasion/dpatch.py
@@ -51,6 +51,7 @@ class DPatch(EvasionAttack):
         "learning_rate",
         "max_iter",
         "batch_size",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, LossGradientsMixin, ObjectDetectorMixin)
@@ -62,6 +63,7 @@ class DPatch(EvasionAttack):
         learning_rate: float = 5.0,
         max_iter: int = 500,
         batch_size: int = 16,
+        verbose: bool = True,
     ):
         """
         Create an instance of the :class:`.DPatch`.
@@ -71,6 +73,7 @@ class DPatch(EvasionAttack):
         :param learning_rate: The learning rate of the optimization.
         :param max_iter: The number of optimization steps.
         :param batch_size: The size of the training batch.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=estimator)
 
@@ -81,6 +84,7 @@ class DPatch(EvasionAttack):
         self._patch = np.random.randint(
             self.estimator.clip_values[0], self.estimator.clip_values[1], size=patch_shape
         ).astype(np.float32)
+        self.verbose = verbose
         self._check_params()
 
         self.target_label = []
@@ -119,7 +123,7 @@ class DPatch(EvasionAttack):
                     raise ValueError("The target_label as list of integers needs to of length number of images in `x`.")
                 self.target_label = target_label
 
-        for i_step in trange(self.max_iter, desc="DPatch iteration"):
+        for i_step in trange(self.max_iter, desc="DPatch iteration", disable=not self.verbose):
             if i_step == 0 or (i_step + 1) % 100 == 0:
                 logger.info("Training Step: %i", i_step + 1)
 
@@ -286,3 +290,6 @@ class DPatch(EvasionAttack):
             raise ValueError("The batch size must be of type int.")
         if self.batch_size <= 0:
             raise ValueError("The batch size must be greater than 0.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/elastic_net.py
+++ b/art/attacks/evasion/elastic_net.py
@@ -62,6 +62,7 @@ class ElasticNet(EvasionAttack):
         "initial_const",
         "batch_size",
         "decision_rule",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, ClassGradientsMixin)
@@ -78,6 +79,7 @@ class ElasticNet(EvasionAttack):
         initial_const: float = 1e-3,
         batch_size: int = 1,
         decision_rule: str = "EN",
+        verbose: bool = True,
     ) -> None:
         """
         Create an ElasticNet attack instance.
@@ -96,6 +98,7 @@ class ElasticNet(EvasionAttack):
                Carlini and Wagner (2016).
         :param batch_size: Internal size of batches on which adversarial samples are generated.
         :param decision_rule: Decision rule. 'EN' means Elastic Net rule, 'L1' means L1 rule, 'L2' means L2 rule.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=classifier)
         self.confidence = confidence
@@ -107,6 +110,7 @@ class ElasticNet(EvasionAttack):
         self.initial_const = initial_const
         self.batch_size = batch_size
         self.decision_rule = decision_rule
+        self.verbose = verbose
         self._check_params()
 
     def _loss(self, x: np.ndarray, x_adv: np.ndarray) -> tuple:
@@ -201,7 +205,7 @@ class ElasticNet(EvasionAttack):
 
         # Compute adversarial examples with implicit batching
         nb_batches = int(np.ceil(x_adv.shape[0] / float(self.batch_size)))
-        for batch_id in trange(nb_batches, desc="EAD"):
+        for batch_id in trange(nb_batches, desc="EAD", disable=not self.verbose):
             batch_index_1, batch_index_2 = batch_id * self.batch_size, (batch_id + 1) * self.batch_size
             x_batch = x_adv[batch_index_1:batch_index_2]
             y_batch = y[batch_index_1:batch_index_2]
@@ -386,3 +390,6 @@ class ElasticNet(EvasionAttack):
 
         if not isinstance(self.decision_rule, six.string_types) or self.decision_rule not in ["EN", "L1", "L2"]:
             raise ValueError("The decision rule only supports `EN`, `L1`, `L2`.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/frame_saliency.py
+++ b/art/attacks/evasion/frame_saliency.py
@@ -59,6 +59,7 @@ class FrameSaliencyAttack(EvasionAttack):
         "method",
         "frame_index",
         "batch_size",
+        "verbose",
     ]
     _estimator_requirements = (BaseEstimator, NeuralNetworkMixin, ClassGradientsMixin)
 
@@ -69,6 +70,7 @@ class FrameSaliencyAttack(EvasionAttack):
         method: str = "iterative_saliency",
         frame_index: int = 1,
         batch_size: int = 1,
+        verbose: bool = True,
     ):
         """
         :param classifier: A trained classifier.
@@ -80,6 +82,7 @@ class FrameSaliencyAttack(EvasionAttack):
                        original attack).
         :param frame_index: Index of the axis in input (feature) array `x` representing the frame dimension.
         :param batch_size: Size of the batch on which adversarial samples are generated.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=classifier)
 
@@ -87,6 +90,7 @@ class FrameSaliencyAttack(EvasionAttack):
         self.method = method
         self.frame_index = frame_index
         self.batch_size = batch_size
+        self.verbose = verbose
         self._check_params()
 
     def generate(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
@@ -146,7 +150,7 @@ class FrameSaliencyAttack(EvasionAttack):
         x_adv_new = self.attacker.generate(x, targets, mask=mask)
 
         # Here starts the main iteration:
-        for i in trange(nb_frames, desc="Frame saliency"):
+        for i in trange(nb_frames, desc="Frame saliency", disable=not self.verbose):
             # Check if attack has already succeeded for all inputs:
             if sum(attack_failure) == 0:
                 break
@@ -217,3 +221,6 @@ class FrameSaliencyAttack(EvasionAttack):
 
         if not self.estimator == self.attacker.estimator:
             raise Warning("Different classifiers given for computation of saliency scores and adversarial noise.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -58,6 +58,7 @@ class HopSkipJump(EvasionAttack):
         "init_size",
         "curr_iter",
         "batch_size",
+        "verbose",
     ]
     _estimator_requirements = (BaseEstimator, ClassifierMixin)
 
@@ -70,6 +71,7 @@ class HopSkipJump(EvasionAttack):
         max_eval: int = 10000,
         init_eval: int = 100,
         init_size: int = 100,
+        verbose: bool = True,
     ) -> None:
         """
         Create a HopSkipJump attack instance.
@@ -81,6 +83,7 @@ class HopSkipJump(EvasionAttack):
         :param max_eval: Maximum number of evaluations for estimating gradient.
         :param init_eval: Initial number of evaluations for estimating gradient.
         :param init_size: Maximum number of trials for initial generation of adversarial examples.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=classifier)
         self._targeted = targeted
@@ -91,6 +94,7 @@ class HopSkipJump(EvasionAttack):
         self.init_size = init_size
         self.curr_iter = 0
         self.batch_size = 1
+        self.verbose = verbose
         self._check_params()
         self.curr_iter = 0
 
@@ -151,7 +155,7 @@ class HopSkipJump(EvasionAttack):
             y = np.argmax(y, axis=1)
 
         # Generate the adversarial samples
-        for ind, val in enumerate(tqdm(x_adv, desc="HopSkipJump")):
+        for ind, val in enumerate(tqdm(x_adv, desc="HopSkipJump", disable=not self.verbose)):
             self.curr_iter = start
             if self.targeted:
                 x_adv[ind] = self._perturb(
@@ -561,3 +565,6 @@ class HopSkipJump(EvasionAttack):
 
         if not isinstance(self.init_size, (int, np.int)) or self.init_size <= 0:
             raise ValueError("The number of initial trials must be a positive integer.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -71,7 +71,12 @@ class PixelThreshold(EvasionAttack):
     _estimator_requirements = (BaseEstimator, NeuralNetworkMixin, ClassifierMixin)
 
     def __init__(
-        self, classifier: "CLASSIFIER_NEURALNETWORK_TYPE", th: Optional[int], es: int, targeted: bool, verbose: bool,
+        self,
+        classifier: "CLASSIFIER_NEURALNETWORK_TYPE",
+        th: Optional[int],
+        es: int,
+        targeted: bool,
+        verbose: bool = True,
     ) -> None:
         """
         Create a :class:`.PixelThreshold` instance.
@@ -80,7 +85,7 @@ class PixelThreshold(EvasionAttack):
         :param th: threshold value of the Pixel/ Threshold attack. th=None indicates finding a minimum threshold.
         :param es: Indicates whether the attack uses CMAES (0) or DE (1) as Evolutionary Strategy.
         :param targeted: Indicates whether the attack is targeted (True) or untargeted (False).
-        :param verbose: Indicates whether to print verbose messages of ES used.
+        :param verbose: Print verbose messages of ES and show progress bars.
         """
         super().__init__(estimator=classifier)
 
@@ -105,12 +110,18 @@ class PixelThreshold(EvasionAttack):
         if self.th is not None:
             if self.th <= 0:
                 raise ValueError("The perturbation size `eps` has to be positive.")
+
         if not isinstance(self.es, int):
             raise ValueError("The flag `es` has to be of type int.")
+
         if not isinstance(self.targeted, bool):
             raise ValueError("The flag `targeted` has to be of type bool.")
+
         if not isinstance(self.verbose, bool):
             raise ValueError("The flag `verbose` has to be of type bool.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")
 
     def generate(self, x: np.ndarray, y: Optional[np.ndarray] = None, max_iter: int = 100, **kwargs) -> np.ndarray:
         """
@@ -141,7 +152,7 @@ class PixelThreshold(EvasionAttack):
             x = x * 255.0
 
         adv_x_best = []
-        for image, target_class in tqdm(zip(x, y), desc="Pixel threshold"):
+        for image, target_class in tqdm(zip(x, y), desc="Pixel threshold", disable=not self.verbose):
             if self.th is None:
                 self.min_th = 127
                 start, end = 1, 127

--- a/art/attacks/evasion/shadow_attack.py
+++ b/art/attacks/evasion/shadow_attack.py
@@ -56,6 +56,7 @@ class ShadowAttack(EvasionAttack):
         "lambda_s",
         "batch_size",
         "targeted",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, LossGradientsMixin, ClassifierMixin)
@@ -73,6 +74,7 @@ class ShadowAttack(EvasionAttack):
         lambda_s: float = 0.5,
         batch_size: int = 400,
         targeted: bool = False,
+        verbose: bool = True,
     ):
         """
         Create an instance of the :class:`.ShadowAttack`.
@@ -86,6 +88,7 @@ class ShadowAttack(EvasionAttack):
         :param lambda_s: Scalar penalty weight for similarity of color channels in perturbation.
         :param batch_size: The size of the training batch.
         :param targeted: True if the attack is targeted.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=estimator)
 
@@ -97,6 +100,7 @@ class ShadowAttack(EvasionAttack):
         self.lambda_c = lambda_c
         self.lambda_s = lambda_s
         self._targeted = targeted
+        self.verbose = verbose
         self._check_params()
 
         self.framework: Optional[str]
@@ -146,7 +150,7 @@ class ShadowAttack(EvasionAttack):
             - (self.estimator.clip_values[1] - self.estimator.clip_values[0]) / 2
         )
 
-        for _ in trange(self.nb_steps, desc="Shadow attack"):
+        for _ in trange(self.nb_steps, desc="Shadow attack", disable=not self.verbose):
             gradients_ce = np.mean(
                 self.estimator.loss_gradient(x=x_batch + perturbation, y=y_batch, sampling=False)
                 * (1 - 2 * int(self.targeted)),
@@ -281,3 +285,6 @@ class ShadowAttack(EvasionAttack):
 
         if not isinstance(self.targeted, bool):
             raise ValueError("The targeted argument must be of type bool.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/spatial_transformation.py
+++ b/art/attacks/evasion/spatial_transformation.py
@@ -54,6 +54,7 @@ class SpatialTransformation(EvasionAttack):
         "num_translations",
         "max_rotation",
         "num_rotations",
+        "verbose",
     ]
     _estimator_requirements = (BaseEstimator, NeuralNetworkMixin)
 
@@ -64,6 +65,7 @@ class SpatialTransformation(EvasionAttack):
         num_translations: int = 1,
         max_rotation: float = 0.0,
         num_rotations: int = 1,
+        verbose: bool = True,
     ) -> None:
         """
         :param classifier: A trained classifier.
@@ -73,12 +75,14 @@ class SpatialTransformation(EvasionAttack):
         :param max_rotation: The maximum rotation in either direction in degrees. The value is expected to be in the
                range `[0, 180]`.
         :param num_rotations: The number of rotations to search on grid spacing.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=classifier)
         self.max_translation = max_translation
         self.num_translations = num_translations
         self.max_rotation = max_rotation
         self.num_rotations = num_rotations
+        self.verbose = verbose
         self._check_params()
 
         self.fooling_rate: Optional[float] = None
@@ -139,7 +143,11 @@ class SpatialTransformation(EvasionAttack):
             rot = 0.0
 
             # Initialize progress bar
-            pbar = tqdm(len(grid_trans_x) * len(grid_trans_y) * len(grid_rot), desc="Spatial transformation")
+            pbar = tqdm(
+                len(grid_trans_x) * len(grid_trans_y) * len(grid_rot),
+                desc="Spatial transformation",
+                disable=not self.verbose,
+            )
 
             for trans_x_i in grid_trans_x:
                 for trans_y_i in grid_trans_y:
@@ -207,3 +215,6 @@ class SpatialTransformation(EvasionAttack):
 
         if not isinstance(self.num_rotations, int) or self.num_rotations <= 0:
             raise ValueError("The number of rotations must be a positive integer.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/square_attack.py
+++ b/art/attacks/evasion/square_attack.py
@@ -49,6 +49,7 @@ class SquareAttack(EvasionAttack):
         "eps",
         "p_init",
         "nb_restarts",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, ClassifierMixin)
@@ -61,6 +62,7 @@ class SquareAttack(EvasionAttack):
         eps: float = 0.3,
         p_init: float = 0.8,
         nb_restarts: int = 1,
+        verbose: bool = True,
     ):
         """
         Create a :class:`.SquareAttack` instance.
@@ -71,6 +73,7 @@ class SquareAttack(EvasionAttack):
         :param eps: Maximum perturbation that the attacker can introduce.
         :param p_init: Initial fraction of elements.
         :param nb_restarts: Number of restarts.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=estimator)
 
@@ -79,6 +82,7 @@ class SquareAttack(EvasionAttack):
         self.eps = eps
         self.p_init = p_init
         self.nb_restarts = nb_restarts
+        self.verbose = verbose
         self._check_params()
 
     def _get_logits_diff(self, x: np.ndarray, y: np.ndarray) -> np.ndarray:
@@ -131,7 +135,7 @@ class SquareAttack(EvasionAttack):
             width = x.shape[2]
             channels = x.shape[3]
 
-        for _ in trange(self.nb_restarts, desc="SquareAttack - restarts"):
+        for _ in trange(self.nb_restarts, desc="SquareAttack - restarts", disable=not self.verbose):
 
             # Determine correctly predicted samples
             y_pred = self.estimator.predict(x_adv)
@@ -166,7 +170,9 @@ class SquareAttack(EvasionAttack):
 
                 x_adv[sample_is_robust] = x_robust
 
-                for i_iter in trange(self.max_iter, desc="SquareAttack - iterations", leave=False):
+                for i_iter in trange(
+                    self.max_iter, desc="SquareAttack - iterations", leave=False, disable=not self.verbose
+                ):
 
                     percentage_of_elements = self._get_percentage_of_elements(i_iter)
 
@@ -290,7 +296,9 @@ class SquareAttack(EvasionAttack):
 
                 x_adv[sample_is_robust] = x_robust
 
-                for i_iter in trange(self.max_iter, desc="SquareAttack - iterations", leave=False):
+                for i_iter in trange(
+                    self.max_iter, desc="SquareAttack - iterations", leave=False, disable=not self.verbose
+                ):
 
                     percentage_of_elements = self._get_percentage_of_elements(i_iter)
 
@@ -469,3 +477,6 @@ class SquareAttack(EvasionAttack):
 
         if not isinstance(self.nb_restarts, int) or self.nb_restarts <= 0:
             raise ValueError("The argument nb_restarts has to be of type int and larger than zero.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/universal_perturbation.py
+++ b/art/attacks/evasion/universal_perturbation.py
@@ -71,6 +71,7 @@ class UniversalPerturbation(EvasionAttack):
         "eps",
         "norm",
         "batch_size",
+        "verbose",
     ]
     _estimator_requirements = (BaseEstimator, ClassifierMixin)
 
@@ -84,6 +85,7 @@ class UniversalPerturbation(EvasionAttack):
         eps: float = 10.0,
         norm: Union[int, float, str] = np.inf,
         batch_size: int = 32,
+        verbose: bool = True,
     ) -> None:
         """
         :param classifier: A trained classifier.
@@ -96,6 +98,7 @@ class UniversalPerturbation(EvasionAttack):
         :param eps: Attack step size (input variation).
         :param norm: The norm of the adversarial perturbation. Possible values: "inf", np.inf, 2.
         :param batch_size: Batch size for model evaluations in UniversalPerturbation.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=classifier)
         self.attacker = attacker
@@ -105,6 +108,7 @@ class UniversalPerturbation(EvasionAttack):
         self.eps = eps
         self.norm = norm
         self.batch_size = batch_size
+        self.verbose = verbose
         self._check_params()
 
     def generate(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
@@ -136,7 +140,7 @@ class UniversalPerturbation(EvasionAttack):
 
         # Generate the adversarial examples
         nb_iter = 0
-        pbar = tqdm(self.max_iter, desc="Universal perturbation")
+        pbar = tqdm(self.max_iter, desc="Universal perturbation", disable=not self.verbose)
 
         while fooling_rate < 1.0 - self.delta and nb_iter < self.max_iter:
             # Go through all the examples randomly
@@ -181,19 +185,6 @@ class UniversalPerturbation(EvasionAttack):
 
         return x_adv
 
-    def _check_params(self) -> None:
-        if not isinstance(self.delta, (float, int)) or self.delta < 0 or self.delta > 1:
-            raise ValueError("The desired accuracy must be in the range [0, 1].")
-
-        if not isinstance(self.max_iter, (int, np.int)) or self.max_iter <= 0:
-            raise ValueError("The number of iterations must be a positive integer.")
-
-        if not isinstance(self.eps, (float, int)) or self.eps <= 0:
-            raise ValueError("The eps coefficient must be a positive float.")
-
-        if not isinstance(self.batch_size, (int, np.int)) or self.batch_size <= 0:
-            raise ValueError("The batch_size must be a positive integer.")
-
     def _get_attack(self, a_name: str, params: Optional[Dict[str, Any]] = None) -> EvasionAttack:
         """
         Get an attack object from its name.
@@ -227,3 +218,19 @@ class UniversalPerturbation(EvasionAttack):
         class_module = getattr(module_, sub_mods[-1])
 
         return class_module
+
+    def _check_params(self) -> None:
+        if not isinstance(self.delta, (float, int)) or self.delta < 0 or self.delta > 1:
+            raise ValueError("The desired accuracy must be in the range [0, 1].")
+
+        if not isinstance(self.max_iter, (int, np.int)) or self.max_iter <= 0:
+            raise ValueError("The number of iterations must be a positive integer.")
+
+        if not isinstance(self.eps, (float, int)) or self.eps <= 0:
+            raise ValueError("The eps coefficient must be a positive float.")
+
+        if not isinstance(self.batch_size, (int, np.int)) or self.batch_size <= 0:
+            raise ValueError("The batch_size must be a positive integer.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/wasserstein.py
+++ b/art/attacks/evasion/wasserstein.py
@@ -63,6 +63,7 @@ class Wasserstein(EvasionAttack):
         "conjugate_sinkhorn_max_iter",
         "projected_sinkhorn_max_iter",
         "batch_size",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, LossGradientsMixin, ClassifierMixin)
@@ -84,6 +85,7 @@ class Wasserstein(EvasionAttack):
         conjugate_sinkhorn_max_iter: int = 400,
         projected_sinkhorn_max_iter: int = 400,
         batch_size: int = 1,
+        verbose: bool = True,
     ):
         """
         Create a Wasserstein attack instance.
@@ -103,6 +105,7 @@ class Wasserstein(EvasionAttack):
         :param conjugate_sinkhorn_max_iter: The maximum number of iterations for the conjugate sinkhorn optimizer.
         :param projected_sinkhorn_max_iter: The maximum number of iterations for the projected sinkhorn optimizer.
         :param batch_size: Size of batches.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=estimator)
 
@@ -120,6 +123,7 @@ class Wasserstein(EvasionAttack):
         self.conjugate_sinkhorn_max_iter = conjugate_sinkhorn_max_iter
         self.projected_sinkhorn_max_iter = projected_sinkhorn_max_iter
         self.batch_size = batch_size
+        self.verbose = verbose
         self._check_params()
 
     def generate(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
@@ -155,7 +159,7 @@ class Wasserstein(EvasionAttack):
 
         # Compute perturbation with implicit batching
         nb_batches = int(np.ceil(x.shape[0] / float(self.batch_size)))
-        for batch_id in trange(nb_batches, desc="Wasserstein"):
+        for batch_id in trange(nb_batches, desc="Wasserstein", disable=not self.verbose):
             logger.debug("Processing batch %i out of %i", batch_id, nb_batches)
 
             batch_index_1, batch_index_2 = batch_id * self.batch_size, (batch_id + 1) * self.batch_size
@@ -746,3 +750,6 @@ class Wasserstein(EvasionAttack):
 
         if self.batch_size <= 0:
             raise ValueError("The batch size `batch_size` has to be positive.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/zoo.py
+++ b/art/attacks/evasion/zoo.py
@@ -68,6 +68,7 @@ class ZooAttack(EvasionAttack):
         "nb_parallel",
         "batch_size",
         "variable_h",
+        "verbose",
     ]
     _estimator_requirements = (BaseEstimator, ClassifierMixin)
 
@@ -86,6 +87,7 @@ class ZooAttack(EvasionAttack):
         nb_parallel: int = 128,
         batch_size: int = 1,
         variable_h: float = 1e-4,
+        verbose: bool = True,
     ):
         """
         Create a ZOO attack instance.
@@ -111,6 +113,7 @@ class ZooAttack(EvasionAttack):
                encouraged for ZOO, as the algorithm already runs `nb_parallel` coordinate updates in parallel for each
                sample. The batch size is a multiplier of `nb_parallel` in terms of memory consumption.
         :param variable_h: Step size for numerical estimation of derivatives.
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=classifier)
 
@@ -136,6 +139,7 @@ class ZooAttack(EvasionAttack):
         self.nb_parallel = nb_parallel
         self.batch_size = batch_size
         self.variable_h = variable_h
+        self.verbose = verbose
         self._check_params()
 
         # Initialize some internal variables
@@ -215,7 +219,7 @@ class ZooAttack(EvasionAttack):
         # Compute adversarial examples with implicit batching
         nb_batches = int(np.ceil(x.shape[0] / float(self.batch_size)))
         x_adv = []
-        for batch_id in trange(nb_batches, desc="ZOO"):
+        for batch_id in trange(nb_batches, desc="ZOO", disable=not self.verbose):
             batch_index_1, batch_index_2 = batch_id * self.batch_size, (batch_id + 1) * self.batch_size
             x_batch = x[batch_index_1:batch_index_2]
             y_batch = y[batch_index_1:batch_index_2]
@@ -601,3 +605,6 @@ class ZooAttack(EvasionAttack):
 
         if not isinstance(self.batch_size, (int, np.int)) or self.batch_size < 1:
             raise ValueError("The batch size must be an integer greater than zero.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/extraction/knockoff_nets.py
+++ b/art/attacks/extraction/knockoff_nets.py
@@ -54,6 +54,7 @@ class KnockoffNets(ExtractionAttack):
         "nb_stolen",
         "sampling_strategy",
         "reward",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, ClassifierMixin)
@@ -67,6 +68,7 @@ class KnockoffNets(ExtractionAttack):
         nb_stolen: int = 1,
         sampling_strategy: str = "random",
         reward: str = "all",
+        verbose: bool = True,
     ) -> None:
         """
         Create a KnockoffNets attack instance. Note, it is assumed that both the victim classifier and the thieved
@@ -79,6 +81,7 @@ class KnockoffNets(ExtractionAttack):
         :param nb_stolen: Number of queries submitted to the victim classifier to steal it.
         :param sampling_strategy: Sampling strategy, either `random` or `adaptive`.
         :param reward: Reward type, in ['cert', 'div', 'loss', 'all'].
+        :param verbose: Show progress bars.
         """
         super().__init__(estimator=classifier)
 
@@ -88,6 +91,7 @@ class KnockoffNets(ExtractionAttack):
         self.nb_stolen = nb_stolen
         self.sampling_strategy = sampling_strategy
         self.reward = reward
+        self.verbose = verbose
         self._check_params()
 
     def extract(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> "CLASSIFIER_TYPE":
@@ -211,7 +215,7 @@ class KnockoffNets(ExtractionAttack):
         queried_labels = []
 
         avg_reward = 0.0
-        for it in trange(1, self.nb_stolen + 1, desc="Knock-off nets"):
+        for it in trange(1, self.nb_stolen + 1, desc="Knock-off nets", disable=not self.verbose):
             # Sample an action
             action = np.random.choice(np.arange(0, nb_actions), p=probs)
 
@@ -396,3 +400,6 @@ class KnockoffNets(ExtractionAttack):
 
         if self.reward not in ["cert", "div", "loss", "all"]:
             raise ValueError("Reward type must be in ['cert', 'div', 'loss', 'all'].")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/inference/model_inversion/mi_face.py
+++ b/art/attacks/inference/model_inversion/mi_face.py
@@ -55,6 +55,7 @@ class MIFace(InferenceAttack):
         "threshold",
         "learning_rate",
         "batch_size",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, ClassifierMixin, ClassGradientsMixin)

--- a/art/attacks/inference/model_inversion/mi_face.py
+++ b/art/attacks/inference/model_inversion/mi_face.py
@@ -113,7 +113,9 @@ class MIFace(InferenceAttack):
         x_infer = x.astype(ART_NUMPY_DTYPE)
 
         # Compute inversions with implicit batching
-        for batch_id in trange(int(np.ceil(x.shape[0] / float(self.batch_size))), desc="Model inversion", disable=not self.verbose):
+        for batch_id in trange(
+            int(np.ceil(x.shape[0] / float(self.batch_size))), desc="Model inversion", disable=not self.verbose
+        ):
             batch_index_1, batch_index_2 = batch_id * self.batch_size, (batch_id + 1) * self.batch_size
             batch = x_infer[batch_index_1:batch_index_2]
             batch_labels = y[batch_index_1:batch_index_2]
@@ -151,7 +153,7 @@ class MIFace(InferenceAttack):
         if not isinstance(self.window_length, (int, np.int)) or self.window_length < 0:
             raise ValueError("The window length must be a non-negative integer.")
 
-        if not isinstance(self.max_iter, float) or self.max_iter < 0.0:
+        if not isinstance(self.threshold, float) or self.threshold < 0.0:
             raise ValueError("The threshold must be a non-negative float.")
 
         if not isinstance(self.learning_rate, float) or self.learning_rate < 0.0:

--- a/art/attacks/poisoning/feature_collision_attack.py
+++ b/art/attacks/poisoning/feature_collision_attack.py
@@ -60,6 +60,7 @@ class FeatureCollisionAttack(PoisoningAttackWhiteBox):
         "max_iter",
         "similarity_coeff",
         "watermark",
+        "verbose",
     ]
 
     _estimator_requirements = (BaseEstimator, NeuralNetworkMixin, ClassifierMixin, KerasClassifier)
@@ -77,6 +78,7 @@ class FeatureCollisionAttack(PoisoningAttackWhiteBox):
         max_iter: int = 120,
         similarity_coeff: float = 256.0,
         watermark: Optional[float] = None,
+        verbose: bool = True,
     ):
         """
         Initialize an Feature Collision Clean-Label poisoning attack
@@ -92,6 +94,7 @@ class FeatureCollisionAttack(PoisoningAttackWhiteBox):
         :param max_iter: The maximum number of iterations for the attack.
         :param similarity_coeff: The maximum number of iterations for the attack.
         :param watermark: Whether The opacity of the watermarked target image.
+        :param verbose: Show progress bars.
         """
         super().__init__(classifier=classifier)  # type: ignore
         self.target = target
@@ -104,6 +107,7 @@ class FeatureCollisionAttack(PoisoningAttackWhiteBox):
         self.max_iter = max_iter
         self.similarity_coeff = similarity_coeff
         self.watermark = watermark
+        self.verbose = verbose
         self._check_params()
 
         self.target_placeholder, self.target_feature_rep = self.estimator.get_activations(
@@ -134,7 +138,7 @@ class FeatureCollisionAttack(PoisoningAttackWhiteBox):
             old_objective = self.objective(poison_features, target_features, init_attack, old_attack)
             last_m_objectives = [old_objective]
 
-            for i in trange(self.max_iter, desc="Feature collision"):
+            for i in trange(self.max_iter, desc="Feature collision", disable=not self.verbose):
                 # forward step
                 new_attack = self.forward_step(old_attack)
 
@@ -172,26 +176,6 @@ class FeatureCollisionAttack(PoisoningAttackWhiteBox):
             final_attacks.append(final_poison)
 
         return np.vstack(final_attacks), self.estimator.predict(x)
-
-    def _check_params(self) -> None:
-        if self.learning_rate <= 0:
-            raise ValueError("Learning rate must be strictly positive")
-        if self.max_iter < 1:
-            raise ValueError("Value of max_iter at least 1")
-        if not isinstance(self.feature_layer, (str, int)):
-            raise TypeError("Feature layer should be a string or int")
-        if self.decay_coeff <= 0:
-            raise ValueError("Decay coefficient must be positive")
-        if self.stopping_tol <= 0:
-            raise ValueError("Stopping tolerance must be positive")
-        if self.obj_threshold and self.obj_threshold <= 0:
-            raise ValueError("Objective threshold must be positive")
-        if self.num_old_obj <= 0:
-            raise ValueError("Number of old stored objectives must be positive")
-        if self.max_iter <= 0:
-            raise ValueError("Number of old stored objectives must be positive")
-        if self.watermark and not (isinstance(self.watermark, float) and 0 <= self.watermark < 1):
-            raise ValueError("Watermark must be between 0 and 1")
 
     def forward_step(self, poison: np.ndarray) -> np.ndarray:
         """
@@ -286,3 +270,34 @@ def tensor_norm(tensor, norm_type: Union[int, float, str] = 2):
         import mxnet
 
         return mxnet.ndarray.norm(tensor, ord=norm_type)
+
+    def _check_params(self) -> None:
+        if self.learning_rate <= 0:
+            raise ValueError("Learning rate must be strictly positive")
+
+        if self.max_iter < 1:
+            raise ValueError("Value of max_iter at least 1")
+
+        if not isinstance(self.feature_layer, (str, int)):
+            raise TypeError("Feature layer should be a string or int")
+
+        if self.decay_coeff <= 0:
+            raise ValueError("Decay coefficient must be positive")
+
+        if self.stopping_tol <= 0:
+            raise ValueError("Stopping tolerance must be positive")
+
+        if self.obj_threshold and self.obj_threshold <= 0:
+            raise ValueError("Objective threshold must be positive")
+
+        if self.num_old_obj <= 0:
+            raise ValueError("Number of old stored objectives must be positive")
+
+        if self.max_iter <= 0:
+            raise ValueError("Number of old stored objectives must be positive")
+
+        if self.watermark and not (isinstance(self.watermark, float) and 0 <= self.watermark < 1):
+            raise ValueError("Watermark must be between 0 and 1")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/defences/preprocessor/jpeg_compression.py
+++ b/art/defences/preprocessor/jpeg_compression.py
@@ -55,7 +55,7 @@ class JpegCompression(Preprocessor):
         https://arxiv.org/abs/1902.06705
     """
 
-    params = ["quality", "channel_index", "channels_first", "clip_values"]
+    params = ["quality", "channel_index", "channels_first", "clip_values", "verbose"]
 
     @deprecated_keyword_arg("channel_index", end_version="1.5.0", replaced_by="channels_first")
     def __init__(
@@ -66,6 +66,7 @@ class JpegCompression(Preprocessor):
         channels_first: bool = False,
         apply_fit: bool = True,
         apply_predict: bool = True,
+        verbose: bool = False,
     ):
         """
         Create an instance of JPEG compression.
@@ -78,6 +79,7 @@ class JpegCompression(Preprocessor):
         :param channels_first: Set channels first or last.
         :param apply_fit: True if applied during fitting/training.
         :param apply_predict: True if applied during predicting.
+        :param verbose: Show progress bars.
         """
         # Remove in 1.5.0
         if channel_index == 3:
@@ -95,6 +97,7 @@ class JpegCompression(Preprocessor):
         self.channel_index = channel_index
         self.channels_first = channels_first
         self.clip_values = clip_values
+        self.verbose = verbose
         self._check_params()
 
     @property
@@ -169,7 +172,7 @@ class JpegCompression(Preprocessor):
 
         # Compress one image at a time
         x_jpeg = x.copy()
-        for idx in tqdm(np.ndindex(x.shape[:2]), desc="JPEG compression"):
+        for idx in tqdm(np.ndindex(x.shape[:2]), desc="JPEG compression", disable=not self.verbose):
             x_jpeg[idx] = self._compress(x[idx], image_mode)
 
         # Undo preparation grayscale images for "L" mode
@@ -218,3 +221,6 @@ class JpegCompression(Preprocessor):
 
         if self.clip_values[1] != 1.0 and self.clip_values[1] != 255:
             raise ValueError("'clip_values' max value must be either 1 or 255.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/defences/preprocessor/mp3_compression.py
+++ b/art/defences/preprocessor/mp3_compression.py
@@ -43,7 +43,7 @@ class Mp3Compression(Preprocessor):
     Implement the MP3 compression defense approach.
     """
 
-    params = ["channel_index", "channels_first", "sample_rate"]
+    params = ["channel_index", "channels_first", "sample_rate", "verbose"]
 
     @deprecated_keyword_arg("channel_index", end_version="1.5.0", replaced_by="channels_first")
     def __init__(
@@ -53,6 +53,7 @@ class Mp3Compression(Preprocessor):
         channels_first: bool = False,
         apply_fit: bool = False,
         apply_predict: bool = True,
+        verbose: bool = False,
     ) -> None:
         """
         Create an instance of MP3 compression.
@@ -63,6 +64,7 @@ class Mp3Compression(Preprocessor):
         :param channels_first: Set channels first or last.
         :param apply_fit: True if applied during fitting/training.
         :param apply_predict: True if applied during predicting.
+        :param verbose: Show progress bars.
         """
         # Remove in 1.5.0
         if channel_index == 3:
@@ -79,6 +81,7 @@ class Mp3Compression(Preprocessor):
         self.channel_index = channel_index
         self.channels_first = channels_first
         self.sample_rate = sample_rate
+        self.verbose = verbose
         self._check_params()
 
     @property
@@ -145,7 +148,7 @@ class Mp3Compression(Preprocessor):
 
         # apply mp3 compression per audio item
         x_mp3 = x.copy()
-        for i, x_i in enumerate(tqdm(x, desc="MP3 compression")):
+        for i, x_i in enumerate(tqdm(x, desc="MP3 compression", disable=not self.verbose)):
             x_mp3[i] = wav_to_mp3(x_i, self.sample_rate)
 
         if self.channels_first:
@@ -165,3 +168,6 @@ class Mp3Compression(Preprocessor):
     def _check_params(self) -> None:
         if not (isinstance(self.sample_rate, (int, np.int)) and self.sample_rate > 0):
             raise ValueError("Sample rate be must a positive integer.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/defences/preprocessor/pixel_defend.py
+++ b/art/defences/preprocessor/pixel_defend.py
@@ -54,7 +54,7 @@ class PixelDefend(Preprocessor):
         https://arxiv.org/abs/1902.06705
     """
 
-    params = ["clip_values", "eps", "pixel_cnn"]
+    params = ["clip_values", "eps", "pixel_cnn", "verbose"]
 
     def __init__(
         self,
@@ -64,6 +64,7 @@ class PixelDefend(Preprocessor):
         batch_size: int = 128,
         apply_fit: bool = False,
         apply_predict: bool = True,
+        verbose: bool = False,
     ) -> None:
         """
         Create an instance of pixel defence.
@@ -72,6 +73,7 @@ class PixelDefend(Preprocessor):
                for features.
         :param eps: Defense parameter 0-255.
         :param pixel_cnn: Pre-trained PixelCNN model.
+        :param verbose: Show progress bars.
         """
         super().__init__()
         self._is_fitted = True
@@ -81,6 +83,7 @@ class PixelDefend(Preprocessor):
         self.eps = eps
         self.batch_size = batch_size
         self.pixel_cnn = pixel_cnn
+        self.verbose = verbose
         self._check_params()
 
     @property
@@ -114,7 +117,7 @@ class PixelDefend(Preprocessor):
         x = x.reshape((x.shape[0], -1))
 
         # Start defence one image at a time
-        for i, x_i in enumerate(tqdm(x, desc="PixelDefend")):
+        for i, x_i in enumerate(tqdm(x, desc="PixelDefend", disable=not self.verbose)):
             for feat_index in range(x.shape[1]):
                 # Setup the search space
                 f_probs = probs[i, feat_index, :]
@@ -176,3 +179,6 @@ class PixelDefend(Preprocessor):
 
         if self.batch_size <= 0:
             raise ValueError("The batch size `batch_size` has to be positive.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/defences/preprocessor/spatial_smoothing.py
+++ b/art/defences/preprocessor/spatial_smoothing.py
@@ -20,7 +20,6 @@ This module implements the local spatial smoothing defence in `SpatialSmoothing`
 
 | Paper link: https://arxiv.org/abs/1704.01155
 
-
 | Please keep in mind the limitations of defences. For more information on the limitations of this defence,
     see https://arxiv.org/abs/1803.09868 . For details on how to evaluate classifier security in general, see
     https://arxiv.org/abs/1902.06705

--- a/art/defences/preprocessor/spatial_smoothing_pytorch.py
+++ b/art/defences/preprocessor/spatial_smoothing_pytorch.py
@@ -20,7 +20,6 @@ This module implements the local spatial smoothing defence in `SpatialSmoothing`
 
 | Paper link: https://arxiv.org/abs/1704.01155
 
-
 | Please keep in mind the limitations of defences. For more information on the limitations of this defence,
     see https://arxiv.org/abs/1803.09868 . For details on how to evaluate classifier security in general, see
     https://arxiv.org/abs/1902.06705

--- a/art/defences/preprocessor/spatial_smoothing_tensorflow.py
+++ b/art/defences/preprocessor/spatial_smoothing_tensorflow.py
@@ -20,7 +20,6 @@ This module implements the local spatial smoothing defence in `SpatialSmoothing`
 
 | Paper link: https://arxiv.org/abs/1704.01155
 
-
 | Please keep in mind the limitations of defences. For more information on the limitations of this defence,
     see https://arxiv.org/abs/1803.09868 . For details on how to evaluate classifier security in general, see
     https://arxiv.org/abs/1902.06705

--- a/art/defences/preprocessor/variance_minimization.py
+++ b/art/defences/preprocessor/variance_minimization.py
@@ -53,7 +53,7 @@ class TotalVarMin(Preprocessor):
         see https://arxiv.org/abs/1902.06705
     """
 
-    params = ["prob", "norm", "lamb", "solver", "max_iter", "clip_values"]
+    params = ["prob", "norm", "lamb", "solver", "max_iter", "clip_values", "verbose"]
 
     def __init__(
         self,
@@ -65,6 +65,7 @@ class TotalVarMin(Preprocessor):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         apply_fit: bool = False,
         apply_predict: bool = True,
+        verbose: bool = False,
     ):
         """
         Create an instance of total variance minimization.
@@ -78,6 +79,7 @@ class TotalVarMin(Preprocessor):
                for features.
         :param apply_fit: True if applied during fitting/training.
         :param apply_predict: True if applied during predicting.
+        :param verbose: Show progress bars.
         """
         super().__init__()
         self._is_fitted = True
@@ -89,6 +91,7 @@ class TotalVarMin(Preprocessor):
         self.solver = solver
         self.max_iter = max_iter
         self.clip_values = clip_values
+        self.verbose = verbose
         self._check_params()
 
     @property
@@ -114,7 +117,7 @@ class TotalVarMin(Preprocessor):
         x_preproc = x.copy()
 
         # Minimize one input at a time
-        for i, x_i in enumerate(tqdm(x_preproc, desc="Variance minimization")):
+        for i, x_i in enumerate(tqdm(x_preproc, desc="Variance minimization", disable=not self.verbose)):
             mask = (np.random.rand(*x_i.shape) < self.prob).astype("int")
             x_preproc[i] = self._minimize(x_i, mask)
 
@@ -242,3 +245,6 @@ class TotalVarMin(Preprocessor):
 
             if np.array(self.clip_values[0] >= self.clip_values[1]).any():
                 raise ValueError("Invalid `clip_values`: min >= max.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/defences/preprocessor/video_compression.py
+++ b/art/defences/preprocessor/video_compression.py
@@ -45,7 +45,7 @@ class VideoCompression(Preprocessor):
     parameter. More information on the constant rate factor: https://trac.ffmpeg.org/wiki/Encode/H.264.
     """
 
-    params = ["video_format", "constant_rate_factor", "channels_first"]
+    params = ["video_format", "constant_rate_factor", "channels_first", "verbose"]
 
     def __init__(
         self,
@@ -55,6 +55,7 @@ class VideoCompression(Preprocessor):
         channels_first: bool = False,
         apply_fit: bool = False,
         apply_predict: bool = True,
+        verbose: bool = False,
     ):
         """
         Create an instance of VideoCompression.
@@ -64,6 +65,7 @@ class VideoCompression(Preprocessor):
         :param channels_first: Set channels first or last.
         :param apply_fit: True if applied during fitting/training.
         :param apply_predict: True if applied during predicting.
+        :param verbose: Show progress bars.
         """
         super().__init__()
         self._is_fitted = True
@@ -72,6 +74,7 @@ class VideoCompression(Preprocessor):
         self.video_format = video_format
         self.constant_rate_factor = constant_rate_factor
         self.channels_first = channels_first
+        self.verbose = verbose
         self._check_params()
 
     @property
@@ -128,7 +131,7 @@ class VideoCompression(Preprocessor):
         # apply video compression per video item
         x_compressed = x.copy()
         with TemporaryDirectory(dir=ART_DATA_PATH) as tmp_dir:
-            for i, x_i in enumerate(tqdm(x, desc="Video compression")):
+            for i, x_i in enumerate(tqdm(x, desc="Video compression", disable=not self.verbose)):
                 x_compressed[i] = compress_video(x_i, self.video_format, self.constant_rate_factor, dir_=tmp_dir)
 
         if self.channels_first:
@@ -148,3 +151,6 @@ class VideoCompression(Preprocessor):
     def _check_params(self) -> None:
         if not (isinstance(self.constant_rate_factor, (int, np.int)) and 0 <= self.constant_rate_factor < 52):
             raise ValueError("Constant rate factor must be an integer in the range [0, 51].")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/estimators/speech_recognition/pytorch_deep_speech.py
+++ b/art/estimators/speech_recognition/pytorch_deep_speech.py
@@ -251,11 +251,7 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
                 enabled = True
 
             self._model, self._optimizer = amp.initialize(
-                models=self._model,
-                optimizers=self._optimizer,
-                enabled=enabled,
-                opt_level=opt_level,
-                loss_scale=1.0,
+                models=self._model, optimizers=self._optimizer, enabled=enabled, opt_level=opt_level, loss_scale=1.0,
             )
 
     def predict(
@@ -462,9 +458,9 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
 
                 # Extract random batch
                 i_batch = np.array(
-                    [x_i for x_i in x_preprocessed[ind[begin : end]]] + [np.array([0.1]), np.array([0.1, 0.2])]
+                    [x_i for x_i in x_preprocessed[ind[begin:end]]] + [np.array([0.1]), np.array([0.1, 0.2])]
                 )[:-2]
-                o_batch = y_preprocessed[ind[begin : end]]
+                o_batch = y_preprocessed[ind[begin:end]]
 
                 # Transform data into the model input space
                 inputs, targets, input_rates, target_sizes, batch_idx = self.transform_model_input(


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds the argument `verbose` to all attacks and defences to define amount of verbose output.

Fixes #640 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
