### PR TITLE
Unify prediction of object detectors

### DIFF
--- a/art/estimators/object_detection/pytorch_faster_rcnn.py
+++ b/art/estimators/object_detection/pytorch_faster_rcnn.py
@@ -208,19 +208,19 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
 
         return grads
 
-    def predict(self, x: np.ndarray, batch_size: int = 128, **kwargs) -> List[Dict[str, "torch.Tensor"]]:
+    def predict(self, x: np.ndarray, batch_size: int = 128, **kwargs) -> List[Dict[str, np.ndarray]]:
         """
         Perform prediction for a batch of inputs.
 
         :param x: Samples of shape (nb_samples, height, width, nb_channels).
         :param batch_size: Batch size.
-        :return: Predictions of format `List[Dict[str, Tensor]]`, one for each input image. The
+        :return: Predictions of format `List[Dict[str, np.ndarray]]`, one for each input image. The
                  fields of the Dict are as follows:
 
-                 - boxes (FloatTensor[N, 4]): the predicted boxes in [x1, y1, x2, y2] format, with values \
+                 - boxes [N, 4]: the predicted boxes in [x1, y1, x2, y2] format, with values \
                    between 0 and H and 0 and W
-                 - labels (Int64Tensor[N]): the predicted labels for each image
-                 - scores (Tensor[N]): the scores or each prediction.
+                 - labels [N]: the predicted labels for each image
+                 - scores [N]: the scores or each prediction.
         """
         import torchvision  # lgtm [py/repeated-import]
 
@@ -239,6 +239,12 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
         for i in range(x.shape[0]):
             image_tensor_list.append(transform(x[i] / norm_factor).to(self._device))
         predictions = self._model(image_tensor_list)
+
+        for i_prediction in range(len(predictions)):
+            predictions[i_prediction]["boxes"] = predictions[i_prediction]["boxes"].detach().cpu().numpy()
+            predictions[i_prediction]["labels"] = predictions[i_prediction]["labels"].detach().cpu().numpy()
+            predictions[i_prediction]["scores"] = predictions[i_prediction]["scores"].detach().cpu().numpy()
+
         return predictions
 
     def fit(self, x: np.ndarray, y, batch_size: int = 128, nb_epochs: int = 20, **kwargs) -> None:

--- a/examples/application_object_detection.py
+++ b/examples/application_object_detection.py
@@ -2,7 +2,7 @@ import cv2
 import numpy as np
 import matplotlib.pyplot as plt
 
-from art.estimators.object_detection.PyTorchFasterRCNN import PyTorchFasterRCNN
+from art.estimators.object_detection import PyTorchFasterRCNN
 from art.attacks.evasion import FastGradientMethod
 
 COCO_INSTANCE_CATEGORY_NAMES = [
@@ -101,19 +101,15 @@ COCO_INSTANCE_CATEGORY_NAMES = [
 
 
 def extract_predictions(predictions_):
-
-    # for key, item in predictions[0].items():
-    #     print(key, item)
-
     # Get the predicted class
-    predictions_class = [COCO_INSTANCE_CATEGORY_NAMES[i] for i in list(predictions_["labels"].numpy())]
+    predictions_class = [COCO_INSTANCE_CATEGORY_NAMES[i] for i in list(predictions_["labels"])]
     print("\npredicted classes:", predictions_class)
 
     # Get the predicted bounding boxes
-    predictions_boxes = [[(i[0], i[1]), (i[2], i[3])] for i in list(predictions_["boxes"].detach().numpy())]
+    predictions_boxes = [[(i[0], i[1]), (i[2], i[3])] for i in list(predictions_["boxes"])]
 
     # Get the predicted prediction score
-    predictions_score = list(predictions_["scores"].detach().numpy())
+    predictions_score = list(predictions_["scores"])
     print("predicted score:", predictions_score)
 
     # Get a list of index with score greater than threshold


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

Update the return of method `predict` in `art.estimators.object_detection` to adhere to common label format.

This pull request also makes modification to enable the combination of `ProjectedGradientDescent` and `TensorFlowFasterRCNN`.

Fixes #655

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
