### PR TITLE
Imperceptible ASR attack independent of estimator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
             tensorflow: 2.2.0
             tf_version: v2
             keras: 2.3.1
+          - name: TensorFlow 2.2.0v1 (Keras 2.3.1 Python 3.7)
+            framework: tensorflow2v1
+            python: 3.7
+            tensorflow: 2.2.0
+            tf_version: v2
+            keras: 2.3.1
           - name: TensorFlow 2.3.1 (Keras 2.4.3 Python 3.7)
             framework: tensorflow
             python: 3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,23 +97,22 @@ jobs:
       - name: Pre-install legacy
         if: ${{ matrix.framework == 'legacy' }}
         run: |
-          sudo apt-get -y -q install ffmpeg libavcodec-extra
           pip install tensorflow==${{ matrix.tensorflow }}
           pip install keras==${{ matrix.keras }}
           pip install scikit-learn==${{ matrix.scikit-learn }}
       - name: Pre-install tensorflow
         if: ${{ matrix.framework == 'tensorflow' || matrix.framework == 'keras' || matrix.framework == 'kerastf' }}
         run: |
-          sudo apt-get -y -q install ffmpeg libavcodec-extra
           pip install tensorflow==${{ matrix.tensorflow }}
           pip install keras==${{ matrix.keras }}
       - name: Pre-install scikit-learn
         if: ${{ matrix.framework == 'scikitlearn' }}
         run: |
-          sudo apt-get -y -q install ffmpeg libavcodec-extra
           pip install scikit-learn==${{ matrix.scikit-learn }}
       - name: Install Dependencies
         run: |
+          sudo apt-get update
+          sudo apt-get -y -q install ffmpeg libavcodec-extra
           python -m pip install --upgrade pip setuptools wheel
           pip3 install -q -r requirements.txt
           pip list
@@ -131,6 +130,7 @@ jobs:
           python-version: 3.7
       - name: Pre-install
         run: |
+          sudo apt-get update
           sudo apt-get -y -q install ffmpeg libavcodec-extra
           pip install tensorflow==2.2.0
           pip install keras==2.3.1

--- a/art/attacks/evasion/__init__.py
+++ b/art/attacks/evasion/__init__.py
@@ -12,7 +12,7 @@ from art.attacks.evasion.elastic_net import ElasticNet
 from art.attacks.evasion.fast_gradient import FastGradientMethod
 from art.attacks.evasion.hclu import HighConfidenceLowUncertainty
 from art.attacks.evasion.hop_skip_jump import HopSkipJump
-from art.attacks.evasion.imperceptible_asr.imperceptible_asr import ImperceptibleAsr
+from art.attacks.evasion.imperceptible_asr.imperceptible_asr import ImperceptibleASR
 from art.attacks.evasion.iterative_method import BasicIterativeMethod
 from art.attacks.evasion.newtonfool import NewtonFool
 from art.attacks.evasion.projected_gradient_descent.projected_gradient_descent import ProjectedGradientDescent

--- a/art/attacks/evasion/__init__.py
+++ b/art/attacks/evasion/__init__.py
@@ -12,6 +12,7 @@ from art.attacks.evasion.elastic_net import ElasticNet
 from art.attacks.evasion.fast_gradient import FastGradientMethod
 from art.attacks.evasion.hclu import HighConfidenceLowUncertainty
 from art.attacks.evasion.hop_skip_jump import HopSkipJump
+from art.attacks.evasion.imperceptible_asr.imperceptible_asr import ImperceptibleAsr
 from art.attacks.evasion.iterative_method import BasicIterativeMethod
 from art.attacks.evasion.newtonfool import NewtonFool
 from art.attacks.evasion.projected_gradient_descent.projected_gradient_descent import ProjectedGradientDescent

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
@@ -294,7 +294,8 @@ class ImperceptibleAsr(EvasionAttack):
         masking_threshold = np.array(masking_threshold)
         psd_maximum = np.array(psd_maximum)
 
-        # stabilize masking threshold loss by canceling out the "10*log" term in power spectral density and masking threshold
+        # stabilize masking threshold loss by canceling out the "10*log" term in power spectral density and masking
+        # threshold
         masking_threshold_stabilized = 10 ** (masking_threshold * 0.1)
         psd_maximum_stabilized = 10 ** (psd_maximum * 0.1)
 

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
@@ -24,8 +24,10 @@ This module implements the adversarial and imperceptible attack on automatic spe
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+from typing import Tuple
 
 import numpy as np
+import scipy.signal as ss
 
 from art.attacks.attack import EvasionAttack
 from art.estimators.speech_recognition.speech_recognizer import SpeechRecognizerMixin
@@ -145,3 +147,234 @@ class ImperceptibleAsr(EvasionAttack):
         Apply attack-specific checks.
         """
         pass
+
+
+class PsychoacousticMasker:
+    """
+    Implements psychoacoustic model of Lin and Abdulla (2015) following Qin et al. (2019) simplifications.
+
+    | Lin and Abdulla (2015), https://www.springer.com/gp/book/9783319079738
+    | Qin et al. (2019), http://proceedings.mlr.press/v97/qin19a.html
+    """
+
+    def __init__(self, window_size: int = 2048, hop_size: int = 512, sample_rate: int = 16000) -> None:
+        """
+        Initialization.
+
+        :param window_size: Length of the window. The number of STFT rows is `(window_size // 2 + 1)`.
+        :param hop_size: Number of audio samples between adjacent STFT columns.
+        :param sample_rate: Sampling frequency of audio inputs.
+        """
+        self._window_size = window_size
+        self._hop_size = hop_size
+        self._sample_rate = sample_rate
+
+        # init some private properties for lazy loading
+        self._fft_frequencies = None
+        self._bark = None
+        self._absolute_threshold_hearing = None
+
+    def calculate_threshold_and_psd_maximum(self, audio: np.ndarray):
+        """Compute the global masking threshold for an audio input and also return its maxium power spectral density.
+
+        This method is the main method to call in order to obtain global masking thresholds for an audio input. It also
+        returns the maxium power spectral density (PSD) for each frame. Given an audio input, the following steps are
+        performed:
+
+        1. STFT analysis and sound pressure level normalization
+        2. Identification and filtering of maskers
+        3. Calculation of individual masking thresholds
+        4. Calculation of global masking tresholds
+
+        :param audio: Audio samples of shape `(length,)`.
+        :return: Global masking thresholds of shape `(window_size // 2 + 1, frame_length)` and the PSD maximum for each
+            frame of shape `(frame_length)`.
+        """
+        psd_matrix, psd_max = self.power_spectral_density(audio)
+        threshold = np.zeros(psd_matrix.shape)
+        for frame in range(psd_matrix.shape[1]):
+            # apply methods for finding and filtering maskers
+            maskers, masker_idx = self.filter_maskers(*self.find_maskers(psd_matrix[:, frame]))
+            # apply methods for calculating global threshold
+            threshold[:, frame] = self.calculate_global_threshold(
+                self.calculate_individual_threshold(maskers, masker_idx)
+            )
+        return threshold, psd_max
+
+    @property
+    def window_size(self) -> int:
+        """
+        :return: Window size of the masker.
+        """
+        return self._window_size
+
+    @property
+    def hop_size(self) -> int:
+        """
+        :return: Hop size of the masker.
+        """
+        return self._hop_size
+
+    @property
+    def sample_rate(self) -> int:
+        """
+        :return: Sample rate of the masker.
+        """
+        return self._sample_rate
+
+    @property
+    def fft_frequencies(self) -> np.ndarray:
+        """
+        :return: Discrete fourier transform sample frequencies.
+        """
+        if self._fft_frequencies is None:
+            self._fft_frequencies = np.linspace(0, self.sample_rate / 2, self.window_size // 2 + 1)
+        return self._fft_frequencies
+
+    @property
+    def bark(self) -> np.ndarray:
+        """
+        :return: Bark scale for discrete fourier transform sample frequencies.
+        """
+        if self._bark is None:
+            self._bark = 13 * np.arctan(0.00076 * self.fft_frequencies) + 3.5 * np.arctan(
+                np.square(self.fft_frequencies / 7500.0)
+            )
+        return self._bark
+
+    @property
+    def absolute_threshold_hearing(self) -> np.ndarray:
+        """
+        :return: Absolute threshold of hearing (ATH) for discrete fourier transform sample frequencies.
+        """
+        if self._absolute_threshold_hearing is None:
+            # ATH applies only to frequency range 20Hz<=f<=20kHz
+            # note: deviates from Qin et al. implementation by using the Hz range as valid domain
+            valid_domain = np.logical_and(20 <= self.fft_frequencies, self.fft_frequencies <= 2e4)
+            freq = self.fft_frequencies[valid_domain] * 0.001
+
+            # outside valid ATH domain, set values to np.inf
+            self._absolute_threshold_hearing = np.ones(valid_domain.shape) * np.inf
+            self._absolute_threshold_hearing[valid_domain] = (
+                3.64 * pow(freq, -0.8) - 6.5 * np.exp(-0.6 * np.square(freq - 3.3)) + 0.001 * pow(freq, 4) - 12
+            )
+        return self._absolute_threshold_hearing
+
+    def power_spectral_density(self, audio: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """Compute the power spectral density matrix for an audio input.
+
+        :param audio: Audio sample of shape `(length,)`.
+        :return: PSD matrix of shape `(window_size // 2 + 1, frame_length)` and maxium vector of shape `(frame_length)`.
+        """
+        # compute short-time Fourier transform (STFT)
+        stft_params = {
+            "fs": self.sample_rate,
+            "window": ss.get_window("hann", self.window_size, fftbins=True),
+            "nperseg": self.window_size,
+            "nfft": self.window_size,
+            "noverlap": self.window_size - self.hop_size,
+            "boundary": None,
+            "padded": False,
+        }
+        _, _, stft_matrix = ss.stft(audio, **stft_params)
+
+        # undo SciPy's hard-coded normalization
+        # https://github.com/scipy/scipy/blob/01d8bfb6f239df4ce70c799b9b485b53733c9911/scipy/signal/spectral.py#L1802
+        stft_matrix *= stft_params["window"].sum()
+
+        # compute power spectral density (PSD)
+        gain_factor = np.sqrt(8.0 / 3.0)
+        psd_matrix = 10 * np.log10(np.abs(gain_factor * stft_matrix / self.window_size) ** 2 + np.finfo(np.float32).eps)
+
+        # normalize PSD at 96dB
+        # note: deviates from Qin et al. implementation by taking maximum across frames
+        psd_matrix_max = np.max(psd_matrix, axis=0)
+        psd_matrix_normalized = 96.0 - psd_matrix_max + psd_matrix
+
+        return psd_matrix_normalized, psd_matrix_max
+
+    @staticmethod
+    def find_maskers(psd_vector: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """Identify maskers.
+
+        Possible maskers are local PSD maxima. Following Qin et al., all maskers are treated as tonal. Thus neglecting
+        the nontonal type.
+
+        :param psd_vector: PSD vector of shape `(window_size // 2 + 1)`.
+        :return: Possible PSD maskers and indices.
+        """
+        # identify maskers. For simplification it is assumed that all maskers are tonal (vs. nontonal).
+        masker_idx = ss.argrelmax(psd_vector)[0]
+
+        # smooth maskers with their direct neighbors
+        psd_maskers = 10 * np.log10(np.sum([10 ** (psd_vector[masker_idx + i] / 10) for i in range(-1, 2)], axis=0))
+        return psd_maskers, masker_idx
+
+    def filter_maskers(self, maskers: np.ndarray, masker_idx: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """Filter maskers.
+
+        First, discard all maskers that are below the absolute threshold of hearing. Second, reduce pairs of maskers
+        that are within 0.5 bark distance of each other by keeping the larger masker.
+
+        :param maskers: Masker PSD values.
+        :param masker_idx: Masker indices.
+        :return: Filtered PSD maskers and indices.
+        """
+        # filter on the absolute threshold of hearing
+        # note: deviates from Qin et al. implementation by filtering first on ATH and only then on bark distance
+        ath_condition = maskers > self.absolute_threshold_hearing[masker_idx]
+        masker_idx = masker_idx[ath_condition]
+        maskers = maskers[ath_condition]
+
+        # filter on the bark distance
+        bark_condition = np.ones(masker_idx.shape, dtype=bool)
+        i_prev = 0
+        for i in range(1, len(masker_idx)):
+            # find pairs of maskers that are within 0.5 bark distance of each other
+            if self.bark[i] - self.bark[i_prev] < 0.5:
+                # discard the smaller masker
+                i_todelete, i_prev = (i_prev, i_prev + 1) if maskers[i_prev] < maskers[i] else (i, i_prev)
+                bark_condition[i_todelete] = False
+            else:
+                i_prev = i
+        masker_idx = masker_idx[bark_condition]
+        maskers = maskers[bark_condition]
+
+        return maskers, masker_idx
+
+    def calculate_individual_threshold(self, maskers: np.ndarray, masker_idx: np.ndarray) -> np.ndarray:
+        """Calculate individual masking threshold with frequency denoted at bark scale.
+
+        :param maskers: Masker PSD values.
+        :param masker_idx: Masker indices.
+        :return: Individual threshold vector of shape `(window_size // 2 + 1)`.
+        """
+        delta_shift = -6.025 - 0.275 * self.bark
+        threshold = np.zeros(masker_idx.shape + self.bark.shape)
+        # TODO reduce for loop
+        for k, (masker_j, masker) in enumerate(zip(masker_idx, maskers)):
+            # critical band rate of the masker
+            z_j = self.bark[masker_j]
+            # distance maskees to masker in bark
+            delta_z = self.bark - z_j
+            # define two-slope spread function:
+            #   if delta_z <= 0, spread_function = 27*delta_z
+            #   if delta_z > 0, spread_function = [-27+0.37*max(PSD_masker-40,0]*delta_z
+            spread_function = 27 * delta_z
+            spread_function[delta_z > 0] = (-27 + 0.37 * max(masker - 40, 0)) * delta_z[delta_z > 0]
+
+            # calculate threshold
+            threshold[k, :] = masker + delta_shift[masker_j] + spread_function
+        return threshold
+
+    def calculate_global_threshold(self, individual_threshold):
+        """Calculate global masking threshold.
+
+        :param individual_threshold: Individual masking threshold vector.
+        :return: Global threshold vector of shape `(window_size // 2 + 1)`.
+        """
+        # note: deviates from Qin et al. implementation by taking the log of the summation, which they do for numerical
+        #       stability of the stage 2 optimization. We stabilize the optimization in the loss itself.
+        return 10 * np.log10(
+            np.sum(10 ** (individual_threshold / 10), axis=0) + 10 ** (self.absolute_threshold_hearing / 10)
+        )

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
@@ -1,0 +1,77 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+This module implements the adversarial and imperceptible attack on automatic speech recognition systems of Qin et al.
+(2019). It generates an adversarial audio example.
+
+| Paper link: http://proceedings.mlr.press/v97/qin19a.html
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+import numpy as np
+
+from art.attacks.attack import EvasionAttack
+from art.estimators.speech_recognition.speech_recognizer import SpeechRecognizerMixin
+from art.estimators.tensorflow import TensorFlowV2Estimator
+
+logger = logging.getLogger(__name__)
+
+
+class ImperceptibleAsr(EvasionAttack):
+    """
+    Implementation of the imperceptible attack against a speech recognition model.
+
+    | Paper link: http://proceedings.mlr.press/v97/qin19a.html
+    """
+
+    attack_params = EvasionAttack.attack_params + []
+
+    _estimator_requirements = (TensorFlowV2Estimator, SpeechRecognizerMixin)
+
+    def __init__(
+        self,
+        estimator: "TensorFlowV2Estimator",
+    ) -> None:
+        """
+        Create an instance of the :class:`.ImperceptibleAsr`.
+
+        :param estimator: A trained classifier.
+        """
+        # Super initialization
+        super().__init__(estimator=estimator)
+        self._check_params()
+
+    def generate(self, x: np.ndarray, y: np.ndarray, **kwargs) -> np.ndarray:
+        """
+        Generate adversarial examples and return them as an array. This method should be overridden by all concrete
+        evasion attack implementations.
+
+        :param x: An array with the original inputs to be attacked.
+        :param y: Correct labels or target labels for `x`, depending if the attack is targeted or not. This parameter
+            is only used by some of the attacks.
+        :return: An array holding the adversarial examples.
+        """
+        pass
+
+    def _check_params(self) -> None:
+        """
+        Apply attack-specific checks.
+        """
+        pass

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
@@ -76,9 +76,14 @@ class ImperceptibleASR(EvasionAttack):
         Create an instance of the :class:`.ImperceptibleASR`.
 
         :param estimator: A trained speech recognition estimator.
+        :param masker: A Psychoacoustic masker.
         :param eps: Initial max norm bound for adversarial perturbation.
         :param learning_rate_1: Learning rate for stage 1 of attack.
         :param max_iter_1: Number of iterations for stage 1 of attack.
+        :param alpha: Initial alpha value for balancing stage 2 loss.
+        :param learning_rate_2: Learning rate for stage 2 of attack.
+        :param max_iter_2: Number of iterations for stage 2 of attack.
+        :param batch_size: Batch size.
         """
         import tensorflow.compat.v1 as tf1
 
@@ -267,7 +272,9 @@ class ImperceptibleASR(EvasionAttack):
 
         return np.array(x_imperceptible, dtype=object)
 
-    def _loss_gradient_masking_threshold(self, perturbation: np.ndarray, x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def _loss_gradient_masking_threshold(
+        self, perturbation: np.ndarray, x: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Compute loss gradient of the global masking threshold w.r.t. the PSD approximate of the perturbation.
 
@@ -386,7 +393,36 @@ class ImperceptibleASR(EvasionAttack):
         """
         Apply attack-specific checks.
         """
-        pass
+        if self.eps <= 0:
+            raise ValueError("The perturbation max norm bound `eps` has to be positive.")
+
+        if not isinstance(self.alpha, float):
+            raise ValueError("The value of alpha must be of type float.")
+        if self.alpha <= 0.0:
+            raise ValueError("The value of alpha must be positive")
+
+        if not isinstance(self.max_iter_1, int):
+            raise ValueError("The maximum number of iterations for stage 1 must be of type int.")
+        if self.max_iter_1 <= 0:
+            raise ValueError("The maximum number of iterations for stage 1 must be greater than 0.")
+
+        if not isinstance(self.max_iter_2, int):
+            raise ValueError("The maximum number of iterations for stage 2 must be of type int.")
+        if self.max_iter_2 <= 0:
+            raise ValueError("The maximum number of iterations for stage 2 must be greater than 0.")
+
+        if not isinstance(self.learning_rate_1, float):
+            raise ValueError("The learning rate for stage 1 must be of type float.")
+        if self.learning_rate_1 <= 0.0:
+            raise ValueError("The learning rate for stage 1 must be greater than 0.0.")
+
+        if not isinstance(self.learning_rate_2, float):
+            raise ValueError("The learning rate for stage 2 must be of type float.")
+        if self.learning_rate_2 <= 0.0:
+            raise ValueError("The learning rate for stage 2 must be greater than 0.0.")
+
+        if self.batch_size <= 0:
+            raise ValueError("The batch size `batch_size` has to be positive.")
 
 
 class PsychoacousticMasker:

--- a/art/utils.py
+++ b/art/utils.py
@@ -1214,8 +1214,13 @@ def is_probability(vector: np.ndarray) -> bool:
     return is_sum_1 and is_smaller_1 and is_larger_0
 
 
-def pad_audio_input(x: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Apply padding to a batch of audio samples such that it has shape of (batch_size, max_length)."""
+def pad_sequence_input(x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Apply padding to a batch of 1-dimensional samples such that it has shape of (batch_size, max_length).
+
+    :param x: A batch of 1-dimensional input data, e.g. `np.array([np.array([1,2,3]), np.array([4,5,6,7])])`.
+    :return: The padded input batch and its corresponding mask.
+    """
     max_length = max(map(len, x))
     batch_size = x.shape[0]
 

--- a/art/utils.py
+++ b/art/utils.py
@@ -1212,3 +1212,17 @@ def is_probability(vector: np.ndarray) -> bool:
     is_larger_0 = np.amin(vector) >= 0.0
 
     return is_sum_1 and is_smaller_1 and is_larger_0
+
+
+def pad_audio_input(x: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Apply padding to a batch of audio samples such that it has shape of (batch_size, max_length)."""
+    max_length = max(map(len, x))
+    batch_size = x.shape[0]
+
+    x_padded = np.zeros((batch_size, max_length))
+    x_mask = np.zeros((batch_size, max_length), dtype=bool)
+
+    for i, x_i in enumerate(x):
+        x_padded[i, : len(x_i)] = x_i
+        x_mask[i, : len(x_i)] = 1
+    return x_padded, x_mask

--- a/conftest.py
+++ b/conftest.py
@@ -38,7 +38,7 @@ from tests.utils import ARTTestFixtureNotImplemented, get_attack_classifier_pt
 
 logger = logging.getLogger(__name__)
 
-deep_learning_frameworks = ["keras", "tensorflow1", "tensorflow2", "pytorch", "kerastf", "mxnet"]
+deep_learning_frameworks = ["keras", "tensorflow1", "tensorflow2", "tensorflow2v1", "pytorch", "kerastf", "mxnet"]
 non_deep_learning_frameworks = ["scikitlearn"]
 
 art_supported_frameworks = []
@@ -723,6 +723,7 @@ def skip_by_framework(request, framework):
         if "tensorflow" in framework_to_skip_list:
             framework_to_skip_list.append("tensorflow1")
             framework_to_skip_list.append("tensorflow2")
+            framework_to_skip_list.append("tensorflow2v1")
 
         if framework in framework_to_skip_list:
             pytest.skip("skipped on this platform: {}".format(framework))

--- a/tests/attacks/evasion/conftest.py
+++ b/tests/attacks/evasion/conftest.py
@@ -1,0 +1,118 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+import pytest
+
+from art.estimators.pytorch import PyTorchEstimator
+from art.estimators.speech_recognition.speech_recognizer import SpeechRecognizerMixin
+from art.estimators.tensorflow import TensorFlowV2Estimator
+from tests.utils import ARTTestFixtureNotImplemented
+
+
+@pytest.fixture
+def audio_sample():
+    """
+    Create audio sample.
+    """
+    sample_rate = 16000
+    test_input = np.ones((sample_rate)) * 10e3
+    return test_input
+
+
+@pytest.fixture
+def audio_data():
+    """
+    Create audio fixtures of shape (nb_samples=3,) with elements of variable length.
+    """
+    sample_rate = 16000
+    test_input = np.array(
+        [
+            np.zeros(sample_rate),
+            np.ones(sample_rate * 2) * 2e3,
+            np.ones(sample_rate * 3) * 3e3,
+            np.ones(sample_rate * 3) * 3e3,
+        ],
+        dtype=object,
+    )
+    test_target = ["DUMMY"] * test_input.shape[0]
+    return test_input, test_target
+
+
+@pytest.fixture
+def audio_batch_padded():
+    """
+    Create audio fixtures of shape (batch_size=2,) with elements of variable length.
+    """
+    sample_rate = 16000
+    test_input = np.ones((2, sample_rate)) * 2e3
+    return test_input
+
+
+@pytest.fixture
+def asr_dummy_estimator(framework):
+    def _asr_dummy_estimator(**kwargs):
+        asr_dummy = None
+        if framework == "tensorflow2":
+
+            class TensorFlowV2AsrDummy(TensorFlowV2Estimator, SpeechRecognizerMixin):
+                def get_activations():
+                    pass
+
+                def predict(self, x):
+                    pass
+
+                def loss_gradient(self, x, y, **kwargs):
+                    return x
+
+                def set_learning_phase():
+                    pass
+
+                @property
+                def input_shape(self):
+                    return None
+
+            asr_dummy = TensorFlowV2AsrDummy(channels_first=None, model=None, clip_values=None)
+        if framework == "pytorch":
+
+            class PyTorchAsrDummy(PyTorchEstimator, SpeechRecognizerMixin):
+                def get_activations():
+                    pass
+
+                def predict(self, x):
+                    pass
+
+                def loss_gradient(self, x, y, **kwargs):
+                    return x
+
+                def set_learning_phase():
+                    pass
+
+                @property
+                def input_shape(self):
+                    return None
+
+            asr_dummy = PyTorchAsrDummy(channels_first=None, model=None, clip_values=None)
+        if asr_dummy is None:
+            raise ARTTestFixtureNotImplemented(
+                "ASR dummy estimator not available for this framework", asr_dummy_estimator.__name__, framework
+            )
+        return asr_dummy
+
+    return _asr_dummy_estimator

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -34,21 +34,21 @@ class TestImperceptibleASR:
     Test the ImperceptibleASR attack.
     """
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_is_subclass(self, art_warning):
         try:
             assert issubclass(ImperceptibleASR, EvasionAttack)
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_implements_abstract_methods(self, art_warning, asr_dummy_estimator):
         try:
             ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_generate(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -64,7 +64,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_generate_batch(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -80,7 +80,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_adversarial(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -107,7 +107,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_imperceptible(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -134,7 +134,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_loss_gradient_masking_threshold(self, art_warning, asr_dummy_estimator, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
@@ -161,7 +161,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_loss_gradient_masking_threshold_tf(self, art_warning, asr_dummy_estimator, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
@@ -188,7 +188,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_approximate_power_spectral_density_tf(self, art_warning, asr_dummy_estimator, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -21,67 +21,13 @@ import logging
 
 import numpy as np
 import pytest
-import tensorflow as tf
 from numpy.testing import assert_array_equal
 
 from art.attacks.attack import EvasionAttack
 from art.attacks.evasion.imperceptible_asr.imperceptible_asr import ImperceptibleAsr, PsychoacousticMasker
-from art.estimators.speech_recognition.speech_recognizer import SpeechRecognizerMixin
-from art.estimators.tensorflow import TensorFlowV2Estimator
+from tests.utils import ARTTestException
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture
-def audio_sample():
-    """
-    Create audio sample.
-    """
-    sample_rate = 16000
-    test_input = np.ones((sample_rate)) * 10e3
-    return test_input
-
-
-@pytest.fixture
-def audio_data():
-    """
-    Create audio fixtures of shape (nb_samples=3,) with elements of variable length.
-    """
-    sample_rate = 16000
-    test_input = np.array(
-        [
-            np.zeros(sample_rate),
-            np.ones(sample_rate * 2) * 2e3,
-            np.ones(sample_rate * 3) * 3e3,
-            np.ones(sample_rate * 3) * 3e3,
-        ],
-        dtype=object,
-    )
-    return test_input
-
-
-@pytest.fixture
-def audio_batch_padded():
-    """
-    Create audio fixtures of shape (batch_size=2,) with elements of variable length.
-    """
-    sample_rate = 16000
-    test_input = np.zeros((2, sample_rate)) * 2e3
-    return test_input
-
-
-class TensorFlowV2AsrDummy(TensorFlowV2Estimator, SpeechRecognizerMixin):
-    def get_activations():
-        pass
-
-    def predict(self, x):
-        pass
-
-    def loss_gradient(self, x, y, **kwargs):
-        return x
-
-    def set_learning_phase():
-        pass
 
 
 class TestImperceptibleAsr:
@@ -89,57 +35,187 @@ class TestImperceptibleAsr:
     Test the ImperceptibleAsr attack.
     """
 
-    def test_is_subclass(self):
-        assert issubclass(ImperceptibleAsr, EvasionAttack)
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_is_subclass(self, art_warning):
+        try:
+            assert issubclass(ImperceptibleAsr, EvasionAttack)
+        except ARTTestException as e:
+            art_warning(e)
 
-    def test_implements_abstract_methods(self):
-        ImperceptibleAsr(estimator=TensorFlowV2AsrDummy(), masker=PsychoacousticMasker())
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_implements_abstract_methods(self, art_warning, asr_dummy_estimator):
+        try:
+            ImperceptibleAsr(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
+        except ARTTestException as e:
+            art_warning(e)
 
-    def test_create_adversarial_numpy(self, mocker, audio_data):
-        test_input = audio_data
-        test_target = ["dummy"] * test_input.shape[0]
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_generate(self, art_warning, mocker, asr_dummy_estimator, audio_data):
+        try:
+            test_input, test_target = audio_data
 
-        mocker.patch.object(TensorFlowV2AsrDummy, "predict", return_value=test_target)
+            mocker.patch.object(ImperceptibleAsr, "_create_adversarial")
+            mocker.patch.object(ImperceptibleAsr, "_create_imperceptible")
 
-        # learning rate of zero ensures that adversarial example equals test input
-        imperceptible_asr = ImperceptibleAsr(
-            estimator=TensorFlowV2AsrDummy(), masker=PsychoacousticMasker(), max_iter_1=10, learning_rate_1=0
-        )
-        adversarial = imperceptible_asr._create_adversarial(test_input, test_target)
+            imperceptible_asr = ImperceptibleAsr(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
+            _ = imperceptible_asr._generate_batch(test_input, test_target)
 
-        # test shape and adversarial example result
-        assert [x.shape for x in test_input] == [a.shape for a in adversarial]
-        assert [(a - x).sum() for a, x in zip(adversarial, test_input)] == [0.0] * 4
+            imperceptible_asr._create_adversarial.assert_called()
+            imperceptible_asr._create_imperceptible.assert_called()
+        except ARTTestException as e:
+            art_warning(e)
 
-    # # TODO does only work with TF2 >= 2.2....
-    # def test_classifier_type_check_fail(self):
-    #    backend_test_classifier_type_check_fail(ImperceptibleAsr, [TensorFlowV2Estimator, SpeechRecognizerMixin])
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_generate_batch(self, art_warning, mocker, asr_dummy_estimator, audio_data):
+        try:
+            test_input, test_target = audio_data
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires Tensorflow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
-    def test_loss_gradient_masking_threshold_tf(self, audio_batch_padded):
-        import tensorflow.compat.v1 as tf1
+            mocker.patch.object(ImperceptibleAsr, "_create_adversarial")
+            mocker.patch.object(ImperceptibleAsr, "_create_imperceptible")
 
-        tf1.reset_default_graph()
+            imperceptible_asr = ImperceptibleAsr(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
+            _ = imperceptible_asr._generate_batch(test_input, test_target)
 
-        test_delta = audio_batch_padded
-        test_psd_maxium = np.ones((test_delta.shape[0], 28))
-        test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
+            imperceptible_asr._create_adversarial.assert_called()
+            imperceptible_asr._create_imperceptible.assert_called()
+        except ARTTestException as e:
+            art_warning(e)
 
-        # TODO mock masker
-        imperceptible_asr = ImperceptibleAsr(
-            estimator=TensorFlowV2AsrDummy(), masker=PsychoacousticMasker(), max_iter_1=10, learning_rate_1=0
-        )
-        feed_dict = {
-            imperceptible_asr._delta: test_delta,
-            imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maxium,
-            imperceptible_asr._masking_threshold_tf: test_masking_threshold,
-        }
-        with tf1.Session() as sess:
-            loss_gradient, loss = sess.run(imperceptible_asr._loss_gradient_masking_threshold_op_tf, feed_dict)
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_create_adversarial(self, art_warning, mocker, asr_dummy_estimator, audio_data):
+        try:
+            test_input, test_target = audio_data
 
-        assert loss_gradient.shape == test_delta.shape
-        assert loss.ndim == 1 and loss.shape[0] == test_delta.shape[0]
+            estimator = asr_dummy_estimator()
+            mocker.patch.object(estimator, "predict", return_value=test_target)
+            mocker.patch.object(
+                ImperceptibleAsr,
+                "_loss_gradient_masking_threshold",
+                return_value=(np.zeros_like(audio_data), [0] * test_input.shape[0]),
+            )
+
+            # learning rate of zero ensures that adversarial example equals test input
+            imperceptible_asr = ImperceptibleAsr(
+                estimator=estimator, masker=PsychoacousticMasker(), max_iter_1=15, learning_rate_1=0
+            )
+            adversarial = imperceptible_asr._create_adversarial(test_input, test_target)
+
+            # test shape and adversarial example result
+            assert [x.shape for x in test_input] == [a.shape for a in adversarial]
+            assert [(a - x).sum() for a, x in zip(adversarial, test_input)] == [0.0] * test_input.shape[0]
+        except ARTTestException as e:
+            art_warning(e)
+
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_create_imperceptible(self, art_warning, mocker, asr_dummy_estimator, audio_data):
+        try:
+            test_input, test_target = audio_data
+            test_adversarial = test_input
+
+            estimator = asr_dummy_estimator()
+            mocker.patch.object(estimator, "predict", return_value=test_target)
+            mocker.patch.object(
+                ImperceptibleAsr,
+                "_loss_gradient_masking_threshold",
+                return_value=(np.zeros_like(test_input), [0] * test_input.shape[0]),
+            )
+
+            # learning rate of zero ensures that adversarial example equals test input
+            imperceptible_asr = ImperceptibleAsr(
+                estimator=estimator, masker=PsychoacousticMasker(), max_iter_2=25, learning_rate_2=0
+            )
+            adversarial = imperceptible_asr._create_imperceptible(test_input, test_adversarial, test_target)
+
+            # test shape and adversarial example result
+            assert [x.shape for x in test_input] == [a.shape for a in adversarial]
+            assert [(x - a).sum() for a, x in zip(adversarial, test_input)] == [0.0] * test_input.shape[0]
+        except ARTTestException as e:
+            art_warning(e)
+
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_loss_gradient_masking_threshold(self, art_warning, asr_dummy_estimator, audio_batch_padded):
+        try:
+            import tensorflow.compat.v1 as tf1
+
+            tf1.reset_default_graph()
+
+            test_delta = audio_batch_padded
+            test_psd_maxium = np.ones((test_delta.shape[0], 28))
+            test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
+
+            imperceptible_asr = ImperceptibleAsr(
+                estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(), max_iter_1=10, learning_rate_1=0
+            )
+            feed_dict = {
+                imperceptible_asr._delta: test_delta,
+                imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maxium,
+                imperceptible_asr._masking_threshold_tf: test_masking_threshold,
+            }
+            with tf1.Session() as sess:
+                loss_gradient, loss = sess.run(imperceptible_asr._loss_gradient_masking_threshold_op_tf, feed_dict)
+
+            assert loss_gradient.shape == test_delta.shape
+            assert loss.ndim == 1 and loss.shape[0] == test_delta.shape[0]
+        except ARTTestException as e:
+            art_warning(e)
+
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_loss_gradient_masking_threshold_tf(self, art_warning, asr_dummy_estimator, audio_batch_padded):
+        try:
+            import tensorflow.compat.v1 as tf1
+
+            tf1.reset_default_graph()
+
+            test_delta = audio_batch_padded
+            test_psd_maxium = np.ones((test_delta.shape[0], 28))
+            test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
+
+            imperceptible_asr = ImperceptibleAsr(
+                estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(), max_iter_1=10, learning_rate_1=0
+            )
+            feed_dict = {
+                imperceptible_asr._delta: test_delta,
+                imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maxium,
+                imperceptible_asr._masking_threshold_tf: test_masking_threshold,
+            }
+            with tf1.Session() as sess:
+                loss_gradient, loss = sess.run(imperceptible_asr._loss_gradient_masking_threshold_op_tf, feed_dict)
+
+            assert loss_gradient.shape == test_delta.shape
+            assert loss.ndim == 1 and loss.shape[0] == test_delta.shape[0]
+        except ARTTestException as e:
+            art_warning(e)
+
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_approximate_power_spectral_density_tf(self, art_warning, asr_dummy_estimator, audio_batch_padded):
+        try:
+            import tensorflow.compat.v1 as tf1
+
+            tf1.reset_default_graph()
+
+            test_delta = audio_batch_padded
+            test_psd_maxium = np.ones((test_delta.shape[0], 28))
+
+            masker = PsychoacousticMasker()
+            imperceptible_asr = ImperceptibleAsr(
+                estimator=asr_dummy_estimator(), masker=masker, max_iter_1=10, learning_rate_1=0
+            )
+            feed_dict = {
+                imperceptible_asr._delta: test_delta,
+                imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maxium,
+            }
+
+            approximate_psd_tf = imperceptible_asr._approximate_power_spectral_density_tf(
+                imperceptible_asr._delta, imperceptible_asr._power_spectral_density_maximum_tf
+            )
+            with tf1.Session() as sess:
+                psd_approximated = sess.run(approximate_psd_tf, feed_dict)
+
+            assert psd_approximated.ndim == 3
+            assert psd_approximated.shape[0] == test_delta.shape[0]  # batch_size
+            assert psd_approximated.shape[1] == masker.window_size // 2 + 1
+        except ARTTestException as e:
+            art_warning(e)
 
 
 class TestPsychoacousticMasker:
@@ -147,66 +223,91 @@ class TestPsychoacousticMasker:
     Test the PsychoacousticMasker.
     """
 
-    def test_power_spectral_density(self, audio_sample):
-        test_input = audio_sample
+    @pytest.mark.framework_agnostic
+    def test_power_spectral_density(self, art_warning, audio_sample):
+        try:
+            test_input = audio_sample
 
-        masker = PsychoacousticMasker()
-        psd_matrix, psd_max = masker.power_spectral_density(test_input)
+            masker = PsychoacousticMasker()
+            psd_matrix, psd_max = masker.power_spectral_density(test_input)
 
-        assert psd_matrix.shape[0] == masker.window_size // 2 + 1
-        assert psd_matrix.shape[1] == psd_max.shape[0]
+            assert psd_matrix.shape[0] == masker.window_size // 2 + 1
+            assert psd_matrix.shape[1] == psd_max.shape[0]
+        except ARTTestException as e:
+            art_warning(e)
 
-    def test_find_maskers(self):
-        test_psd_vector = np.array([2, 10, 96, 90, 35, 40, 36, 60, 55, 91, 40])
+    @pytest.mark.framework_agnostic
+    def test_find_maskers(self, art_warning):
+        try:
+            test_psd_vector = np.array([2, 10, 96, 90, 35, 40, 36, 60, 55, 91, 40])
 
-        masker = PsychoacousticMasker()
-        maskers, masker_idx = masker.find_maskers(test_psd_vector)
+            masker = PsychoacousticMasker()
+            maskers, masker_idx = masker.find_maskers(test_psd_vector)
 
-        # test masker_idx shape and first, last maskers
-        assert masker_idx.tolist() == [2, 5, 7, 9]
-        assert_array_equal(
-            maskers[[0, -1]], 10 * np.log10(np.sum(10 ** np.array([[1.0, 9.6, 9.0], [5.5, 9.1, 4.0]]), axis=1))
-        )
+            # test masker_idx shape and first, last maskers
+            assert masker_idx.tolist() == [2, 5, 7, 9]
+            assert_array_equal(
+                maskers[[0, -1]], 10 * np.log10(np.sum(10 ** np.array([[1.0, 9.6, 9.0], [5.5, 9.1, 4.0]]), axis=1))
+            )
+        except ARTTestException as e:
+            art_warning(e)
 
-    def test_filter_maskers(self):
-        test_psd_vector = np.array([2, 10, 96, 90, 35, 40, 36, 60, 55, 91, 40])
-        test_masker_idx = np.array([2, 5, 7, 9])
-        test_maskers = test_psd_vector[test_masker_idx]
+    @pytest.mark.framework_agnostic
+    def test_filter_maskers(self, art_warning):
+        try:
+            test_psd_vector = np.array([2, 10, 96, 90, 35, 40, 36, 60, 55, 91, 40])
+            test_masker_idx = np.array([2, 5, 7, 9])
+            test_maskers = test_psd_vector[test_masker_idx]
 
-        masker = PsychoacousticMasker()
-        maskers, masker_idx = masker.filter_maskers(test_maskers, test_masker_idx)
+            masker = PsychoacousticMasker()
+            maskers, masker_idx = masker.filter_maskers(test_maskers, test_masker_idx)
 
-        assert masker_idx.tolist() == [9]
-        assert maskers.tolist() == [91]
+            assert masker_idx.tolist() == [9]
+            assert maskers.tolist() == [91]
+        except ARTTestException as e:
+            art_warning(e)
 
-    def test_calculate_individual_threshold(self, mocker):
-        test_masker_idx = np.array([2, 5, 7, 9])
-        test_maskers = np.array([96, 40, 60, 9])
+    @pytest.mark.framework_agnostic
+    def test_calculate_individual_threshold(self, art_warning, mocker):
+        try:
+            test_masker_idx = np.array([2, 5, 7, 9])
+            test_maskers = np.array([96, 40, 60, 9])
 
-        masker = PsychoacousticMasker()
-        threshold = masker.calculate_individual_threshold(test_maskers, test_masker_idx)
+            masker = PsychoacousticMasker()
+            threshold = masker.calculate_individual_threshold(test_maskers, test_masker_idx)
 
-        assert threshold.shape == test_masker_idx.shape + (masker.window_size // 2 + 1,)
+            assert threshold.shape == test_masker_idx.shape + (masker.window_size // 2 + 1,)
+        except ARTTestException as e:
+            art_warning(e)
 
-    def test_calculate_global_threshold(self, mocker):
-        test_threshold = np.array([[0, 10, 20], [10, 0, 20]])
+    @pytest.mark.framework_agnostic
+    def test_calculate_global_threshold(self, art_warning, mocker):
+        try:
+            test_threshold = np.array([[0, 10, 20], [10, 0, 20]])
 
-        mocker.patch(
-            "art.attacks.evasion.imperceptible_asr.imperceptible_asr.PsychoacousticMasker.absolute_threshold_hearing",
-            new_callable=mocker.PropertyMock,
-            return_value=np.zeros(test_threshold.shape[1]),
-        )
+            mocker.patch(
+                "art.attacks.evasion.imperceptible_asr.imperceptible_asr."
+                "PsychoacousticMasker.absolute_threshold_hearing",
+                new_callable=mocker.PropertyMock,
+                return_value=np.zeros(test_threshold.shape[1]),
+            )
 
-        masker = PsychoacousticMasker()
-        threshold = masker.calculate_global_threshold(test_threshold)
+            masker = PsychoacousticMasker()
+            threshold = masker.calculate_global_threshold(test_threshold)
 
-        assert threshold.tolist() == (10 * np.log10([12, 12, 201])).tolist()
+            assert threshold.tolist() == (10 * np.log10([12, 12, 201])).tolist()
+        except ARTTestException as e:
+            art_warning(e)
 
-    def test_calculate_threshold_and_psd_maximum(self, audio_sample):
-        test_input = audio_sample
+    @pytest.mark.framework_agnostic
+    def test_calculate_threshold_and_psd_maximum(self, art_warning, audio_sample):
+        try:
+            test_input = audio_sample
 
-        masker = PsychoacousticMasker()
-        threshold, psd_max = masker.calculate_threshold_and_psd_maximum(test_input)
+            masker = PsychoacousticMasker()
+            threshold, psd_max = masker.calculate_threshold_and_psd_maximum(test_input)
 
-        assert threshold.shape[1] == psd_max.shape[0]
-        assert threshold.shape[0] == masker.window_size // 2 + 1
+            assert threshold.shape[1] == psd_max.shape[0]
+            assert threshold.shape[0] == masker.window_size // 2 + 1
+        except ARTTestException as e:
+            art_warning(e)

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -1,0 +1,59 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+import pytest
+
+from art.attacks.attack import EvasionAttack
+from art.attacks.evasion.imperceptible_asr.imperceptible_asr import ImperceptibleAsr
+from art.estimators.speech_recognition.speech_recognizer import SpeechRecognizerMixin
+from art.estimators.tensorflow import TensorFlowV2Estimator
+
+logger = logging.getLogger(__name__)
+
+
+class TensorFlowV2AsrDummy(TensorFlowV2Estimator, SpeechRecognizerMixin):
+    def get_activations():
+        pass
+
+    def predict(self, x):
+        pass
+
+    def loss_gradient(self, x, y, **kwargs):
+        return x
+
+    def set_learning_phase():
+        pass
+
+
+class TestImperceptibleAsr:
+    """
+    Test the ImperceptibleAsr attack.
+    """
+
+    def test_is_subclass(self):
+        assert issubclass(ImperceptibleAsr, EvasionAttack)
+
+    def test_implements_abstract_methods(self):
+        ImperceptibleAsr(estimator=TensorFlowV2AsrDummy())
+
+    # # TODO does only work with TF2 >= 2.2....
+    # def test_classifier_type_check_fail(self):
+    #    backend_test_classifier_type_check_fail(ImperceptibleAsr, [TensorFlowV2Estimator, SpeechRecognizerMixin])

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -21,31 +21,30 @@ import logging
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
 
 from art.attacks.attack import EvasionAttack
-from art.attacks.evasion.imperceptible_asr.imperceptible_asr import ImperceptibleAsr, PsychoacousticMasker
+from art.attacks.evasion.imperceptible_asr.imperceptible_asr import ImperceptibleASR, PsychoacousticMasker
 from tests.utils import ARTTestException
 
 logger = logging.getLogger(__name__)
 
 
-class TestImperceptibleAsr:
+class TestImperceptibleASR:
     """
-    Test the ImperceptibleAsr attack.
+    Test the ImperceptibleASR attack.
     """
 
     @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
     def test_is_subclass(self, art_warning):
         try:
-            assert issubclass(ImperceptibleAsr, EvasionAttack)
+            assert issubclass(ImperceptibleASR, EvasionAttack)
         except ARTTestException as e:
             art_warning(e)
 
     @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
     def test_implements_abstract_methods(self, art_warning, asr_dummy_estimator):
         try:
-            ImperceptibleAsr(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
+            ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
         except ARTTestException as e:
             art_warning(e)
 
@@ -54,10 +53,10 @@ class TestImperceptibleAsr:
         try:
             test_input, test_target = audio_data
 
-            mocker.patch.object(ImperceptibleAsr, "_create_adversarial")
-            mocker.patch.object(ImperceptibleAsr, "_create_imperceptible")
+            mocker.patch.object(ImperceptibleASR, "_create_adversarial")
+            mocker.patch.object(ImperceptibleASR, "_create_imperceptible")
 
-            imperceptible_asr = ImperceptibleAsr(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
             _ = imperceptible_asr._generate_batch(test_input, test_target)
 
             imperceptible_asr._create_adversarial.assert_called()
@@ -70,10 +69,10 @@ class TestImperceptibleAsr:
         try:
             test_input, test_target = audio_data
 
-            mocker.patch.object(ImperceptibleAsr, "_create_adversarial")
-            mocker.patch.object(ImperceptibleAsr, "_create_imperceptible")
+            mocker.patch.object(ImperceptibleASR, "_create_adversarial")
+            mocker.patch.object(ImperceptibleASR, "_create_imperceptible")
 
-            imperceptible_asr = ImperceptibleAsr(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
             _ = imperceptible_asr._generate_batch(test_input, test_target)
 
             imperceptible_asr._create_adversarial.assert_called()
@@ -89,13 +88,13 @@ class TestImperceptibleAsr:
             estimator = asr_dummy_estimator()
             mocker.patch.object(estimator, "predict", return_value=test_target)
             mocker.patch.object(
-                ImperceptibleAsr,
+                ImperceptibleASR,
                 "_loss_gradient_masking_threshold",
                 return_value=(np.zeros_like(audio_data), [0] * test_input.shape[0]),
             )
 
             # learning rate of zero ensures that adversarial example equals test input
-            imperceptible_asr = ImperceptibleAsr(
+            imperceptible_asr = ImperceptibleASR(
                 estimator=estimator, masker=PsychoacousticMasker(), max_iter_1=15, learning_rate_1=0
             )
             adversarial = imperceptible_asr._create_adversarial(test_input, test_target)
@@ -115,13 +114,13 @@ class TestImperceptibleAsr:
             estimator = asr_dummy_estimator()
             mocker.patch.object(estimator, "predict", return_value=test_target)
             mocker.patch.object(
-                ImperceptibleAsr,
+                ImperceptibleASR,
                 "_loss_gradient_masking_threshold",
                 return_value=(np.zeros_like(test_input), [0] * test_input.shape[0]),
             )
 
             # learning rate of zero ensures that adversarial example equals test input
-            imperceptible_asr = ImperceptibleAsr(
+            imperceptible_asr = ImperceptibleASR(
                 estimator=estimator, masker=PsychoacousticMasker(), max_iter_2=25, learning_rate_2=0
             )
             adversarial = imperceptible_asr._create_imperceptible(test_input, test_adversarial, test_target)
@@ -143,7 +142,7 @@ class TestImperceptibleAsr:
             test_psd_maxium = np.ones((test_delta.shape[0], 28))
             test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
 
-            imperceptible_asr = ImperceptibleAsr(
+            imperceptible_asr = ImperceptibleASR(
                 estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(), max_iter_1=10, learning_rate_1=0
             )
             feed_dict = {
@@ -170,7 +169,7 @@ class TestImperceptibleAsr:
             test_psd_maxium = np.ones((test_delta.shape[0], 28))
             test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
 
-            imperceptible_asr = ImperceptibleAsr(
+            imperceptible_asr = ImperceptibleASR(
                 estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(), max_iter_1=10, learning_rate_1=0
             )
             feed_dict = {
@@ -197,7 +196,7 @@ class TestImperceptibleAsr:
             test_psd_maxium = np.ones((test_delta.shape[0], 28))
 
             masker = PsychoacousticMasker()
-            imperceptible_asr = ImperceptibleAsr(
+            imperceptible_asr = ImperceptibleASR(
                 estimator=asr_dummy_estimator(), masker=masker, max_iter_1=10, learning_rate_1=0
             )
             feed_dict = {
@@ -246,7 +245,7 @@ class TestPsychoacousticMasker:
 
             # test masker_idx shape and first, last maskers
             assert masker_idx.tolist() == [2, 5, 7, 9]
-            assert_array_equal(
+            np.testing.assert_array_equal(
                 maskers[[0, -1]], 10 * np.log10(np.sum(10 ** np.array([[1.0, 9.6, 9.0], [5.5, 9.1, 4.0]]), axis=1))
             )
         except ARTTestException as e:

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -95,8 +95,10 @@ class TestImperceptibleASR:
 
             # learning rate of zero ensures that adversarial example equals test input
             imperceptible_asr = ImperceptibleASR(
-                estimator=estimator, masker=PsychoacousticMasker(), max_iter_1=15, learning_rate_1=0
+                estimator=estimator, masker=PsychoacousticMasker(), max_iter_1=15, learning_rate_1=0.5
             )
+            # learning rate of zero ensures that adversarial example equals test input
+            imperceptible_asr.learning_rate_1 = 0
             adversarial = imperceptible_asr._create_adversarial(test_input, test_target)
 
             # test shape and adversarial example result
@@ -119,10 +121,11 @@ class TestImperceptibleASR:
                 return_value=(np.zeros_like(test_input), [0] * test_input.shape[0]),
             )
 
-            # learning rate of zero ensures that adversarial example equals test input
             imperceptible_asr = ImperceptibleASR(
-                estimator=estimator, masker=PsychoacousticMasker(), max_iter_2=25, learning_rate_2=0
+                estimator=estimator, masker=PsychoacousticMasker(), max_iter_2=25, learning_rate_2=0.5
             )
+            # learning rate of zero ensures that adversarial example equals test input
+            imperceptible_asr.learning_rate_2 = 0
             adversarial = imperceptible_asr._create_imperceptible(test_input, test_adversarial, test_target)
 
             # test shape and adversarial example result
@@ -143,7 +146,7 @@ class TestImperceptibleASR:
             test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
 
             imperceptible_asr = ImperceptibleASR(
-                estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(), max_iter_1=10, learning_rate_1=0
+                estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(),
             )
             feed_dict = {
                 imperceptible_asr._delta: test_delta,
@@ -170,7 +173,7 @@ class TestImperceptibleASR:
             test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
 
             imperceptible_asr = ImperceptibleASR(
-                estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(), max_iter_1=10, learning_rate_1=0
+                estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(),
             )
             feed_dict = {
                 imperceptible_asr._delta: test_delta,
@@ -197,7 +200,7 @@ class TestImperceptibleASR:
 
             masker = PsychoacousticMasker()
             imperceptible_asr = ImperceptibleASR(
-                estimator=asr_dummy_estimator(), masker=masker, max_iter_1=10, learning_rate_1=0
+                estimator=asr_dummy_estimator(), masker=masker,
             )
             feed_dict = {
                 imperceptible_asr._delta: test_delta,


### PR DESCRIPTION
# Description

Implements an imperceptible ASR attack. The attack is independent of a specific ASR estimator and will be able to handle TensorFlow ASR estimators (and soon PyTorch ASR estimators).

The PR comes with a separate implementation of the Psychoaccoustic model (steps 1 to 5 of the MPEG-1, Psychoacoustic Model 1, ISO standard) described in Lin and Abdulla, Principles of Psychoacoustics (2015).

Related to https://github.com/Trusted-AI/adversarial-robustness-toolbox/issues/273

## Type of change

Please check all the relevant options.

- [x] New feature (non-breaking)

# Testing

Attack comes with a set of tests.

**Test Configuration**:
- Fedora 31 and Fedora 31
- Python 3.6.10 and Python 3.8.5
- ART 1.5 development
- Lingvo 0.6.4 with TensorFlow 2.1.0 and TensorFlow 2.2.0 only

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
