### PR TITLE
enable PGD masks for non-classification tasks

### DIFF
--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
@@ -168,13 +168,9 @@ class ProjectedGradientDescentCommon(FastGradientMethod):
         mask = kwargs.get("mask")
 
         if mask is not None:
-            if classifier_mixin:
-                # Ensure the mask is broadcastable
-                if len(mask.shape) > len(x.shape) or mask.shape != x.shape[-len(mask.shape) :]:
-                    raise ValueError("Mask shape must be broadcastable to input shape.")
-
-            else:
-                raise ValueError("Mask is only supported for classification.")
+            # Ensure the mask is broadcastable
+            if len(mask.shape) > len(x.shape) or mask.shape != x.shape[-len(mask.shape) :]:
+                raise ValueError("Mask shape must be broadcastable to input shape.")
 
         return mask
 

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
@@ -153,12 +153,11 @@ class ProjectedGradientDescentCommon(FastGradientMethod):
         return targets
 
     @staticmethod
-    def _get_mask(x: np.ndarray, classifier_mixin: bool = True, **kwargs) -> np.ndarray:
+    def _get_mask(x: np.ndarray, **kwargs) -> np.ndarray:
         """
         Get the mask from the kwargs.
 
         :param x: An array with the original inputs.
-        :param classifier_mixin: Whether the estimator is of type `ClassifierMixin`.
         :param mask: An array with a mask to be applied to the adversarial perturbations. Shape needs to be
                      broadcastable to the shape of x. Any features for which the mask is zero will not be adversarially
                      perturbed.
@@ -313,7 +312,7 @@ class ProjectedGradientDescentNumpy(ProjectedGradientDescentCommon):
             targets = self._set_targets(x, y, classifier_mixin=False)
 
             # Get the mask
-            mask = self._get_mask(x, classifier_mixin=False, **kwargs)
+            mask = self._get_mask(x, **kwargs)
 
             # Start to compute adversarial examples
             if x.dtype == np.object:


### PR DESCRIPTION
Signed-off-by: Mathieu Sinn <mathsinn@ie.ibm.com>

# Description

Disabled error that was thrown when providing masks to PGD attacks for non-classification estimators.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Local tests

**Test Configuration**:
- MacOS
- Python version 3.7
- ART version or commit number 1.4.1
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
