### PR TITLE
Update AutoProjectedGradientDescent

### DIFF
--- a/art/attacks/evasion/auto_projected_gradient_descent.py
+++ b/art/attacks/evasion/auto_projected_gradient_descent.py
@@ -96,7 +96,9 @@ class AutoProjectedGradientDescent(EvasionAttack):
             )
 
         if loss_type is None:
-            if is_probability(estimator.predict(x=np.ones(shape=(1, *estimator.input_shape), dtype=np.float32))):
+            if hasattr(estimator, "predict") and is_probability(
+                estimator.predict(x=np.ones(shape=(1, *estimator.input_shape), dtype=np.float32))
+            ):
                 raise ValueError(
                     "AutoProjectedGradientDescent is expecting logits as estimator output, the provided "
                     "estimator seems to predict probabilities."

--- a/art/attacks/evasion/auto_projected_gradient_descent.py
+++ b/art/attacks/evasion/auto_projected_gradient_descent.py
@@ -138,7 +138,8 @@ class AutoProjectedGradientDescent(EvasionAttack):
                         #     # Not completely sure if the following line is correct.
                         #     # `i_y_pred_arg[:, -2], i_y_pred_arg[:, -1]` seems closer to the output of `loss_fn` than
                         #     # `i_y_pred_arg[:, -1], i_y_pred_arg[:, -2]`
-                        #     i_z_i = tf.where(i_y_pred_arg[:, -1] != i_y_true[:], i_y_pred_arg[:, -2], i_y_pred_arg[:, -1])
+                        #     i_z_i = tf.where(i_y_pred_arg[:, -1] != i_y_true[:], i_y_pred_arg[:, -2],
+                        #                      i_y_pred_arg[:, -1])
                         #
                         #     z_1 = tf.gather(y_pred, i_y_pred_arg[:, -1], axis=1, batch_dims=0)
                         #     z_3 = tf.gather(y_pred, i_y_pred_arg[:, -3], axis=1, batch_dims=0)
@@ -157,7 +158,8 @@ class AutoProjectedGradientDescent(EvasionAttack):
                         # def loss_fn(y_true, y_pred):
                         #     i_y_true = np.argmax(y_true, axis=1)
                         #     i_y_pred_arg = np.argsort(y_pred, axis=1)
-                        #     i_z_i = np.where(i_y_pred_arg[:, -1] != i_y_true[:], i_y_pred_arg[:, -1], i_y_pred_arg[:, -2])
+                        #     i_z_i = np.where(i_y_pred_arg[:, -1] != i_y_true[:], i_y_pred_arg[:, -1],
+                        #                      i_y_pred_arg[:, -2])
                         #
                         #     z_1 = y_pred[:, i_y_pred_arg[:, -1]]
                         #     z_3 = y_pred[:, i_y_pred_arg[:, -3]]
@@ -174,7 +176,8 @@ class AutoProjectedGradientDescent(EvasionAttack):
                         #     return np.mean(dlr)
                         #
                         # self._loss_fn = loss_fn
-                        # self._loss_object = difference_logits_ratio(y_true=estimator._labels_ph, y_pred=estimator._output)
+                        # self._loss_object = difference_logits_ratio(y_true=estimator._labels_ph,
+                        #                                             y_pred=estimator._output)
 
                 estimator_apgd = TensorFlowClassifier(
                     input_ph=estimator._input_ph,

--- a/art/attacks/evasion/auto_projected_gradient_descent.py
+++ b/art/attacks/evasion/auto_projected_gradient_descent.py
@@ -126,7 +126,7 @@ class AutoProjectedGradientDescent(EvasionAttack):
                     else:
 
                         raise ValueError(
-                            "The loss `difference_logits_ratio` has not been validate completely. It seems that "
+                            "The loss `difference_logits_ratio` has not been validate completely. It seems that the "
                             "commented implemented below is failing to selected the second largest logit for cases "
                             "where the largest logit is the true logit. For future work `difference_logits_ratio` and "
                             "loss_fn should return the same loss value."

--- a/art/estimators/classification/keras.py
+++ b/art/estimators/classification/keras.py
@@ -300,7 +300,7 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
         # Get the internal layer
         self._layer_names = self._get_layers()
 
-    def loss(self, x: np.ndarray, y: np.ndarray, **kwargs) -> np.ndarray:
+    def loss(self, x: np.ndarray, y: np.ndarray, reduction: str = "none", **kwargs) -> np.ndarray:
         """
         Compute the loss of the neural network for samples `x`.
 
@@ -308,6 +308,10 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
                   nb_channels) or (nb_samples, nb_channels, nb_pixels_1, nb_pixels_2).
         :param y: Target values (class labels) one-hot-encoded of shape `(nb_samples, nb_classes)` or indices
                   of shape `(nb_samples,)`.
+        :param reduction: Specifies the reduction to apply to the output: 'none' | 'mean' | 'sum'.
+                   'none': no reduction will be applied
+                   'mean': the sum of the output will be divided by the number of elements in the output,
+                   'sum': the output will be summed.
         :return: Loss values.
         :rtype: Format as expected by the `model`
         """
@@ -323,8 +327,8 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
         shape_match = [i is None or i == j for i, j in zip(self._input_shape, x_preprocessed.shape[1:])]
         if not all(shape_match):
             raise ValueError(
-                "Error when checking x: expected preprocessed x to have shape {} but got array with shape {"
-                "}".format(self._input_shape, x_preprocessed.shape[1:])
+                "Error when checking x: expected preprocessed x to have shape {} but got array with "
+                "shape {}.".format(self._input_shape, x_preprocessed.shape[1:])
             )
 
         # Adjust the shape of y for loss functions that do not take labels in one-hot encoding
@@ -349,7 +353,16 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
             for i, loss_function in enumerate(self._model.loss_functions):
                 loss_function.reduction = prev_reduction[i]
 
-        return k.eval(loss)
+        loss_value = k.eval(loss)
+
+        if reduction == "none":
+            loss_value = loss_value
+        elif reduction == "mean":
+            loss_value = np.mean(loss_value, axis=0)
+        elif reduction == "sum":
+            loss_value = np.sum(loss_value, axis=0)
+
+        return loss_value
 
     def loss_gradient(self, x: np.ndarray, y: np.ndarray, **kwargs) -> np.ndarray:
         """

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -396,13 +396,17 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
 
         return grads
 
-    def loss(self, x: np.ndarray, y: np.ndarray, **kwargs) -> np.ndarray:
+    def loss(self, x: np.ndarray, y: np.ndarray, reduction: str = "none", **kwargs) -> np.ndarray:
         """
         Compute the loss function w.r.t. `x`.
 
         :param x: Sample input with shape as expected by the model.
         :param y: Target values (class labels) one-hot-encoded of shape `(nb_samples, nb_classes)` or indices
                   of shape `(nb_samples,)`.
+        :param reduction: Specifies the reduction to apply to the output: 'none' | 'mean' | 'sum'.
+                   'none': no reduction will be applied
+                   'mean': the sum of the output will be divided by the number of elements in the output,
+                   'sum': the output will be summed.
         :return: Array of losses of the same shape as `x`.
         """
         import torch  # lgtm [py/repeated-import]
@@ -422,8 +426,9 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         # Compute the loss and return
         model_outputs = self._model(inputs_t)
         prev_reduction = self._loss.reduction
-        # return individual loss values
-        self._loss.reduction = "none"
+
+        # Return individual loss values
+        self._loss.reduction = reduction
         loss = self._loss(model_outputs[-1], labels_t)
         self._loss.reduction = prev_reduction
         return loss.detach().numpy()


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request provides updates for `AutoProjectedGradientDescent`. It extends `AutoProjectedGradientDescent` to run with estimators of all frameworks using the estimator's loss function requiring the estimator to predict logits and provide loss gradients. It updates `AutoProjectedGradientDescent` to use the new method `loss` of the Estimator API replacing custom functions in `AutoProjectedGradientDescent` and implements method `loss` for `TensorFlowClassifer`. It disables the loss type `difference_logits_ratio` for `TensorFlowClassifer`, for now until a suspected bug in that loss function has been fixed, by commenting the implementation as it seems to fail to select the second largest logit for cases where the largest logit is the true logit which occurs in small number of predictions, this only affects `AutoProjectedGradientDescent` with `TensorFlowClassifer`.)

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
