### PR TITLE
Add support for multi-channel images to JpegCompression

### DIFF
--- a/art/defences/preprocessor/jpeg_compression.py
+++ b/art/defences/preprocessor/jpeg_compression.py
@@ -47,6 +47,10 @@ class JpegCompression(Preprocessor):
     """
     Implement the JPEG compression defence approach.
 
+    For input images or videos with 3 color channels the compression is applied in mode `RGB`
+    (3x8-bit pixels, true color), for all other numbers of channels the compression is applied for each channel with
+    mode `L` (8-bit pixels, black and white).
+
     | Paper link: https://arxiv.org/abs/1705.02900, https://arxiv.org/abs/1608.00853
 
 
@@ -124,6 +128,10 @@ class JpegCompression(Preprocessor):
     def __call__(self, x: np.ndarray, y: Optional[np.ndarray] = None) -> Tuple[np.ndarray, Optional[np.ndarray]]:
         """
         Apply JPEG compression to sample `x`.
+
+        For input images or videos with 3 color channels the compression is applied in mode `RGB`
+        (3x8-bit pixels, true color), for all other numbers of channels the compression is applied for each channel with
+        mode `L` (8-bit pixels, black and white).
 
         :param x: Sample to compress with shape of `NCHW`, `NHWC`, `NCFHW` or `NFHWC`. `x` values are expected to be in
                   the data range [0, 1] or [0, 255].

--- a/tests/defences/preprocessor/test_jpeg_compression.py
+++ b/tests/defences/preprocessor/test_jpeg_compression.py
@@ -103,6 +103,8 @@ def test_jpeg_compression_video_data(art_warning, video_batch, channels_first):
 def test_jpeg_compress(art_warning, image_batch, channels_first):
     try:
         test_input, test_output = image_batch
+        # Run only for grayscale [1] and RGB [3] data because testing `_compress` which is applied internally only to
+        # either grayscale or RGB data.
         if test_input.shape[-1] in [1, 3]:
             jpeg_compression = JpegCompression(clip_values=(0, 255))
 

--- a/tests/defences/preprocessor/test_jpeg_compression.py
+++ b/tests/defences/preprocessor/test_jpeg_compression.py
@@ -50,7 +50,7 @@ class DataGenerator:
         return (255 * np.ones(data_shape)).astype(ART_NUMPY_DTYPE)
 
 
-@pytest.fixture(params=[1, 3], ids=["grayscale", "RGB"])
+@pytest.fixture(params=[1, 2, 3, 5], ids=["grayscale", "grayscale-2", "RGB", "grayscale-5"])
 def image_batch(request, channels_first):
     """
     Image fixtures of shape NHWC and NCHW.
@@ -62,7 +62,7 @@ def image_batch(request, channels_first):
     return test_input, test_output
 
 
-@pytest.fixture(params=[1, 3], ids=["grayscale", "RGB"])
+@pytest.fixture(params=[1, 2, 3, 5], ids=["grayscale", "grayscale-2", "RGB", "grayscale-5"])
 def video_batch(request, channels_first):
     """
     Video fixtures of shape NFHWC and NCFHW.
@@ -103,13 +103,14 @@ def test_jpeg_compression_video_data(art_warning, video_batch, channels_first):
 def test_jpeg_compress(art_warning, image_batch, channels_first):
     try:
         test_input, test_output = image_batch
-        jpeg_compression = JpegCompression(clip_values=(0, 255))
+        if test_input.shape[-1] in [1, 3]:
+            jpeg_compression = JpegCompression(clip_values=(0, 255))
 
-        image_mode = "RGB" if test_input.shape[-1] == 3 else "L"
-        test_single_input = np.squeeze(test_input[0]).astype(np.uint8)
-        test_single_output = np.squeeze(test_output[0]).astype(np.uint8)
+            image_mode = "RGB" if test_input.shape[-1] == 3 else "L"
+            test_single_input = np.squeeze(test_input[0]).astype(np.uint8)
+            test_single_output = np.squeeze(test_output[0]).astype(np.uint8)
 
-        assert_array_equal(jpeg_compression._compress(test_single_input, image_mode), test_single_output)
+            assert_array_equal(jpeg_compression._compress(test_single_input, image_mode), test_single_output)
     except ARTTestException as e:
         art_warning(e)
 


### PR DESCRIPTION
# Description

This pull request add support for multi-channel images to `JpegCompression`.

Fixes #673 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
