### PR TITLE
Add progress bar to art.utils.get_file

### DIFF
--- a/art/estimators/speech_recognition/pytorch_deep_speech.py
+++ b/art/estimators/speech_recognition/pytorch_deep_speech.py
@@ -75,6 +75,7 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
         preprocessing: "PREPROCESSING_TYPE" = None,
         device_type: str = "gpu",
+        verbose: bool = True,
     ):
         """
         Initialization of an instance PyTorchDeepSpeech.
@@ -136,6 +137,8 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
             preprocessing=preprocessing,
         )
 
+        self.verbose = verbose
+
         # Check clip values
         if self.clip_values is not None:
             if not np.all(self.clip_values[0] == -1):
@@ -190,7 +193,7 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
                 raise ValueError("The input pretrained model %s is not supported." % pretrained_model)
 
             # Download model
-            model_path = get_file(filename=filename, path=ART_DATA_PATH, url=url, extract=False)
+            model_path = get_file(filename=filename, path=ART_DATA_PATH, url=url, extract=False, verbose=self.verbose)
 
             # Then load model
             self._model = load_model(device=self._device, model_path=model_path, use_half=use_half)

--- a/art/utils.py
+++ b/art/utils.py
@@ -1001,6 +1001,7 @@ def get_file(filename: str, url: str, path: Optional[str] = None, extract: bool 
                 if verbose:
                     with tqdm() as t:
                         last_block = [0]
+
                         def progress_bar(blocks: int = 1, block_size: int = 1, total_size: Optional[int] = None):
                             """
                             :param blocks: Number of blocks transferred so far [default: 1].

--- a/art/utils.py
+++ b/art/utils.py
@@ -35,6 +35,7 @@ import zipfile
 import numpy as np
 from scipy.special import gammainc
 import six
+from tqdm import tqdm
 
 from art.config import ART_DATA_PATH, ART_NUMPY_DTYPE
 
@@ -949,7 +950,7 @@ def _extract(full_path: str, path: str) -> bool:
     return True
 
 
-def get_file(filename: str, url: str, path: Optional[str] = None, extract: bool = False) -> str:
+def get_file(filename: str, url: str, path: Optional[str] = None, extract: bool = False, verbose: bool = False) -> str:
     """
     Downloads a file from a URL if it not already in the cache. The file at indicated by `url` is downloaded to the
     path `path` (default is ~/.art/data). and given the name `filename`. Files in tar, tar.gz, tar.bz, and zip formats
@@ -959,6 +960,7 @@ def get_file(filename: str, url: str, path: Optional[str] = None, extract: bool 
     :param url: Download URL.
     :param path: Folder to store the download. If not specified, `~/.art/data` is used instead.
     :param extract: If true, tries to extract the archive.
+    :param verbose: If true, print download progress bar.
     :return: Path to the downloaded file.
     """
     if path is None:
@@ -983,7 +985,7 @@ def get_file(filename: str, url: str, path: Optional[str] = None, extract: bool 
     download = not os.path.exists(full_path)
 
     if download:
-        logger.info("Downloading data from %s", url)
+        #         logger.info("Downloading data from %s", url)
         error_msg = "URL fetch failure on {}: {} -- {}"
         try:
             try:
@@ -996,7 +998,25 @@ def get_file(filename: str, url: str, path: Optional[str] = None, extract: bool 
 
                 ssl._create_default_https_context = ssl._create_unverified_context
 
-                urlretrieve(url, full_path)
+                if verbose:
+                    with tqdm() as t:
+                        last_block = [0]
+                        def progress_bar(blocks: int = 1, block_size: int = 1, total_size: Optional[int] = None):
+                            """
+                            :param blocks: Number of blocks transferred so far [default: 1].
+                            :param block_size: Size of each block (in tqdm units) [default: 1].
+                            :param total_size: Total size (in tqdm units). If [default: None] or -1, remains unchanged.
+                            """
+                            if total_size not in (None, -1):
+                                t.total = total_size
+                            displayed = t.update((blocks - last_block[0]) * block_size)
+                            last_block[0] = blocks
+                            return displayed
+
+                        urlretrieve(url, full_path, reporthook=progress_bar)
+                else:
+                    urlretrieve(url, full_path)
+
             except HTTPError as exception:
                 raise Exception(error_msg.format(url, exception.code, exception.msg)) from HTTPError  # type: ignore
             except URLError as exception:

--- a/art/utils.py
+++ b/art/utils.py
@@ -985,7 +985,7 @@ def get_file(filename: str, url: str, path: Optional[str] = None, extract: bool 
     download = not os.path.exists(full_path)
 
     if download:
-        #         logger.info("Downloading data from %s", url)
+        logger.info("Downloading data from %s", url)
         error_msg = "URL fetch failure on {}: {} -- {}"
         try:
             try:

--- a/tests/attacks/evasion/test_auto_attack.py
+++ b/tests/attacks/evasion/test_auto_attack.py
@@ -41,7 +41,7 @@ def fix_get_mnist_subset(get_mnist_dataset):
     yield x_train_mnist[:n_train], y_train_mnist[:n_train], x_test_mnist[:n_test], y_test_mnist[:n_test]
 
 
-@pytest.mark.framework_agnostic
+@pytest.mark.skipMlFramework("tensorflow1", "keras", "pytorch", "non_dl_frameworks", "mxnet", "kerastf")
 def test_generate_default(art_warning, fix_get_mnist_subset, image_dl_estimator):
     try:
         classifier, _ = image_dl_estimator(from_logits=True)
@@ -60,7 +60,7 @@ def test_generate_default(art_warning, fix_get_mnist_subset, image_dl_estimator)
         art_warning(e)
 
 
-@pytest.mark.framework_agnostic
+@pytest.mark.skipMlFramework("tensorflow1", "keras", "pytorch", "non_dl_frameworks", "mxnet", "kerastf")
 def test_generate_attacks_and_targeted(art_warning, fix_get_mnist_subset, image_dl_estimator):
     try:
         classifier, _ = image_dl_estimator(from_logits=True)

--- a/tests/attacks/evasion/test_auto_projected_gradient_descent.py
+++ b/tests/attacks/evasion/test_auto_projected_gradient_descent.py
@@ -38,7 +38,6 @@ def fix_get_mnist_subset(get_mnist_dataset):
     yield x_train_mnist[:n_train], y_train_mnist[:n_train], x_test_mnist[:n_test], y_test_mnist[:n_test]
 
 
-@pytest.mark.framework_agnostic
 @pytest.mark.skipMlFramework("tensorflow1", "keras", "pytorch", "non_dl_frameworks", "mxnet", "kerastf")
 def test_generate(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:


### PR DESCRIPTION
# Description

This pull request adds an optional (verbose mode) progress bar  to `art.utils.get_file` which is frequently used to download large model files by model-specific estimators. With this update users of model-specific estimators will get updates about the download progress when creating such an estimator.

Fixes #692

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
