### PR TITLE
Fix optional parameter in infer method

### DIFF
--- a/art/attacks/inference/attribute_inference/black_box.py
+++ b/art/attacks/inference/attribute_inference/black_box.py
@@ -121,7 +121,7 @@ class AttributeInferenceBlackBox(AttributeInferenceAttack):
         # train attack model
         self.attack_model.fit(x_train, y_ready)
 
-    def infer(self, x: np.ndarray, y: np.ndarray = None, **kwargs) -> np.ndarray:
+    def infer(self, x: np.ndarray, y: np.ndarray, **kwargs) -> np.ndarray:
         """
         Infer the attacked feature.
 
@@ -131,7 +131,7 @@ class AttributeInferenceBlackBox(AttributeInferenceAttack):
         :type values: `np.ndarray`
         :return: The inferred feature values.
         """
-        if y is not None and y.shape[0] != x.shape[0]:
+        if y.shape[0] != x.shape[0]:
             raise ValueError("Number of rows in x and y do not match")
         if self.estimator.input_shape[0] != x.shape[1] + 1:
             raise ValueError("Number of features in x + 1 does not match input_shape of classifier")

--- a/art/attacks/inference/attribute_inference/black_box.py
+++ b/art/attacks/inference/attribute_inference/black_box.py
@@ -121,7 +121,7 @@ class AttributeInferenceBlackBox(AttributeInferenceAttack):
         # train attack model
         self.attack_model.fit(x_train, y_ready)
 
-    def infer(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
+    def infer(self, x: np.ndarray, y: np.ndarray = None, **kwargs) -> np.ndarray:
         """
         Infer the attacked feature.
 


### PR DESCRIPTION
Signed-off-by: abigailt <abigailt@il.ibm.com>

# Description

`y` param should not be optional in `infer()` method in `AttributeInferenceBlackBox` class.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Testing

Ran all attribute inference unit tests.

**Test Configuration**:
- OS: MacOS 10.14.6
- Python version: 3.7

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
