### PR TITLE
Add support for variable length input to MP3Compression

### DIFF
--- a/art/defences/preprocessor/mp3_compression.py
+++ b/art/defences/preprocessor/mp3_compression.py
@@ -140,18 +140,26 @@ class Mp3Compression(Preprocessor):
                 x_mp3 = x_mp3 * 2 ** -15
             return x_mp3
 
-        if x.ndim != 3:
+        if x.dtype != np.object and x.ndim != 3:
             raise ValueError("Mp3 compression can only be applied to temporal data across at least one channel.")
 
-        if self.channels_first:
+        if x.dtype != np.object and self.channels_first:
             x = np.swapaxes(x, 1, 2)
 
         # apply mp3 compression per audio item
         x_mp3 = x.copy()
         for i, x_i in enumerate(tqdm(x, desc="MP3 compression", disable=not self.verbose)):
-            x_mp3[i] = wav_to_mp3(x_i, self.sample_rate)
+            if x.dtype == np.object and x_i.ndim == 1:
+                x_i = np.expand_dims(x_i, axis=1)
 
-        if self.channels_first:
+            x_i = wav_to_mp3(x_i, self.sample_rate)
+
+            if x.dtype == np.object:
+                x_i = np.squeeze(x_i)
+
+            x_mp3[i] = x_i
+
+        if x.dtype != np.object and self.channels_first:
             x_mp3 = np.swapaxes(x_mp3, 1, 2)
 
         return x_mp3, y

--- a/art/defences/preprocessor/mp3_compression.py
+++ b/art/defences/preprocessor/mp3_compression.py
@@ -96,8 +96,8 @@ class Mp3Compression(Preprocessor):
         """
         Apply MP3 compression to sample `x`.
 
-        :param x: Sample to compress with shape `(batch_size, length, channel)`. `x` values are recommended to be of
-                  type `np.int16`.
+        :param x: Sample to compress with shape `(batch_size, length, channel)` or an array of sample arrays with shape
+                  (length,) or (length, channel). `x` values are recommended to be of type `np.int16`.
         :param y: Labels of the sample `x`. This function does not affect them in any way.
         :return: Compressed sample.
         """

--- a/art/defences/preprocessor/mp3_compression.py
+++ b/art/defences/preprocessor/mp3_compression.py
@@ -149,13 +149,22 @@ class Mp3Compression(Preprocessor):
         # apply mp3 compression per audio item
         x_mp3 = x.copy()
         for i, x_i in enumerate(tqdm(x, desc="MP3 compression", disable=not self.verbose)):
-            if x.dtype == np.object and x_i.ndim == 1:
-                x_i = np.expand_dims(x_i, axis=1)
+            x_i_ndim_0 = x_i.ndim
+            if x.dtype == np.object:
+                if x_i.ndim == 1:
+                    x_i = np.expand_dims(x_i, axis=1)
+
+                if x_i_ndim_0 == 2 and self.channels_first:
+                    x_i = np.swapaxes(x_i, 0, 1)
 
             x_i = wav_to_mp3(x_i, self.sample_rate)
 
             if x.dtype == np.object:
-                x_i = np.squeeze(x_i)
+                if x_i_ndim_0 == 2 and self.channels_first:
+                    x_i = np.swapaxes(x_i, 0, 1)
+
+                if x_i_ndim_0 == 1:
+                    x_i = np.squeeze(x_i)
 
             x_mp3[i] = x_i
 


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds support for variable length input to `MP3Compression` and makes it compatible with estimator `PyTorchDeepSpeech`.

Fixes #680

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
