### PR TITLE
Change default return of PyTorchDeepSpeech.predict

### DIFF
--- a/art/estimators/speech_recognition/pytorch_deep_speech.py
+++ b/art/estimators/speech_recognition/pytorch_deep_speech.py
@@ -411,6 +411,10 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
 
         results = self._apply_preprocessing_gradient(x_, results)
 
+        if x.dtype != np.object:
+            results = np.array([i for i in results], dtype=x.dtype)
+            assert results.shape == x.shape and results.dtype == x.dtype
+
         return results
 
     def fit(self, x: np.ndarray, y: np.ndarray, batch_size: int = 128, nb_epochs: int = 10, **kwargs) -> None:

--- a/art/estimators/speech_recognition/pytorch_deep_speech.py
+++ b/art/estimators/speech_recognition/pytorch_deep_speech.py
@@ -266,8 +266,8 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
                                      prediction output. If transcription_output is not available, then probability
                                      output is returned.
         :type transcription_output: `bool`
-        :return: Probability (if transcription_output is None or False) or transcription (if transcription_output is
-                 True) predictions:
+        :return: Predicted probability (if transcription_output False) or transcription (default, if
+                 transcription_output is True or None):
                  - Probability return is a tuple of (probs, sizes), where `probs` is the probability of characters of
                  shape (nb_samples, seq_length, nb_classes) and `sizes` is the real sequence length of shape
                  (nb_samples,).
@@ -335,7 +335,7 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
         # Check if users want transcription outputs
         transcription_output = kwargs.get("transcription_output")
 
-        if transcription_output is None or transcription_output is False:
+        if transcription_output is False:
             return result_outputs, result_output_sizes
 
         # Now users want transcription outputs


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request changes the default return format of method `predict` in `PyTorchDeepSpeech` from a Tuple of probabilities and sequence lengths to an array of transcriptions (array of predicted strings). This change aligns `PyTorchDeepSpeech` with the other ART estimators to predict by default in the same format as it accepts as input. This change also enables using `PyTorchDeepSpeech` with `ProjectedGradientDescent` and `FastGradientMethod` in cases where no labels are provided to their method `generate` and these attacks use the labels predicted by `PyTorchDeepSpeech` 's method `predict`.

Fixes #688

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
