### PR TITLE
Avoid using deprecated Numpy methods to create object array 

### DIFF
--- a/art/estimators/speech_recognition/pytorch_deep_speech.py
+++ b/art/estimators/speech_recognition/pytorch_deep_speech.py
@@ -276,7 +276,8 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
         """
         import torch  # lgtm [py/repeated-import]
 
-        x_ = np.array([x_i for x_i in x] + [np.array([0.1]), np.array([0.1, 0.2])])[:-2]
+        x_ = np.empty(len(x), dtype=object)
+        x_[:] = x
 
         # Put the model in the eval mode
         self._model.eval()
@@ -361,7 +362,8 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
         """
         from warpctc_pytorch import CTCLoss
 
-        x_ = np.array([x_i for x_i in x] + [np.array([0.1]), np.array([0.1, 0.2])])[:-2]
+        x_ = np.empty(len(x), dtype=object)
+        x_[:] = x
 
         # Put the model in the training mode
         self._model.train()
@@ -405,9 +407,9 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
         results = np.array(results)
 
         if results.shape[0] == 1:
-            results = np.array(
-                [results_i for results_i in results] + [np.array([0.1]), np.array([0.1, 0.2])], dtype="object"
-            )[:-2]
+            results_ = np.empty(len(results), dtype=object)
+            results_[:] = results
+            results = results_
 
         results = self._apply_preprocessing_gradient(x_, results)
 
@@ -465,9 +467,8 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
                 )
 
                 # Extract random batch
-                i_batch = np.array(
-                    [x_i for x_i in x_preprocessed[ind[begin:end]]] + [np.array([0.1]), np.array([0.1, 0.2])]
-                )[:-2]
+                i_batch = np.empty(len(x_preprocessed[ind[begin:end]]), dtype=object)
+                i_batch[:] = x_preprocessed[ind[begin:end]]
                 o_batch = y_preprocessed[ind[begin:end]]
 
                 # Transform data into the model input space

--- a/art/estimators/speech_recognition/pytorch_deep_speech.py
+++ b/art/estimators/speech_recognition/pytorch_deep_speech.py
@@ -277,7 +277,7 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
         import torch  # lgtm [py/repeated-import]
 
         x_ = np.empty(len(x), dtype=object)
-        x_[:] = x
+        x_[:] = list(x)
 
         # Put the model in the eval mode
         self._model.eval()
@@ -363,7 +363,7 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
         from warpctc_pytorch import CTCLoss
 
         x_ = np.empty(len(x), dtype=object)
-        x_[:] = x
+        x_[:] = list(x)
 
         # Put the model in the training mode
         self._model.train()
@@ -408,7 +408,7 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
 
         if results.shape[0] == 1:
             results_ = np.empty(len(results), dtype=object)
-            results_[:] = results
+            results_[:] = list(results)
             results = results_
 
         results = self._apply_preprocessing_gradient(x_, results)
@@ -468,7 +468,7 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
 
                 # Extract random batch
                 i_batch = np.empty(len(x_preprocessed[ind[begin:end]]), dtype=object)
-                i_batch[:] = x_preprocessed[ind[begin:end]]
+                i_batch[:] = list(x_preprocessed[ind[begin:end]])
                 o_batch = y_preprocessed[ind[begin:end]]
 
                 # Transform data into the model input space


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request avoids using deprecated Numpy methods to create object arrays from ragged sequences.

Fixes #694

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
