### PR TITLE
 Mask for AutoAttack, APGD, DPatch, and AdversarialPatch*

### DIFF
--- a/art/attacks/evasion/adversarial_patch/adversarial_patch.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch.py
@@ -127,6 +127,10 @@ class AdversarialPatch(EvasionAttack):
 
         :param x: An array with the original input images of shape NHWC or NCHW or input videos of shape NFHWC or NFCHW.
         :param y: An array with the original true labels.
+        :param mask: An boolean array of shape equal to the shape of a single samples (1, H, W) or the shape of `x`
+                     (N, H, W) without their channel dimensions. Any features for which the mask is True can be the
+                     center location of the patch during sampling.
+        :type mask: `np.ndarray`
         :return: An array with adversarial patch and an array of the patch mask.
         """
         logger.info("Creating adversarial patch.")

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
@@ -163,9 +163,8 @@ class AdversarialPatchNumpy(EvasionAttack):
         logger.info("Creating adversarial patch.")
 
         mask = kwargs.get("mask")
-        if (
-            mask is not None
-            and (mask.dtype != np.bool)
+        if mask is not None and (
+            (mask.dtype != np.bool)
             or not (mask.shape[0] == 1 or mask.shape[0] == x.shape[0])
             or not (
                 (mask.shape[1] == x.shape[1] and mask.shape[2] == x.shape[2])

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
@@ -228,6 +228,8 @@ class AdversarialPatchNumpy(EvasionAttack):
                      center location of the patch during sampling.
         :return: The patched instances.
         """
+        if mask is not None:
+            mask = mask.copy()
         patch = patch_external if patch_external is not None else self.patch
         patched_x, _, _ = self._augment_images_with_random_patch(x, patch, mask=mask, scale=scale)
         return patched_x
@@ -473,10 +475,10 @@ class AdversarialPatchNumpy(EvasionAttack):
                 shift_h = 0
                 shift_w = 0
         else:
-            edge_x_0 = (self.patch_shape[self.i_h] * scale) // 2
-            edge_x_1 = self.patch_shape[self.i_h] * scale - edge_x_0
-            edge_y_0 = (self.patch_shape[self.i_w] * scale) // 2
-            edge_y_1 = self.patch_shape[self.i_w] * scale - edge_y_0
+            edge_x_0 = int(self.patch_shape[self.i_h] * scale) // 2
+            edge_x_1 = int(self.patch_shape[self.i_h] * scale) - edge_x_0
+            edge_y_0 = int(self.patch_shape[self.i_w] * scale) // 2
+            edge_y_1 = int(self.patch_shape[self.i_w] * scale) - edge_y_0
 
             mask_2d[0:edge_x_0, :] = False
             mask_2d[-edge_x_1:, :] = False
@@ -485,7 +487,7 @@ class AdversarialPatchNumpy(EvasionAttack):
 
             num_pos = np.argwhere(mask_2d).shape[0]
             pos_id = np.random.choice(num_pos, size=1)
-            pos = np.argwhere(mask_2d > 0)[pos_id[0]]
+            pos = np.argwhere(mask_2d)[pos_id[0]]
             shift_h = pos[0] - (self.estimator.input_shape[self.i_h]) / 2.0
             shift_w = pos[1] - (self.estimator.input_shape[self.i_w]) / 2.0
 

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
@@ -214,13 +214,18 @@ class AdversarialPatchNumpy(EvasionAttack):
 
         return self.patch, self._get_circular_patch_mask()
 
-    def apply_patch(self, x: np.ndarray, scale: float, patch_external: np.ndarray = None) -> np.ndarray:
+    def apply_patch(
+        self, x: np.ndarray, scale: float, patch_external: np.ndarray = None, mask: Optional[np.ndarray] = None
+    ) -> np.ndarray:
         """
         A function to apply the learned adversarial patch to images or videos.
 
         :param x: Instances to apply randomly transformed patch.
         :param scale: Scale of the applied patch in relation to the classifier input shape.
         :param patch_external: External patch to apply to images `x`.
+        :param mask: An boolean array of shape equal to the shape of a single samples (1, H, W) or the shape of `x`
+                     (N, H, W) without their channel dimensions. Any features for which the mask is True can be the
+                     center location of the patch during sampling.
         :return: The patched instances.
         """
         patch = patch_external if patch_external is not None else self.patch

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
@@ -163,6 +163,8 @@ class AdversarialPatchNumpy(EvasionAttack):
         logger.info("Creating adversarial patch.")
 
         mask = kwargs.get("mask")
+        if mask is not None:
+            mask = mask.copy()
         if mask is not None and (
             (mask.dtype != np.bool)
             or not (mask.shape[0] == 1 or mask.shape[0] == x.shape[0])

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
@@ -289,19 +289,21 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
                 im_scale = scale
 
             if mask is None:
-                padding_after_scaling_h = (self.image_shape[self.i_h] - im_scale * padded_patch.shape[
-                    self.i_h + 1]) / 2.0
-                padding_after_scaling_w = (self.image_shape[self.i_w] - im_scale * padded_patch.shape[
-                    self.i_w + 1]) / 2.0
+                padding_after_scaling_h = (
+                    self.image_shape[self.i_h] - im_scale * padded_patch.shape[self.i_h + 1]
+                ) / 2.0
+                padding_after_scaling_w = (
+                    self.image_shape[self.i_w] - im_scale * padded_patch.shape[self.i_w + 1]
+                ) / 2.0
                 x_shift = np.random.uniform(-padding_after_scaling_w, padding_after_scaling_w)
                 y_shift = np.random.uniform(-padding_after_scaling_h, padding_after_scaling_h)
             else:
                 mask_2d = mask[i_sample, :, :]
 
-                edge_x_0 = int(im_scale * padded_patch.shape[self.i_w+1]) // 2
-                edge_x_1 = int(im_scale * padded_patch.shape[self.i_w+1]) - edge_x_0
-                edge_y_0 = int(im_scale * padded_patch.shape[self.i_h+1]) // 2
-                edge_y_1 = int(im_scale * padded_patch.shape[self.i_h+1]) - edge_y_0
+                edge_x_0 = int(im_scale * padded_patch.shape[self.i_w + 1]) // 2
+                edge_x_1 = int(im_scale * padded_patch.shape[self.i_w + 1]) - edge_x_0
+                edge_y_0 = int(im_scale * padded_patch.shape[self.i_h + 1]) // 2
+                edge_y_1 = int(im_scale * padded_patch.shape[self.i_h + 1]) - edge_y_0
 
                 mask_2d[0:edge_x_0, :] = False
                 if edge_x_1 > 0:
@@ -346,8 +348,8 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
         image_mask = tfa.image.transform(image_mask, transform_vectors, "BILINEAR",)
         padded_patch = tfa.image.transform(padded_patch, transform_vectors, "BILINEAR",)
 
-        image_mask = tfa.image.transform(image_mask, translation_vectors, "BILINEAR", )
-        padded_patch = tfa.image.transform(padded_patch, translation_vectors, "BILINEAR", )
+        image_mask = tfa.image.transform(image_mask, translation_vectors, "BILINEAR",)
+        padded_patch = tfa.image.transform(padded_patch, translation_vectors, "BILINEAR",)
 
         if self.nb_dims == 4:
             image_mask = tf.stack([image_mask] * images.shape[1], axis=1)

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
@@ -429,17 +429,26 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
             self._get_circular_patch_mask(nb_samples=1).numpy()[0],
         )
 
-    def apply_patch(self, x: np.ndarray, scale: float, patch_external: Optional[np.ndarray] = None) -> np.ndarray:
+    def apply_patch(
+        self,
+        x: np.ndarray,
+        scale: float,
+        patch_external: Optional[np.ndarray] = None,
+        mask: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
         """
         A function to apply the learned adversarial patch to images or videos.
 
         :param x: Instances to apply randomly transformed patch.
         :param scale: Scale of the applied patch in relation to the classifier input shape.
         :param patch_external: External patch to apply to images `x`.
+        :param mask: An boolean array of shape equal to the shape of a single samples (1, H, W) or the shape of `x`
+                     (N, H, W) without their channel dimensions. Any features for which the mask is True can be the
+                     center location of the patch during sampling.
         :return: The patched samples.
         """
         patch = patch_external if patch_external is not None else self._patch
-        return self._random_overlay(images=x, patch=patch, scale=scale).numpy()
+        return self._random_overlay(images=x, patch=patch, scale=scale, mask=mask).numpy()
 
     def reset_patch(self, initial_patch_value: np.ndarray) -> None:
         """

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
@@ -367,6 +367,8 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
 
         shuffle = kwargs.get("shuffle", True)
         mask = kwargs.get("mask")
+        if mask is not None:
+            mask = mask.copy()
         if mask is not None and (
             (mask.dtype != np.bool)
             or not (mask.shape[0] == 1 or mask.shape[0] == x.shape[0])

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
@@ -290,12 +290,12 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
             padding_after_scaling_h = self.image_shape[self.i_h] - im_scale * padded_patch.shape[self.i_h]
             padding_after_scaling_w = self.image_shape[self.i_w] - im_scale * padded_patch.shape[self.i_w]
 
-            mask_2d = mask[i_sample, :, :]
-
-            if mask_2d is None:
+            if mask is None:
                 x_shift = np.random.uniform(-padding_after_scaling_w, padding_after_scaling_w)
                 y_shift = np.random.uniform(-padding_after_scaling_h, padding_after_scaling_h)
             else:
+                mask_2d = mask[i_sample, :, :]
+
                 edge_x_0 = (self.patch_shape[self.i_h] * scale) // 2
                 edge_x_1 = self.patch_shape[self.i_h] * scale - edge_x_0
                 edge_y_0 = (self.patch_shape[self.i_w] * scale) // 2
@@ -367,9 +367,8 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
 
         shuffle = kwargs.get("shuffle", True)
         mask = kwargs.get("mask")
-        if (
-            mask is not None
-            and (mask.dtype != np.bool)
+        if mask is not None and (
+            (mask.dtype != np.bool)
             or not (mask.shape[0] == 1 or mask.shape[0] == x.shape[0])
             or not (
                 (mask.shape[1] == x.shape[1] and mask.shape[2] == x.shape[2])

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
@@ -338,10 +338,7 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
             x_origin_delta = x_origin - x_origin_shifted
             y_origin_delta = y_origin - y_origin_shifted
 
-            # a_2 = x_origin_delta - (x_shift / im_scale)
-            # b_2 = y_origin_delta - (y_shift / im_scale)
-
-            # transform_vectors.append([a_0, a_1, a_2, b_0, b_1, b_2, 0, 0])
+            # Run translation in a second step to position patch exactly inside of the mask
             transform_vectors.append([a_0, a_1, x_origin_delta, b_0, b_1, y_origin_delta, 0, 0])
             translation_vectors.append([1, 0, -x_shift, 0, 1, -y_shift, 0, 0])
 

--- a/art/attacks/evasion/auto_attack.py
+++ b/art/attacks/evasion/auto_attack.py
@@ -179,7 +179,9 @@ class AutoAttack(EvasionAttack):
             if attack.targeted:
                 attack.set_params(targeted=False)
 
-            x_adv, sample_is_robust = self._run_attack(x=x_adv, y=y, mask=mask, sample_is_robust=sample_is_robust, attack=attack)
+            x_adv, sample_is_robust = self._run_attack(
+                x=x_adv, y=y, mask=mask, sample_is_robust=sample_is_robust, attack=attack
+            )
 
         # Targeted attacks
         if self.targeted:

--- a/art/attacks/evasion/auto_attack.py
+++ b/art/attacks/evasion/auto_attack.py
@@ -151,8 +151,14 @@ class AutoAttack(EvasionAttack):
                   (nb_samples,). Only provide this parameter if you'd like to use true labels when crafting adversarial
                   samples. Otherwise, model predictions are used as labels to avoid the "label leaking" effect
                   (explained in this paper: https://arxiv.org/abs/1611.01236). Default is `None`.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
+        :type mask: `np.ndarray`
         :return: An array holding the adversarial examples.
         """
+        mask = kwargs.get("mask")
+
         x_adv = x.astype(ART_NUMPY_DTYPE)
         y = check_and_transform_label_format(y, self.estimator.nb_classes)
 
@@ -173,7 +179,7 @@ class AutoAttack(EvasionAttack):
             if attack.targeted:
                 attack.set_params(targeted=False)
 
-            x_adv, sample_is_robust = self._run_attack(x=x_adv, y=y, sample_is_robust=sample_is_robust, attack=attack)
+            x_adv, sample_is_robust = self._run_attack(x=x_adv, y=y, mask=mask, sample_is_robust=sample_is_robust, attack=attack)
 
         # Targeted attacks
         if self.targeted:
@@ -199,19 +205,24 @@ class AutoAttack(EvasionAttack):
                         target = check_and_transform_label_format(targeted_labels[:, i], self.estimator.nb_classes)
 
                         x_adv, sample_is_robust = self._run_attack(
-                            x=x_adv, y=target, sample_is_robust=sample_is_robust, attack=attack
+                            x=x_adv, y=target, mask=mask, sample_is_robust=sample_is_robust, attack=attack
                         )
 
         return x_adv
 
     def _run_attack(
-        self, x: np.ndarray, y: np.ndarray, sample_is_robust: np.ndarray, attack: EvasionAttack,
+        self, x: np.ndarray, y: np.ndarray, mask: np.ndarray, sample_is_robust: np.ndarray, attack: EvasionAttack,
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Run attack.
 
-        :param x: An array with the original inputs.
+        :param x: An array of the original inputs.
+        :param y: An array of the labels.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
         :param sample_is_robust: Store the initial robustness of examples.
+        :param attack: Evasion attack to run.
         :return: An array holding the adversarial examples.
         """
         # Attack only correctly classified samples
@@ -219,7 +230,7 @@ class AutoAttack(EvasionAttack):
         y_robust = y[sample_is_robust]
 
         # Generate adversarial examples
-        x_robust_adv = attack.generate(x=x_robust, y=y_robust)
+        x_robust_adv = attack.generate(x=x_robust, y=y_robust, mask=mask)
         y_pred_robust_adv = self.estimator_orig.predict(x_robust_adv)
 
         # Check and update successful examples

--- a/art/attacks/evasion/auto_projected_gradient_descent.py
+++ b/art/attacks/evasion/auto_projected_gradient_descent.py
@@ -360,8 +360,14 @@ class AutoProjectedGradientDescent(EvasionAttack):
                   (nb_samples,). Only provide this parameter if you'd like to use true labels when crafting adversarial
                   samples. Otherwise, model predictions are used as labels to avoid the "label leaking" effect
                   (explained in this paper: https://arxiv.org/abs/1611.01236). Default is `None`.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
+        :type mask: `np.ndarray`
         :return: An array holding the adversarial examples.
         """
+        mask = kwargs.get("mask")
+
         y = check_and_transform_label_format(y, self.estimator.nb_classes)
 
         if y is None:
@@ -449,6 +455,9 @@ class AutoProjectedGradientDescent(EvasionAttack):
                     assert x_k.shape == grad.shape
 
                     perturbation = grad
+
+                    if mask is not None:
+                        perturbation = perturbation * (mask.astype(ART_NUMPY_DTYPE))
 
                     # Apply perturbation and clip
                     z_k_p_1 = x_k + eta * perturbation

--- a/art/attacks/evasion/dpatch.py
+++ b/art/attacks/evasion/dpatch.py
@@ -116,6 +116,8 @@ class DPatch(EvasionAttack):
         :return: Adversarial patch.
         """
         mask = kwargs.get("mask")
+        if mask is not None:
+            mask = mask.copy()
         if (
             mask is not None
             and (mask.dtype != np.bool)

--- a/art/attacks/evasion/dpatch.py
+++ b/art/attacks/evasion/dpatch.py
@@ -242,9 +242,9 @@ class DPatch(EvasionAttack):
         :param channels_first: Set channels first or last.
         :param channel_index: Index of the color channel.
         :type channel_index: `int`
-        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
-                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
-                     features for which the mask is zero will not be adversarially perturbed.
+        :param mask: An boolean array of shape equal to the shape of a single samples (1, H, W) or the shape of `x`
+                     (N, H, W) without their channel dimensions. Any features for which the mask is True can be the
+                     center location of the patch during sampling.
         :type mask: `np.ndarray`
         """
         # Remove in 1.5.0

--- a/art/attacks/evasion/dpatch.py
+++ b/art/attacks/evasion/dpatch.py
@@ -311,7 +311,11 @@ class DPatch(EvasionAttack):
         return x_copy, transformations
 
     def apply_patch(
-        self, x: np.ndarray, patch_external: Optional[np.ndarray] = None, random_location: bool = False,
+        self,
+        x: np.ndarray,
+        patch_external: Optional[np.ndarray] = None,
+        random_location: bool = False,
+        mask: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Apply the adversarial patch to images.
@@ -319,6 +323,9 @@ class DPatch(EvasionAttack):
         :param x: Images to be patched.
         :param patch_external: External patch to apply to images `x`. If None the attacks patch will be applied.
         :param random_location: True if patch location should be random.
+        :param mask: An boolean array of shape equal to the shape of a single samples (1, H, W) or the shape of `x`
+                     (N, H, W) without their channel dimensions. Any features for which the mask is True can be the
+                     center location of the patch during sampling.
         :return: The patched images.
         """
         if patch_external is not None:
@@ -327,7 +334,11 @@ class DPatch(EvasionAttack):
             patch_local = self._patch
 
         patched_images, _ = self._augment_images_with_patch(
-            x=x, patch=patch_local, random_location=random_location, channels_first=self.estimator.channels_first
+            x=x,
+            patch=patch_local,
+            random_location=random_location,
+            channels_first=self.estimator.channels_first,
+            mask=mask,
         )
 
         return patched_images

--- a/art/attacks/evasion/fast_gradient.py
+++ b/art/attacks/evasion/fast_gradient.py
@@ -161,12 +161,14 @@ class FastGradientMethod(EvasionAttack):
                   (nb_samples,). Only provide this parameter if you'd like to use true labels when crafting adversarial
                   samples. Otherwise, model predictions are used as labels to avoid the "label leaking" effect
                   (explained in this paper: https://arxiv.org/abs/1611.01236). Default is `None`.
-        :param mask: An array with a mask to be applied to the adversarial perturbations. Shape needs to be
-                     broadcastable to the shape of x. Any features for which the mask is zero will not be adversarially
-                     perturbed.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
         :type mask: `np.ndarray`
         :return: An array holding the adversarial examples.
         """
+        mask = kwargs.get("mask")
+
         if isinstance(self.estimator, ClassifierMixin):
             y = check_and_transform_label_format(y, self.estimator.nb_classes)
 
@@ -182,11 +184,9 @@ class FastGradientMethod(EvasionAttack):
                 )
             y = y / np.sum(y, axis=1, keepdims=True)
 
-            mask = kwargs.get("mask")
-            if mask is not None:
-                # ensure the mask is broadcastable:
-                if len(mask.shape) > len(x.shape) or mask.shape != x.shape[-len(mask.shape) :]:
-                    raise ValueError("mask shape must be broadcastable to input shape")
+            # Check the mask
+            if mask is not None and (len(mask.shape) > len(x.shape) or mask.shape != x.shape[-len(mask.shape):]):
+                raise ValueError("Mask shape must be broadcastable to input shape.")
 
             # Return adversarial examples computed with minimal perturbation if option is active
             rate_best: Optional[float]

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
@@ -177,6 +177,10 @@ class ProjectedGradientDescent(EvasionAttack):
                   (nb_samples,). Only provide this parameter if you'd like to use true labels when crafting adversarial
                   samples. Otherwise, model predictions are used as labels to avoid the "label leaking" effect
                   (explained in this paper: https://arxiv.org/abs/1611.01236). Default is `None`.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
+        :type mask: `np.ndarray`
         :return: An array holding the adversarial examples.
         """
         logger.info("Creating adversarial samples.")

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
@@ -119,22 +119,25 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
                   (nb_samples,). Only provide this parameter if you'd like to use true labels when crafting adversarial
                   samples. Otherwise, model predictions are used as labels to avoid the "label leaking" effect
                   (explained in this paper: https://arxiv.org/abs/1611.01236). Default is `None`.
-        :param mask: An array with a mask to be applied to the adversarial perturbations. Shape needs to be
-                     broadcastable to the shape of x. Any features for which the mask is zero will not be adversarially
-                     perturbed.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
         :type mask: `np.ndarray`
         :return: An array holding the adversarial examples.
         """
         import torch  # lgtm [py/repeated-import]
+
+        mask = kwargs.get("mask")
+
+        # Check the mask
+        if mask is not None and (len(mask.shape) > len(x.shape) or mask.shape != x.shape[-len(mask.shape):]):
+            raise ValueError("Mask shape must be broadcastable to input shape.")
 
         # Check whether random eps is enabled
         self._random_eps()
 
         # Set up targets
         targets = self._set_targets(x, y)
-
-        # Get the mask
-        mask = self._get_mask(x, **kwargs)
 
         # Create dataset
         if mask is not None:
@@ -235,9 +238,9 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
                   (nb_samples,). Only provide this parameter if you'd like to use true labels when crafting adversarial
                   samples. Otherwise, model predictions are used as labels to avoid the "label leaking" effect
                   (explained in this paper: https://arxiv.org/abs/1611.01236). Default is `None`.
-        :param mask: An array with a mask to be applied to the adversarial perturbations. Shape needs to be
-                     broadcastable to the shape of x. Any features for which the mask is zero will not be adversarially
-                     perturbed.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
         :return: Perturbations.
         """
         import torch  # lgtm [py/repeated-import]
@@ -308,9 +311,9 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
                   (nb_samples,). Only provide this parameter if you'd like to use true labels when crafting adversarial
                   samples. Otherwise, model predictions are used as labels to avoid the "label leaking" effect
                   (explained in this paper: https://arxiv.org/abs/1611.01236).
-        :param mask: An array with a mask to be applied to the adversarial perturbations. Shape needs to be
-                     broadcastable to the shape of x. Any features for which the mask is zero will not be adversarially
-                     perturbed.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
         :param eps: Maximum perturbation that the attacker can introduce.
         :param eps_step: Attack step size (input variation) at each iteration.
         :param random_init: Random initialisation within the epsilon ball. For random_init=False starting at the

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
@@ -118,22 +118,25 @@ class ProjectedGradientDescentTensorFlowV2(ProjectedGradientDescentCommon):
                   (nb_samples,). Only provide this parameter if you'd like to use true labels when crafting adversarial
                   samples. Otherwise, model predictions are used as labels to avoid the "label leaking" effect
                   (explained in this paper: https://arxiv.org/abs/1611.01236). Default is `None`.
-        :param mask: An array with a mask to be applied to the adversarial perturbations. Shape needs to be
-                     broadcastable to the shape of x. Any features for which the mask is zero will not be adversarially
-                     perturbed.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
         :type mask: `np.ndarray`
         :return: An array holding the adversarial examples.
         """
         import tensorflow as tf  # lgtm [py/repeated-import]
+
+        mask = kwargs.get("mask")
+
+        # Check the mask
+        if mask is not None and (len(mask.shape) > len(x.shape) or mask.shape != x.shape[-len(mask.shape):]):
+            raise ValueError("Mask shape must be broadcastable to input shape.")
 
         # Check whether random eps is enabled
         self._random_eps()
 
         # Set up targets
         targets = self._set_targets(x, y)
-
-        # Get the mask
-        mask = self._get_mask(x, **kwargs)
 
         # Create dataset
         if mask is not None:
@@ -203,9 +206,9 @@ class ProjectedGradientDescentTensorFlowV2(ProjectedGradientDescentCommon):
 
         :param x: An array with the original inputs.
         :param targets: Target values (class labels) one-hot-encoded of shape `(nb_samples, nb_classes)`.
-        :param mask: An array with a mask to be applied to the adversarial perturbations. Shape needs to be
-                     broadcastable to the shape of x. Any features for which the mask is zero will not be adversarially
-                     perturbed.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
         :return: Adversarial examples.
         """
         adv_x = x
@@ -225,9 +228,9 @@ class ProjectedGradientDescentTensorFlowV2(ProjectedGradientDescentCommon):
                   (nb_samples,). Only provide this parameter if you'd like to use true labels when crafting adversarial
                   samples. Otherwise, model predictions are used as labels to avoid the "label leaking" effect
                   (explained in this paper: https://arxiv.org/abs/1611.01236). Default is `None`.
-        :param mask: An array with a mask to be applied to the adversarial perturbations. Shape needs to be
-                     broadcastable to the shape of x. Any features for which the mask is zero will not be adversarially
-                     perturbed.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
         :return: Perturbations.
         """
         import tensorflow as tf  # lgtm [py/repeated-import]
@@ -299,9 +302,9 @@ class ProjectedGradientDescentTensorFlowV2(ProjectedGradientDescentCommon):
                   (nb_samples,). Only provide this parameter if you'd like to use true labels when crafting adversarial
                   samples. Otherwise, model predictions are used as labels to avoid the "label leaking" effect
                   (explained in this paper: https://arxiv.org/abs/1611.01236). Default is `None`.
-        :param mask: An array with a mask to be applied to the adversarial perturbations. Shape needs to be
-                     broadcastable to the shape of x. Any features for which the mask is zero will not be adversarially
-                     perturbed.
+        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
+                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
+                     features for which the mask is zero will not be adversarially perturbed.
         :param eps: Maximum perturbation that the attacker can introduce.
         :param eps_step: Attack step size (input variation) at each iteration.
         :param random_init: Random initialisation within the epsilon ball. For random_init=False starting at the

--- a/tests/attacks/test_adversarial_patch.py
+++ b/tests/attacks/test_adversarial_patch.py
@@ -107,9 +107,9 @@ class TestAdversarialPatch(TestBase):
         target = np.zeros(self.x_train_mnist.shape[0])
         patch_adv, _ = attack_ap.generate(self.x_train_mnist, target, shuffle=False)
 
-        self.assertAlmostEqual(patch_adv[8, 8, 0], 0.21282613, delta=0.05)
-        self.assertAlmostEqual(patch_adv[14, 14, 0], 0.5411238, delta=0.05)
-        self.assertAlmostEqual(float(np.sum(patch_adv)), 378.3399658203125, delta=1.0)
+        self.assertAlmostEqual(patch_adv[8, 8, 0], 0.3776834, delta=0.05)
+        self.assertAlmostEqual(patch_adv[14, 14, 0], 0.4999926, delta=0.05)
+        self.assertAlmostEqual(float(np.sum(patch_adv)), 405.7377624511719, delta=1.0)
 
     @unittest.skipIf(
         int(keras.__version__.split(".")[0]) == 2 and int(keras.__version__.split(".")[1]) < 3,


### PR DESCRIPTION
# Description

This pull request adds support for perturbation masks to `AutoAttack`, `AutoProejctedGradientDescent`, `DPatch`, `AdversarialPatch`, `AdversarialPatchNumpy`, and `AdversarialPatchTensorFlowV2`.

For `AutoAttack` and`AutoProejctedGradientDescent` the mask defines input features that can be perturbed by these attacks.

For DPatch` and `AdversarialPatch*` the mask defines input features where the center of the patch can be positioned during random sampling of translation transformations. For example if the mask describes the background of an image or specific objects the patch will only be samples on the background or these objects.

Fixes #652

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
