### PR TITLE
Add general support for PyTorch in Imperceptible ASR attack

### DIFF
--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
     from tensorflow.compat.v1 import Tensor
     from torch import Tensor as PTensor
 
+    from art.utils import SPEECH_RECOGNIZER_TYPE
+
 logger = logging.getLogger(__name__)
 
 
@@ -65,7 +67,7 @@ class ImperceptibleASR(EvasionAttack):
 
     def __init__(
         self,
-        estimator: Union["PyTorchEstimator", "TensorFlowV2Estimator"],
+        estimator: "SPEECH_RECOGNIZER_TYPE",
         masker: "PsychoacousticMasker",
         eps: float = 2000.0,
         learning_rate_1: float = 100.0,
@@ -349,7 +351,7 @@ class ImperceptibleASR(EvasionAttack):
 
     def _loss_gradient_masking_threshold_tf(
         self, perturbation: "Tensor", psd_maximum_stabilized: "Tensor", masking_threshold_stabilized: "Tensor"
-    ) -> "Tensor":
+    ) -> Union["Tensor", "Tensor"]:
         """
         Compute loss gradient of the masking threshold loss in TensorFlow.
 
@@ -471,7 +473,6 @@ class ImperceptibleASR(EvasionAttack):
         psd_matrix_approximated = pow(10.0, 9.6) / torch.unsqueeze(psd_maximum_stabilized, 1) * psd_matrix
 
         # return PSD matrix such that shape is (batch_size, window_size // 2 + 1, frame_length)
-        # return torch.transpose(psd_matrix_approximated, 1, 2)
         return psd_matrix_approximated
 
     def _check_params(self) -> None:

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
@@ -494,8 +494,8 @@ class ImperceptibleASR(EvasionAttack):
 
         if not isinstance(self.max_iter_2, int):
             raise ValueError("The maximum number of iterations for stage 2 must be of type int.")
-        if self.max_iter_2 <= 0:
-            raise ValueError("The maximum number of iterations for stage 2 must be greater than 0.")
+        if self.max_iter_2 < 0:
+            raise ValueError("The maximum number of iterations for stage 2 must be non-negative.")
 
         if not isinstance(self.learning_rate_1, float):
             raise ValueError("The learning rate for stage 1 must be of type float.")

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
@@ -254,10 +254,12 @@ class ImperceptibleASR(EvasionAttack):
         if x.ndim != 1:
             alpha = np.expand_dims(alpha, axis=-1)
 
-        perturbation = x_adversarial - x
         x_perturbed = x_adversarial.copy()
 
         for i in range(self.max_iter_2):
+            # get perturbation
+            perturbation = x_perturbed - x
+
             # get loss gradients of both losses
             gradients_net = self.estimator.loss_gradient(x_perturbed, y, batch_mode=True)
             gradients_theta, loss_theta = self._loss_gradient_masking_threshold(perturbation, x)

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
@@ -24,18 +24,21 @@ This module implements the adversarial and imperceptible attack on automatic spe
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Tuple, Union
 
 import numpy as np
 import scipy.signal as ss
 
 from art.attacks.attack import EvasionAttack
+from art.estimators.estimator import BaseEstimator, LossGradientsMixin, NeuralNetworkMixin
+from art.estimators.pytorch import PyTorchEstimator
 from art.estimators.speech_recognition.speech_recognizer import SpeechRecognizerMixin
 from art.estimators.tensorflow import TensorFlowV2Estimator
 from art.utils import pad_sequence_input
 
 if TYPE_CHECKING:
     from tensorflow.compat.v1 import Tensor
+    from torch import Tensor as PTensor
 
 logger = logging.getLogger(__name__)
 
@@ -58,11 +61,11 @@ class ImperceptibleASR(EvasionAttack):
         "batch_size",
     ]
 
-    _estimator_requirements = (TensorFlowV2Estimator, SpeechRecognizerMixin)
+    _estimator_requirements = (NeuralNetworkMixin, LossGradientsMixin, BaseEstimator, SpeechRecognizerMixin)
 
     def __init__(
         self,
-        estimator: "TensorFlowV2Estimator",
+        estimator: Union["PyTorchEstimator", "TensorFlowV2Estimator"],
         masker: "PsychoacousticMasker",
         eps: float = 2000.0,
         learning_rate_1: float = 100.0,
@@ -85,10 +88,6 @@ class ImperceptibleASR(EvasionAttack):
         :param max_iter_2: Number of iterations for stage 2 of attack.
         :param batch_size: Batch size.
         """
-        import tensorflow.compat.v1 as tf1
-
-        # disable eager execution as Lingvo uses tensorflow.compat.v1 API
-        tf1.disable_eager_execution()
 
         # Super initialization
         super().__init__(estimator=estimator)
@@ -108,16 +107,34 @@ class ImperceptibleASR(EvasionAttack):
         self._hop_size = masker.hop_size
         self._sample_rate = masker.sample_rate
 
-        # TensorFlow placeholders
-        self._delta = tf1.placeholder(tf1.float32, shape=[None, None], name="art_delta")
-        self._power_spectral_density_maximum_tf = tf1.placeholder(tf1.float32, shape=[None, None], name="art_psd_max")
-        self._masking_threshold_tf = tf1.placeholder(
-            tf1.float32, shape=[None, None, None], name="art_masking_threshold"
-        )
-        # TensorFlow loss gradient ops
-        self._loss_gradient_masking_threshold_op_tf = self._loss_gradient_masking_threshold_tf(
-            self._delta, self._power_spectral_density_maximum_tf, self._masking_threshold_tf
-        )
+        if isinstance(self.estimator, TensorFlowV2Estimator):
+            import tensorflow.compat.v1 as tf1
+
+            # set framework attribute
+            self._framework = "tensorflow"
+
+            # disable eager execution and use tensorflow.compat.v1 API, e.g. Lingvo uses TF2v1 AP
+            tf1.disable_eager_execution()
+
+            # TensorFlow placeholders
+            self._delta = tf1.placeholder(tf1.float32, shape=[None, None], name="art_delta")
+            self._power_spectral_density_maximum_tf = tf1.placeholder(
+                tf1.float32, shape=[None, None], name="art_psd_max"
+            )
+            self._masking_threshold_tf = tf1.placeholder(
+                tf1.float32, shape=[None, None, None], name="art_masking_threshold"
+            )
+            # TensorFlow loss gradient ops
+            self._loss_gradient_masking_threshold_op_tf = self._loss_gradient_masking_threshold_tf(
+                self._delta, self._power_spectral_density_maximum_tf, self._masking_threshold_tf
+            )
+
+        elif isinstance(self.estimator, PyTorchEstimator):
+            # set framework attribute
+            self._framework = "pytorch"
+        else:
+            # set framework attribute
+            self._framework = None
 
     def generate(self, x: np.ndarray, y: np.ndarray, **kwargs) -> np.ndarray:
         """
@@ -305,13 +322,21 @@ class ImperceptibleASR(EvasionAttack):
         masking_threshold_stabilized = 10 ** (masking_threshold * 0.1)
         psd_maximum_stabilized = 10 ** (psd_maximum * 0.1)
 
-        # get loss gradients (TensorFlow)
-        feed_dict = {
-            self._delta: perturbation_padded,
-            self._power_spectral_density_maximum_tf: psd_maximum_stabilized,
-            self._masking_threshold_tf: masking_threshold_stabilized,
-        }
-        gradients_padded, loss = self.estimator._sess.run(self._loss_gradient_masking_threshold_op_tf, feed_dict)
+        if self._framework == "tensorflow":
+            # get loss gradients (TensorFlow)
+            feed_dict = {
+                self._delta: perturbation_padded,
+                self._power_spectral_density_maximum_tf: psd_maximum_stabilized,
+                self._masking_threshold_tf: masking_threshold_stabilized,
+            }
+            gradients_padded, loss = self.estimator._sess.run(self._loss_gradient_masking_threshold_op_tf, feed_dict)
+        elif self._framework == "pytorch":
+            # get loss gradients (TensorFlow)
+            gradients_padded, loss = self._loss_gradient_masking_threshold_torch(
+                perturbation_padded, psd_maximum_stabilized, masking_threshold_stabilized
+            )
+        else:
+            raise NotImplementedError
 
         # undo padding, i.e. change gradients shape from (nb_samples, max_length) to (nb_samples)
         lengths = delta_mask.sum(axis=1)
@@ -320,7 +345,7 @@ class ImperceptibleASR(EvasionAttack):
             gradient = gradient_padded[:length]
             gradients.append(gradient)
 
-        return np.array(gradients), loss
+        return np.array(gradients, dtype=object), loss
 
     def _loss_gradient_masking_threshold_tf(
         self, perturbation: "Tensor", psd_maximum_stabilized: "Tensor", masking_threshold_stabilized: "Tensor"
@@ -350,6 +375,41 @@ class ImperceptibleASR(EvasionAttack):
         # compute loss gradient
         loss_gradient = tf1.gradients(loss, [perturbation])[0]
         return loss_gradient, loss
+
+    def _loss_gradient_masking_threshold_torch(
+        self, perturbation: np.ndarray, psd_maximum_stabilized: np.ndarray, masking_threshold_stabilized: np.ndarray
+    ) -> Union[np.ndarray, np.ndarray]:
+        """
+        Compute loss gradient of the masking threshold loss in PyTorch.
+
+        See also `ImperceptibleASR._loss_gradient_masking_threshold_tf`.
+        """
+        import torch
+
+        # define tensors
+        perturbation_torch = torch.from_numpy(perturbation).to(self.estimator._device)
+        masking_threshold_stabilized_torch = torch.from_numpy(masking_threshold_stabilized).to(self.estimator._device)
+        psd_maximum_stabilized_torch = torch.from_numpy(psd_maximum_stabilized).to(self.estimator._device)
+
+        # track gradient of perturbation
+        perturbation_torch.requires_grad = True
+
+        # calculate approximate power spectral density
+        psd_perturbation = self._approximate_power_spectral_density_torch(
+            perturbation_torch, psd_maximum_stabilized_torch
+        )
+
+        # calculate hinge loss
+        loss = torch.mean(
+            torch.nn.functional.relu(psd_perturbation - masking_threshold_stabilized_torch), dim=(1, 2), keepdims=False
+        )
+
+        # compute loss gradient
+        loss.sum().backward()
+        loss_gradient = perturbation_torch.grad.cpu().numpy()
+        loss_value = loss.detach().cpu().numpy()
+
+        return loss_gradient, loss_value
 
     def _approximate_power_spectral_density_tf(
         self, perturbation: "Tensor", psd_maximum_stabilized: "Tensor"
@@ -381,13 +441,38 @@ class ImperceptibleASR(EvasionAttack):
         # return PSD matrix such that shape is (batch_size, window_size // 2 + 1, frame_length)
         return tf1.transpose(psd_matrix_approximated, [0, 2, 1])
 
-    def _approximate_power_spectral_density_torch(self):
-        """Approximate the power spectral density for a perturbation `perturbation` in PyTorch."""
-        raise NotImplementedError
+    def _approximate_power_spectral_density_torch(
+        self, perturbation: "PTensor", psd_maximum_stabilized: "PTensor"
+    ) -> "PTensor":
+        """
+        Approximate the power spectral density for a perturbation `perturbation` in PyTorch.
 
-    def _loss_gradient_masking_threshold_torch(self):
-        """Compute loss gradient of the masking threshold loss in PyTorch."""
-        raise NotImplementedError
+        See also `ImperceptibleASR._approximate_power_spectral_density_tf`.
+        """
+        import torch
+
+        # compute short-time Fourier transform (STFT)
+        stft_matrix = torch.stft(
+            perturbation,
+            n_fft=self._window_size,
+            hop_length=self._hop_size,
+            win_length=self._window_size,
+            center=False,
+            window=torch.hann_window(self._window_size).to(self.estimator._device),
+        ).to(self.estimator._device)
+        stft_matrix_abs = torch.sqrt(torch.sum(torch.square(stft_matrix), -1))
+
+        # compute power spectral density (PSD)
+        # note: fixes implementation of Qin et al. by also considering the square root of gain_factor
+        gain_factor = 8.0 / 3.0
+        psd_matrix = gain_factor * torch.square(stft_matrix_abs / self._window_size)
+
+        # approximate normalized psd: psd_matrix_approximated = 10^((96.0 - psd_matrix_max + psd_matrix)/10)
+        psd_matrix_approximated = pow(10.0, 9.6) / torch.unsqueeze(psd_maximum_stabilized, 1) * psd_matrix
+
+        # return PSD matrix such that shape is (batch_size, window_size // 2 + 1, frame_length)
+        # return torch.transpose(psd_matrix_approximated, 1, 2)
+        return psd_matrix_approximated
 
     def _check_params(self) -> None:
         """

--- a/art/utils.py
+++ b/art/utils.py
@@ -93,6 +93,9 @@ if TYPE_CHECKING:
     from art.estimators.object_detection.pytorch_faster_rcnn import PyTorchFasterRCNN
     from art.estimators.object_detection.tensorflow_faster_rcnn import TensorFlowFasterRCNN
 
+    from art.estimators.speech_recognition.pytorch_deep_speech import PyTorchDeepSpeech
+    from art.estimators.speech_recognition.tensorflow_lingvo import TensorFlowLingvoAsr
+
     CLASSIFIER_TYPE = Union[
         Classifier,
         BlackBoxClassifier,
@@ -172,6 +175,10 @@ if TYPE_CHECKING:
         ObjectDetector, PyTorchFasterRCNN, TensorFlowFasterRCNN,
     ]
 
+    SPEECH_RECOGNIZER_TYPE = Union[
+        PyTorchDeepSpeech,
+        TensorFlowLingvoAsr,
+    ]
 
 # --------------------------------------------------------------------------------------------------------- DEPRECATION
 

--- a/tests/attacks/evasion/conftest.py
+++ b/tests/attacks/evasion/conftest.py
@@ -69,7 +69,7 @@ def audio_batch_padded():
 def asr_dummy_estimator(framework):
     def _asr_dummy_estimator(**kwargs):
         asr_dummy = None
-        if framework == "tensorflow2":
+        if framework == "tensorflow2v1":
 
             class TensorFlowV2AsrDummy(TensorFlowV2Estimator, SpeechRecognizerMixin):
                 def get_activations():

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -34,21 +34,21 @@ class TestImperceptibleASR:
     Test the ImperceptibleASR attack.
     """
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_is_subclass(self, art_warning):
         try:
             assert issubclass(ImperceptibleASR, EvasionAttack)
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_implements_abstract_methods(self, art_warning, asr_dummy_estimator):
         try:
             ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_generate(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -64,7 +64,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_generate_batch(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -80,7 +80,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_adversarial(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -107,7 +107,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_imperceptible(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -134,30 +134,17 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
-    def test_loss_gradient_masking_threshold(self, art_warning, asr_dummy_estimator, audio_batch_padded):
+    @pytest.mark.skipMlFramework("tensorflow", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_loss_gradient_masking_threshold(self, art_warning, asr_dummy_estimator, audio_data):
         try:
-            import tensorflow.compat.v1 as tf1
+            test_input, _ = audio_data
+            test_delta = test_input * 0
 
-            tf1.reset_default_graph()
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
+            loss_gradient, loss = imperceptible_asr._loss_gradient_masking_threshold(test_delta, test_input)
 
-            test_delta = audio_batch_padded
-            test_psd_maximum = np.ones((test_delta.shape[0], 28))
-            test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
-
-            imperceptible_asr = ImperceptibleASR(
-                estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(),
-            )
-            feed_dict = {
-                imperceptible_asr._delta: test_delta,
-                imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maximum,
-                imperceptible_asr._masking_threshold_tf: test_masking_threshold,
-            }
-            with tf1.Session() as sess:
-                loss_gradient, loss = sess.run(imperceptible_asr._loss_gradient_masking_threshold_op_tf, feed_dict)
-
-            assert loss_gradient.shape == test_delta.shape
-            assert loss.ndim == 1 and loss.shape[0] == test_delta.shape[0]
+            assert [g.shape for g in loss_gradient] == [d.shape for d in test_delta]
+            assert loss.ndim == 1 and loss.shape == test_delta.shape
         except ARTTestException as e:
             art_warning(e)
 
@@ -172,9 +159,7 @@ class TestImperceptibleASR:
             test_psd_maximum = np.ones((test_delta.shape[0], 28))
             test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
 
-            imperceptible_asr = ImperceptibleASR(
-                estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(),
-            )
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
             feed_dict = {
                 imperceptible_asr._delta: test_delta,
                 imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maximum,
@@ -195,11 +180,10 @@ class TestImperceptibleASR:
             test_psd_maximum = np.ones((test_delta.shape[0], 28))
             test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
 
-            imperceptible_asr = ImperceptibleASR(
-                estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(),
-            )
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
             loss_gradient, loss = imperceptible_asr._loss_gradient_masking_threshold_torch(
-                test_delta, test_psd_maximum, test_masking_threshold)
+                test_delta, test_psd_maximum, test_masking_threshold
+            )
 
             assert loss_gradient.shape == test_delta.shape
             assert loss.ndim == 1 and loss.shape[0] == test_delta.shape[0]
@@ -217,9 +201,7 @@ class TestImperceptibleASR:
             test_psd_maximum = np.ones((test_delta.shape[0], 28))
 
             masker = PsychoacousticMasker()
-            imperceptible_asr = ImperceptibleASR(
-                estimator=asr_dummy_estimator(), masker=masker,
-            )
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=masker)
             feed_dict = {
                 imperceptible_asr._delta: test_delta,
                 imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maximum,
@@ -246,9 +228,7 @@ class TestImperceptibleASR:
             test_psd_maximum = np.ones((test_delta.shape[0], 28))
 
             masker = PsychoacousticMasker()
-            imperceptible_asr = ImperceptibleASR(
-                estimator=asr_dummy_estimator(), masker=masker,
-            )
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=masker)
             approximate_psd_torch = imperceptible_asr._approximate_power_spectral_density_torch(
                 torch.from_numpy(test_delta), torch.from_numpy(test_psd_maximum)
             )

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -142,7 +142,7 @@ class TestImperceptibleASR:
             tf1.reset_default_graph()
 
             test_delta = audio_batch_padded
-            test_psd_maxium = np.ones((test_delta.shape[0], 28))
+            test_psd_maximum = np.ones((test_delta.shape[0], 28))
             test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
 
             imperceptible_asr = ImperceptibleASR(
@@ -150,7 +150,7 @@ class TestImperceptibleASR:
             )
             feed_dict = {
                 imperceptible_asr._delta: test_delta,
-                imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maxium,
+                imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maximum,
                 imperceptible_asr._masking_threshold_tf: test_masking_threshold,
             }
             with tf1.Session() as sess:
@@ -169,7 +169,7 @@ class TestImperceptibleASR:
             tf1.reset_default_graph()
 
             test_delta = audio_batch_padded
-            test_psd_maxium = np.ones((test_delta.shape[0], 28))
+            test_psd_maximum = np.ones((test_delta.shape[0], 28))
             test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
 
             imperceptible_asr = ImperceptibleASR(
@@ -177,11 +177,29 @@ class TestImperceptibleASR:
             )
             feed_dict = {
                 imperceptible_asr._delta: test_delta,
-                imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maxium,
+                imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maximum,
                 imperceptible_asr._masking_threshold_tf: test_masking_threshold,
             }
             with tf1.Session() as sess:
                 loss_gradient, loss = sess.run(imperceptible_asr._loss_gradient_masking_threshold_op_tf, feed_dict)
+
+            assert loss_gradient.shape == test_delta.shape
+            assert loss.ndim == 1 and loss.shape[0] == test_delta.shape[0]
+        except ARTTestException as e:
+            art_warning(e)
+
+    @pytest.mark.skipMlFramework("tensorflow", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_loss_gradient_masking_threshold_torch(self, art_warning, asr_dummy_estimator, audio_batch_padded):
+        try:
+            test_delta = audio_batch_padded
+            test_psd_maximum = np.ones((test_delta.shape[0], 28))
+            test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
+
+            imperceptible_asr = ImperceptibleASR(
+                estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(),
+            )
+            loss_gradient, loss = imperceptible_asr._loss_gradient_masking_threshold_torch(
+                test_delta, test_psd_maximum, test_masking_threshold)
 
             assert loss_gradient.shape == test_delta.shape
             assert loss.ndim == 1 and loss.shape[0] == test_delta.shape[0]
@@ -196,7 +214,7 @@ class TestImperceptibleASR:
             tf1.reset_default_graph()
 
             test_delta = audio_batch_padded
-            test_psd_maxium = np.ones((test_delta.shape[0], 28))
+            test_psd_maximum = np.ones((test_delta.shape[0], 28))
 
             masker = PsychoacousticMasker()
             imperceptible_asr = ImperceptibleASR(
@@ -204,7 +222,7 @@ class TestImperceptibleASR:
             )
             feed_dict = {
                 imperceptible_asr._delta: test_delta,
-                imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maxium,
+                imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maximum,
             }
 
             approximate_psd_tf = imperceptible_asr._approximate_power_spectral_density_tf(
@@ -212,6 +230,29 @@ class TestImperceptibleASR:
             )
             with tf1.Session() as sess:
                 psd_approximated = sess.run(approximate_psd_tf, feed_dict)
+
+            assert psd_approximated.ndim == 3
+            assert psd_approximated.shape[0] == test_delta.shape[0]  # batch_size
+            assert psd_approximated.shape[1] == masker.window_size // 2 + 1
+        except ARTTestException as e:
+            art_warning(e)
+
+    @pytest.mark.skipMlFramework("tensorflow", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_approximate_power_spectral_density_torch(self, art_warning, asr_dummy_estimator, audio_batch_padded):
+        try:
+            import torch
+
+            test_delta = audio_batch_padded
+            test_psd_maximum = np.ones((test_delta.shape[0], 28))
+
+            masker = PsychoacousticMasker()
+            imperceptible_asr = ImperceptibleASR(
+                estimator=asr_dummy_estimator(), masker=masker,
+            )
+            approximate_psd_torch = imperceptible_asr._approximate_power_spectral_density_torch(
+                torch.from_numpy(test_delta), torch.from_numpy(test_psd_maximum)
+            )
+            psd_approximated = approximate_psd_torch.numpy()
 
             assert psd_approximated.ndim == 3
             assert psd_approximated.shape[0] == test_delta.shape[0]  # batch_size


### PR DESCRIPTION
# Description

This PR adds support to the framework-independent (PyTorch and TensorFlow) ASR attack.

Related to https://github.com/Trusted-AI/adversarial-robustness-toolbox/issues/273

**To-Do Checklist**:

* [ ] Test the attack with the PyTorch Deepspeech estimator
* [x] The `torch.stft` does not yet match the `tensorflow.signal.stft`. This needs to be identical so that both masking are identical
* [x] Move to `dev_1.5.0` base

## Type of change

Please check all the relevant options.

- [x] New feature (non-breaking)

# Testing

Attack comes with a set of tests.

**Test Configuration**:
- Fedora 31
- Python 3.8.5
- ART 1.5 development
- Torch 1.7.0

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
