### PR TITLE
Update cost matrix of Wasserstein attack

### DIFF
--- a/art/attacks/evasion/wasserstein.py
+++ b/art/attacks/evasion/wasserstein.py
@@ -542,7 +542,6 @@ class Wasserstein(EvasionAttack):
                 # which only can reproduce L2-norm for p=1 correctly
                 cost_matrix[i, j] = (abs(i - center) ** p + abs(j - center) ** p) ** (1 / p)
 
-
         return cost_matrix
 
     @staticmethod

--- a/art/attacks/evasion/wasserstein.py
+++ b/art/attacks/evasion/wasserstein.py
@@ -537,7 +537,11 @@ class Wasserstein(EvasionAttack):
 
         for i in range(kernel_size):
             for j in range(kernel_size):
-                cost_matrix[i, j] = (abs(i - center) ** 2 + abs(j - center) ** 2) ** (p / 2)
+                # The code of the paper of this attack (https://arxiv.org/abs/1902.07906) implements the cost as:
+                # cost_matrix[i, j] = (abs(i - center) ** 2 + abs(j - center) ** 2) ** (p / 2)
+                # which only can reproduce L2-norm for p=1 correctly
+                cost_matrix[i, j] = (abs(i - center) ** p + abs(j - center) ** p) ** (1 / p)
+
 
         return cost_matrix
 

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -196,7 +196,9 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         if self._reduce_labels and self._int_labels:
             return np.argmax(y, axis=1)
         elif self._reduce_labels:  # float labels
-            return np.argmax(y, axis=1).astype(np.float32)
+            y_index = np.argmax(y, axis=1).astype(np.float32)
+            # y_index = np.expand_dims(y_index, axis=1)
+            return y_index
         else:
             return y
 

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -197,7 +197,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
             return np.argmax(y, axis=1)
         elif self._reduce_labels:  # float labels
             y_index = np.argmax(y, axis=1).astype(np.float32)
-            # y_index = np.expand_dims(y_index, axis=1)
+            y_index = np.expand_dims(y_index, axis=1)
             return y_index
         else:
             return y


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request corrects the cost matrix of the `Wasserstein` attack deviating from the original implementation of the paper to correctly handle the norm `p`.

Fixes #602 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
