### PR TITLE
Format fix for Membership Inference Black-box attack

### DIFF
--- a/art/attacks/inference/membership_inference/black_box.py
+++ b/art/attacks/inference/membership_inference/black_box.py
@@ -273,6 +273,7 @@ class MembershipInferenceBlackBox(InferenceAttack):
                     inferred = predicted.detach().numpy()
                 else:
                     inferred = np.vstack((inferred, predicted.detach().numpy()))
+            inferred = inferred.reshape(-1).astype(np.int)
         else:
             inferred = np.array([np.argmax(arr) for arr in self.attack_model.predict(np.c_[features, y])])
         return inferred


### PR DESCRIPTION

Signed-off-by: abigailt <abigailt@il.ibm.com>

# Description

Fixed format of return value of infer() method when using 'nn' attack model type.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Ran all membership inference unit tests.

**Test Configuration**:
- OS: MacOS 10.14.6
- Python version: 3.7
- TensorFlow / Keras / PyTorch 

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
