### PR TITLE
One-hot attribute inference

### DIFF
--- a/art/attacks/attack.py
+++ b/art/attacks/attack.py
@@ -315,16 +315,14 @@ class AttributeInferenceAttack(InferenceAttack):
     Abstract base class for attribute inference attack classes.
     """
 
-    attack_params = InferenceAttack.attack_params + ["attack_feature"]
+    attack_params = InferenceAttack.attack_params
 
-    def __init__(self, estimator, attack_feature: int = 0):
+    def __init__(self, estimator, **kwargs):
         """
         :param estimator: A trained estimator targeted for inference attack.
         :type estimator: :class:`.art.estimators.estimator.BaseEstimator`
-        :param attack_feature: The index of the feature to be attacked.
         """
         super().__init__(estimator)
-        self.attack_feature = attack_feature
 
     @abc.abstractmethod
     def infer(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:

--- a/art/attacks/attack.py
+++ b/art/attacks/attack.py
@@ -315,14 +315,15 @@ class AttributeInferenceAttack(InferenceAttack):
     Abstract base class for attribute inference attack classes.
     """
 
-    attack_params = InferenceAttack.attack_params
+    attack_params = InferenceAttack.attack_params + ["attack_feature"]
 
-    def __init__(self, estimator, **kwargs):
+    def __init__(self, estimator, attack_feature: Union[int, slice] = 0):
         """
         :param estimator: A trained estimator targeted for inference attack.
         :type estimator: :class:`.art.estimators.estimator.BaseEstimator`
         """
         super().__init__(estimator)
+        self.attack_feature = attack_feature
 
     @abc.abstractmethod
     def infer(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:

--- a/art/attacks/inference/attribute_inference/black_box.py
+++ b/art/attacks/inference/attribute_inference/black_box.py
@@ -22,7 +22,7 @@ This module implements attribute inference attacks.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 
 import numpy as np
 from sklearn.neural_network import MLPClassifier
@@ -48,22 +48,25 @@ class AttributeInferenceBlackBox(AttributeInferenceAttack):
     used as a proxy.
     """
 
-    attack_params = AttributeInferenceAttack.attack_params + ["attack_feature"]
-
     _estimator_requirements = (BaseEstimator, ClassifierMixin)
 
     def __init__(
-        self, classifier: "CLASSIFIER_TYPE", attack_model: Optional["CLASSIFIER_TYPE"] = None, attack_feature: int = 0
+        self, classifier: "CLASSIFIER_TYPE", attack_model: Optional["CLASSIFIER_TYPE"] = None,
+            attack_feature: Union[int, slice] = 0
     ):
         """
         Create an AttributeInferenceBlackBox attack instance.
 
         :param classifier: Target classifier.
         :param attack_model: The attack model to train, optional. If none is provided, a default model will be created.
-        :param attack_feature: The index of the feature to be attacked.
+        :param attack_feature: The index of the feature to be attacked or a slice representing multiple indexes in
+                               case of a one-hot encoded feature.
         """
-        super().__init__(estimator=classifier)
-        self.attack_feature = attack_feature
+        super().__init__(estimator=classifier, attack_feature = attack_feature)
+        if isinstance(self.attack_feature, int):
+            self.single_index_feature = True
+        else:
+            self.single_index_feature = False
 
         if attack_model:
             if ClassifierMixin not in type(attack_model).__mro__:
@@ -107,7 +110,7 @@ class AttributeInferenceBlackBox(AttributeInferenceAttack):
         # Checks:
         if self.estimator.input_shape[0] != x.shape[1]:
             raise ValueError("Shape of x does not match input_shape of classifier")
-        if self.attack_feature >= x.shape[1]:
+        if self.single_index_feature and self.attack_feature >= x.shape[1]:
             raise ValueError("attack_feature must be a valid index to a feature in x")
 
         # get model's predictions for x
@@ -115,8 +118,10 @@ class AttributeInferenceBlackBox(AttributeInferenceAttack):
 
         # get vector of attacked feature
         y = x[:, self.attack_feature]
-        y_one_hot = float_to_categorical(y)
-        y_ready = check_and_transform_label_format(y_one_hot, len(np.unique(y)), return_one_hot=True)
+        y_ready = y
+        if self.single_index_feature:
+            y_one_hot = float_to_categorical(y)
+            y_ready = check_and_transform_label_format(y_one_hot, len(np.unique(y)), return_one_hot=True)
 
         # create training set for attack model
         x_train = np.concatenate((np.delete(x, self.attack_feature, 1), predictions), axis=1).astype(np.float32)
@@ -130,122 +135,27 @@ class AttributeInferenceBlackBox(AttributeInferenceAttack):
 
         :param x: Input to attack. Includes all features except the attacked feature.
         :param y: Original model's predictions for x.
-        :param values: Possible values for attacked feature.
+        :param values: Possible values for attacked feature. Only needed in case of categorical feature (not one-hot).
         :type values: `np.ndarray`
         :return: The inferred feature values.
         """
         if y.shape[0] != x.shape[0]:
             raise ValueError("Number of rows in x and y do not match")
-        if self.estimator.input_shape[0] != x.shape[1] + 1:
+        if self.single_index_feature and self.estimator.input_shape[0] != x.shape[1] + 1:
             raise ValueError("Number of features in x + 1 does not match input_shape of classifier")
 
-        if "values" not in kwargs.keys():
-            raise ValueError("Missing parameter `values`.")
-        values: np.ndarray = kwargs.get("values")
-
         x_test = np.concatenate((x, y), axis=1).astype(np.float32)
-        return np.array([values[np.argmax(arr)] for arr in self.attack_model.predict(x_test)])
+
+        if self.single_index_feature:
+            if "values" not in kwargs.keys():
+                raise ValueError("Missing parameter `values`.")
+            values: np.ndarray = kwargs.get("values")
+            return np.array([values[np.argmax(arr)] for arr in self.attack_model.predict(x_test)])
+        else:
+            return np.array(self.attack_model.predict(x_test))
 
     def _check_params(self) -> None:
-        if self.attack_feature < 0:
-            raise ValueError("Attack feature must be positive.")
-
-
-class AttributeInferenceBlackBoxOneHot(AttributeInferenceAttack):
-    """
-    Implementation of a simple black-box attribute inference attack.
-
-    The idea is to train a simple neural network to learn the attacked feature from the rest of the features and the
-    model's predictions. Assumes the availability of the attacked model's predictions for the samples under attack,
-    in addition to the rest of the feature values. If this is not available, the true class label of the samples may be
-    used as a proxy.
-    """
-
-    attack_params = AttributeInferenceAttack.attack_params + ["attack_feature_one_hot"]
-
-    _estimator_requirements = (BaseEstimator, ClassifierMixin)
-
-    def __init__(
-        self, classifier: "CLASSIFIER_TYPE", attack_feature_one_hot: slice,
-        attack_model: Optional["CLASSIFIER_TYPE"] = None,
-    ):
-        """
-        Create an AttributeInferenceBlackBox attack instance.
-
-        :param classifier: Target classifier.
-        :param attack_model: The attack model to train, optional. If none is provided, a default model will be created.
-        :param attack_feature_one_hot: A slice object representing the indexes of the one-hot encoded feature to attack.
-        """
-        super().__init__(estimator=classifier)
-        self.attack_feature_one_hot = attack_feature_one_hot
-
-        if attack_model:
-            if ClassifierMixin not in type(attack_model).__mro__:
-                raise ValueError("Attack model must be of type Classifier.")
-            self.attack_model = attack_model
-        else:
-            self.attack_model = MLPClassifier(
-                hidden_layer_sizes=(100,),
-                activation="relu",
-                solver="adam",
-                alpha=0.0001,
-                batch_size="auto",
-                learning_rate="constant",
-                learning_rate_init=0.001,
-                power_t=0.5,
-                max_iter=2000,
-                shuffle=True,
-                random_state=None,
-                tol=0.0001,
-                verbose=False,
-                warm_start=False,
-                momentum=0.9,
-                nesterovs_momentum=True,
-                early_stopping=False,
-                validation_fraction=0.1,
-                beta_1=0.9,
-                beta_2=0.999,
-                epsilon=1e-08,
-                n_iter_no_change=10,
-                max_fun=15000,
-            )
-        self._check_params()
-
-    def fit(self, x: np.ndarray) -> None:
-        """
-        Train the attack model.
-
-        :param x: Input to training process. Includes all features used to train the original model.
-        """
-
-        # Checks:
-        if self.estimator.input_shape[0] != x.shape[1]:
-            raise ValueError("Shape of x does not match input_shape of classifier")
-
-        # get model's predictions for x
-        predictions = np.array([np.argmax(arr) for arr in self.estimator.predict(x)]).reshape(-1, 1)
-
-        # get vector of attacked feature
-        y = x[:, self.attack_feature_one_hot]
-        # y_one_hot = float_to_categorical(y)
-        # y_ready = check_and_transform_label_format(y_one_hot, len(np.unique(y)), return_one_hot=True)
-
-        # create training set for attack model
-        x_train = np.concatenate((np.delete(x, self.attack_feature_one_hot, 1), predictions), axis=1).astype(np.float32)
-
-        # train attack model
-        self.attack_model.fit(x_train, y)
-
-    def infer(self, x: np.ndarray, y: np.ndarray, **kwargs) -> np.ndarray:
-        """
-        Infer the attacked feature.
-
-        :param x: Input to attack. Includes all features except the attacked feature.
-        :param y: Original model's predictions for x.
-        :return: The inferred feature values.
-        """
-        if y.shape[0] != x.shape[0]:
-            raise ValueError("Number of rows in x and y do not match")
-
-        x_test = np.concatenate((x, y), axis=1).astype(np.float32)
-        return np.array(self.attack_model.predict(x_test))
+        if not isinstance(self.attack_feature, int) and not isinstance(self.attack_feature, slice):
+            raise ValueError("Attack feature must be either an integer or a slice object.")
+        if isinstance(self.attack_feature, int) and self.attack_feature < 0:
+            raise ValueError("Attack feature index must be positive.")

--- a/art/attacks/inference/attribute_inference/black_box.py
+++ b/art/attacks/inference/attribute_inference/black_box.py
@@ -51,8 +51,10 @@ class AttributeInferenceBlackBox(AttributeInferenceAttack):
     _estimator_requirements = (BaseEstimator, ClassifierMixin)
 
     def __init__(
-        self, classifier: "CLASSIFIER_TYPE", attack_model: Optional["CLASSIFIER_TYPE"] = None,
-            attack_feature: Union[int, slice] = 0
+        self,
+        classifier: "CLASSIFIER_TYPE",
+        attack_model: Optional["CLASSIFIER_TYPE"] = None,
+        attack_feature: Union[int, slice] = 0,
     ):
         """
         Create an AttributeInferenceBlackBox attack instance.
@@ -62,7 +64,7 @@ class AttributeInferenceBlackBox(AttributeInferenceAttack):
         :param attack_feature: The index of the feature to be attacked or a slice representing multiple indexes in
                                case of a one-hot encoded feature.
         """
-        super().__init__(estimator=classifier, attack_feature = attack_feature)
+        super().__init__(estimator=classifier, attack_feature=attack_feature)
         if isinstance(self.attack_feature, int):
             self.single_index_feature = True
         else:

--- a/art/attacks/inference/attribute_inference/white_box_decision_tree.py
+++ b/art/attacks/inference/attribute_inference/white_box_decision_tree.py
@@ -55,6 +55,7 @@ class AttributeInferenceWhiteBoxDecisionTree(AttributeInferenceAttack):
         :param attack_feature: The index of the feature to be attacked.
         """
         super().__init__(estimator=classifier, attack_feature=attack_feature)
+        self._check_params()
 
     def infer(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
         """

--- a/art/attacks/inference/attribute_inference/white_box_decision_tree.py
+++ b/art/attacks/inference/attribute_inference/white_box_decision_tree.py
@@ -44,6 +44,7 @@ class AttributeInferenceWhiteBoxDecisionTree(AttributeInferenceAttack):
 
     | Paper link: https://dl.acm.org/doi/10.1145/2810103.2813677
     """
+    attack_params = AttributeInferenceAttack.attack_params + ["attack_feature"]
 
     _estimator_requirements = (ScikitlearnDecisionTreeClassifier,)
 
@@ -55,6 +56,7 @@ class AttributeInferenceWhiteBoxDecisionTree(AttributeInferenceAttack):
         :param attack_feature: The index of the feature to be attacked.
         """
         super().__init__(estimator=classifier, attack_feature=attack_feature)
+        self.attack_feature = attack_feature
 
     def infer(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
         """
@@ -138,3 +140,7 @@ class AttributeInferenceWhiteBoxDecisionTree(AttributeInferenceAttack):
                 for index, value in enumerate(predicted_pred)
             ]
         )
+
+    def _check_params(self) -> None:
+        if self.attack_feature < 0:
+            raise ValueError("Attack feature must be positive.")

--- a/art/attacks/inference/attribute_inference/white_box_decision_tree.py
+++ b/art/attacks/inference/attribute_inference/white_box_decision_tree.py
@@ -44,7 +44,6 @@ class AttributeInferenceWhiteBoxDecisionTree(AttributeInferenceAttack):
 
     | Paper link: https://dl.acm.org/doi/10.1145/2810103.2813677
     """
-    attack_params = AttributeInferenceAttack.attack_params + ["attack_feature"]
 
     _estimator_requirements = (ScikitlearnDecisionTreeClassifier,)
 
@@ -56,7 +55,6 @@ class AttributeInferenceWhiteBoxDecisionTree(AttributeInferenceAttack):
         :param attack_feature: The index of the feature to be attacked.
         """
         super().__init__(estimator=classifier, attack_feature=attack_feature)
-        self.attack_feature = attack_feature
 
     def infer(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
         """

--- a/art/attacks/inference/attribute_inference/white_box_lifestyle_decision_tree.py
+++ b/art/attacks/inference/attribute_inference/white_box_lifestyle_decision_tree.py
@@ -55,6 +55,7 @@ class AttributeInferenceWhiteBoxLifestyleDecisionTree(AttributeInferenceAttack):
         :param attack_feature: The index of the feature to be attacked.
         """
         super().__init__(estimator=classifier, attack_feature=attack_feature)
+        self._check_params()
 
     def infer(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
         """

--- a/art/attacks/inference/attribute_inference/white_box_lifestyle_decision_tree.py
+++ b/art/attacks/inference/attribute_inference/white_box_lifestyle_decision_tree.py
@@ -44,7 +44,6 @@ class AttributeInferenceWhiteBoxLifestyleDecisionTree(AttributeInferenceAttack):
 
     | Paper link: https://dl.acm.org/doi/10.1145/2810103.2813677
     """
-    attack_params = AttributeInferenceAttack.attack_params + ["attack_feature"]
 
     _estimator_requirements = (ScikitlearnDecisionTreeClassifier,)
 
@@ -56,7 +55,6 @@ class AttributeInferenceWhiteBoxLifestyleDecisionTree(AttributeInferenceAttack):
         :param attack_feature: The index of the feature to be attacked.
         """
         super().__init__(estimator=classifier, attack_feature=attack_feature)
-        self.attack_feature = attack_feature
 
     def infer(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
         """

--- a/art/attacks/inference/attribute_inference/white_box_lifestyle_decision_tree.py
+++ b/art/attacks/inference/attribute_inference/white_box_lifestyle_decision_tree.py
@@ -44,6 +44,7 @@ class AttributeInferenceWhiteBoxLifestyleDecisionTree(AttributeInferenceAttack):
 
     | Paper link: https://dl.acm.org/doi/10.1145/2810103.2813677
     """
+    attack_params = AttributeInferenceAttack.attack_params + ["attack_feature"]
 
     _estimator_requirements = (ScikitlearnDecisionTreeClassifier,)
 
@@ -55,6 +56,7 @@ class AttributeInferenceWhiteBoxLifestyleDecisionTree(AttributeInferenceAttack):
         :param attack_feature: The index of the feature to be attacked.
         """
         super().__init__(estimator=classifier, attack_feature=attack_feature)
+        self.attack_feature = attack_feature
 
     def infer(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
         """
@@ -130,3 +132,7 @@ class AttributeInferenceWhiteBoxLifestyleDecisionTree(AttributeInferenceAttack):
             phi.append(num_value)
 
         return phi
+
+    def _check_params(self) -> None:
+        if self.attack_feature < 0:
+            raise ValueError("Attack feature must be positive.")

--- a/tests/attacks/inference/attribute_inference/test_black_box.py
+++ b/tests/attacks/inference/attribute_inference/test_black_box.py
@@ -26,10 +26,6 @@ import torch.optim as optim
 from sklearn.tree import DecisionTreeClassifier
 
 from art.attacks.inference.attribute_inference.black_box import AttributeInferenceBlackBox
-from art.attacks.inference.attribute_inference.white_box_decision_tree import AttributeInferenceWhiteBoxDecisionTree
-from art.attacks.inference.attribute_inference.white_box_lifestyle_decision_tree import (
-    AttributeInferenceWhiteBoxLifestyleDecisionTree,
-)
 from art.estimators.classification.pytorch import PyTorchClassifier
 from art.estimators.estimator import BaseEstimator
 from art.estimators.classification import ClassifierMixin

--- a/tests/attacks/inference/attribute_inference/test_black_box.py
+++ b/tests/attacks/inference/attribute_inference/test_black_box.py
@@ -147,6 +147,7 @@ def test_black_box_with_model(art_warning, decision_tree_estimator, get_iris_dat
     except ARTTestException as e:
         art_warning(e)
 
+
 @pytest.mark.skipMlFramework("dl_frameworks")
 def test_black_box_one_hot(art_warning, get_iris_dataset):
     try:
@@ -189,8 +190,7 @@ def test_black_box_one_hot(art_warning, get_iris_dataset):
         tree.fit(x_train, y_train)
         classifier = ScikitlearnDecisionTreeClassifier(tree)
 
-        attack = AttributeInferenceBlackBox(classifier,
-                                                  attack_feature=slice(attack_feature, attack_feature+3))
+        attack = AttributeInferenceBlackBox(classifier, attack_feature=slice(attack_feature, attack_feature + 3))
         # get original model's predictions
         x_train_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_train)]).reshape(-1, 1)
         x_test_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_test)]).reshape(-1, 1)
@@ -207,7 +207,6 @@ def test_black_box_one_hot(art_warning, get_iris_dataset):
 
     except ARTTestException as e:
         art_warning(e)
-
 
 
 @pytest.mark.skipMlFramework("dl_frameworks")

--- a/tests/attacks/inference/attribute_inference/test_black_box.py
+++ b/tests/attacks/inference/attribute_inference/test_black_box.py
@@ -25,9 +25,7 @@ import torch.nn as nn
 import torch.optim as optim
 from sklearn.tree import DecisionTreeClassifier
 
-from art.attacks.inference.attribute_inference.black_box import (
-    AttributeInferenceBlackBox, AttributeInferenceBlackBoxOneHot
-)
+from art.attacks.inference.attribute_inference.black_box import AttributeInferenceBlackBox
 from art.attacks.inference.attribute_inference.white_box_decision_tree import AttributeInferenceWhiteBoxDecisionTree
 from art.attacks.inference.attribute_inference.white_box_lifestyle_decision_tree import (
     AttributeInferenceWhiteBoxLifestyleDecisionTree,
@@ -191,8 +189,8 @@ def test_black_box_one_hot(art_warning, get_iris_dataset):
         tree.fit(x_train, y_train)
         classifier = ScikitlearnDecisionTreeClassifier(tree)
 
-        attack = AttributeInferenceBlackBoxOneHot(classifier,
-                                                  attack_feature_one_hot=slice(attack_feature, attack_feature+3))
+        attack = AttributeInferenceBlackBox(classifier,
+                                                  attack_feature=slice(attack_feature, attack_feature+3))
         # get original model's predictions
         x_train_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_train)]).reshape(-1, 1)
         x_test_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_test)]).reshape(-1, 1)
@@ -264,6 +262,28 @@ def test_white_box_lifestyle(art_warning, decision_tree_estimator, get_iris_data
         assert np.sum(train_diff) / len(inferred_train) == pytest.approx(0.3357, abs=0.03)
         assert np.sum(test_diff) / len(inferred_test) == pytest.approx(0.3149, abs=0.03)
         # assert np.sum(train_diff) / len(inferred_train) < np.sum(test_diff) / len(inferred_test)
+    except ARTTestException as e:
+        art_warning(e)
+
+
+def test_errors(art_warning, tabular_dl_estimator_for_attack, get_iris_dataset):
+    try:
+        classifier = tabular_dl_estimator_for_attack(AttributeInferenceBlackBox)
+        (x_train, y_train), (x_test, y_test) = get_iris_dataset
+
+        with pytest.raises(ValueError):
+            AttributeInferenceBlackBox(classifier, attack_feature="a")
+        with pytest.raises(ValueError):
+            AttributeInferenceBlackBox(classifier, attack_feature=-3)
+        attack = AttributeInferenceBlackBox(classifier)
+        with pytest.raises(ValueError):
+            attack.fit(np.delete(x_train, 1, 1))
+        with pytest.raises(ValueError):
+            attack.fit(x_train, 8)
+        with pytest.raises(ValueError):
+            attack.infer(x_train, y_test)
+        with pytest.raises(ValueError):
+            attack.infer(x_train, y_train)
     except ARTTestException as e:
         art_warning(e)
 

--- a/tests/attacks/inference/attribute_inference/test_black_box.py
+++ b/tests/attacks/inference/attribute_inference/test_black_box.py
@@ -23,8 +23,15 @@ import pytest
 import numpy as np
 import torch.nn as nn
 import torch.optim as optim
+from sklearn.tree import DecisionTreeClassifier
 
-from art.attacks.inference.attribute_inference.black_box import AttributeInferenceBlackBox
+from art.attacks.inference.attribute_inference.black_box import (
+    AttributeInferenceBlackBox, AttributeInferenceBlackBoxOneHot
+)
+from art.attacks.inference.attribute_inference.white_box_decision_tree import AttributeInferenceWhiteBoxDecisionTree
+from art.attacks.inference.attribute_inference.white_box_lifestyle_decision_tree import (
+    AttributeInferenceWhiteBoxLifestyleDecisionTree,
+)
 from art.estimators.classification.pytorch import PyTorchClassifier
 from art.estimators.estimator import BaseEstimator
 from art.estimators.classification import ClassifierMixin
@@ -142,6 +149,130 @@ def test_black_box_with_model(art_warning, decision_tree_estimator, get_iris_dat
     except ARTTestException as e:
         art_warning(e)
 
+@pytest.mark.skipMlFramework("dl_frameworks")
+def test_black_box_one_hot(art_warning, get_iris_dataset):
+    try:
+        attack_feature = 2  # petal length
+
+        # need to transform attacked feature into categorical
+        def transform_feature(x):
+            x[x > 0.5] = 2
+            x[(x > 0.2) & (x <= 0.5)] = 1
+            x[x <= 0.2] = 0
+
+        (x_train_iris, y_train_iris), (x_test_iris, y_test_iris) = get_iris_dataset
+        # training data without attacked feature
+        x_train_for_attack = np.delete(x_train_iris, attack_feature, 1)
+        # only attacked feature
+        x_train_feature = x_train_iris[:, attack_feature].copy().reshape(-1, 1)
+        transform_feature(x_train_feature)
+        # transform to one-hot encoding
+        train_one_hot = np.zeros((x_train_feature.size, int(x_train_feature.max()) + 1))
+        train_one_hot[np.arange(x_train_feature.size), x_train_feature.reshape(1, -1).astype(int)] = 1
+        # training data with attacked feature (after transformation)
+        x_train = np.concatenate((x_train_for_attack[:, :attack_feature], train_one_hot), axis=1)
+        x_train = np.concatenate((x_train, x_train_for_attack[:, attack_feature:]), axis=1)
+
+        y_train = np.array([np.argmax(y) for y in y_train_iris]).reshape(-1, 1)
+
+        # test data without attacked feature
+        x_test_for_attack = np.delete(x_test_iris, attack_feature, 1)
+        # only attacked feature
+        x_test_feature = x_test_iris[:, attack_feature].copy().reshape(-1, 1)
+        transform_feature(x_test_feature)
+        # transform to one-hot encoding
+        test_one_hot = np.zeros((x_test_feature.size, int(x_test_feature.max()) + 1))
+        test_one_hot[np.arange(x_test_feature.size), x_test_feature.reshape(1, -1).astype(int)] = 1
+        # test data with attacked feature (after transformation)
+        x_test = np.concatenate((x_test_for_attack[:, :attack_feature], test_one_hot), axis=1)
+        x_test = np.concatenate((x_test, x_test_for_attack[:, attack_feature:]), axis=1)
+
+        tree = DecisionTreeClassifier()
+        tree.fit(x_train, y_train)
+        classifier = ScikitlearnDecisionTreeClassifier(tree)
+
+        attack = AttributeInferenceBlackBoxOneHot(classifier,
+                                                  attack_feature_one_hot=slice(attack_feature, attack_feature+3))
+        # get original model's predictions
+        x_train_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_train)]).reshape(-1, 1)
+        x_test_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_test)]).reshape(-1, 1)
+        # train attack model
+        attack.fit(x_train)
+        # infer attacked feature
+        inferred_train = attack.infer(x_train_for_attack, x_train_predictions)
+        inferred_test = attack.infer(x_test_for_attack, x_test_predictions)
+        # check accuracy
+        train_acc = np.sum(np.all(inferred_train == train_one_hot, axis=1)) / len(inferred_train)
+        test_acc = np.sum(np.all(inferred_test == test_one_hot, axis=1)) / len(inferred_test)
+        assert pytest.approx(0.9145, abs=0.03) == train_acc
+        assert pytest.approx(0.9333, abs=0.03) == test_acc
+
+    except ARTTestException as e:
+        art_warning(e)
+
+
+
+@pytest.mark.skipMlFramework("dl_frameworks")
+def test_white_box(art_warning, decision_tree_estimator, get_iris_dataset):
+    try:
+        attack_feature = 2  # petal length
+        values = [0.14, 0.42, 0.71]  # rounded down
+        priors = [50 / 150, 54 / 150, 46 / 150]
+
+        (x_train_iris, y_train_iris), (x_test_iris, y_test_iris) = get_iris_dataset
+        x_train_for_attack = np.delete(x_train_iris, attack_feature, 1)
+        x_train_feature = x_train_iris[:, attack_feature]
+        x_test_for_attack = np.delete(x_test_iris, attack_feature, 1)
+        x_test_feature = x_test_iris[:, attack_feature]
+
+        classifier = decision_tree_estimator()
+
+        attack = AttributeInferenceWhiteBoxDecisionTree(classifier, attack_feature=attack_feature)
+        x_train_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_train_iris)]).reshape(-1, 1)
+        x_test_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_test_iris)]).reshape(-1, 1)
+        inferred_train = attack.infer(x_train_for_attack, x_train_predictions, values=values, priors=priors)
+        inferred_test = attack.infer(x_test_for_attack, x_test_predictions, values=values, priors=priors)
+        train_diff = np.abs(inferred_train - x_train_feature.reshape(1, -1))
+        test_diff = np.abs(inferred_test - x_test_feature.reshape(1, -1))
+        assert np.sum(train_diff) / len(inferred_train) == pytest.approx(0.2108, abs=0.03)
+        assert np.sum(test_diff) / len(inferred_test) == pytest.approx(0.1988, abs=0.03)
+    except ARTTestException as e:
+        art_warning(e)
+
+
+@pytest.mark.skipMlFramework("dl_frameworks")
+def test_white_box_lifestyle(art_warning, decision_tree_estimator, get_iris_dataset):
+    try:
+        attack_feature = 2  # petal length
+        values = [0.14, 0.42, 0.71]  # rounded down
+        priors = [50 / 150, 54 / 150, 46 / 150]
+
+        (x_train_iris, y_train_iris), (x_test_iris, y_test_iris) = get_iris_dataset
+        x_train_for_attack = np.delete(x_train_iris, attack_feature, 1)
+        x_train_feature = x_train_iris[:, attack_feature]
+        x_test_for_attack = np.delete(x_test_iris, attack_feature, 1)
+        x_test_feature = x_test_iris[:, attack_feature]
+
+        classifier = decision_tree_estimator()
+        attack = AttributeInferenceWhiteBoxLifestyleDecisionTree(classifier, attack_feature=attack_feature)
+        x_train_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_train_iris)]).reshape(-1, 1)
+        x_test_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_test_iris)]).reshape(-1, 1)
+        inferred_train = attack.infer(x_train_for_attack, x_train_predictions, values=values, priors=priors)
+        inferred_test = attack.infer(x_test_for_attack, x_test_predictions, values=values, priors=priors)
+        train_diff = np.abs(inferred_train - x_train_feature.reshape(1, -1))
+        test_diff = np.abs(inferred_test - x_test_feature.reshape(1, -1))
+        assert np.sum(train_diff) / len(inferred_train) == pytest.approx(0.3357, abs=0.03)
+        assert np.sum(test_diff) / len(inferred_test) == pytest.approx(0.3149, abs=0.03)
+        # assert np.sum(train_diff) / len(inferred_train) < np.sum(test_diff) / len(inferred_test)
+    except ARTTestException as e:
+        art_warning(e)
+
 
 def test_classifier_type_check_fail():
     backend_test_classifier_type_check_fail(AttributeInferenceBlackBox, (BaseEstimator, ClassifierMixin))
+    backend_test_classifier_type_check_fail(
+        AttributeInferenceWhiteBoxLifestyleDecisionTree, (ScikitlearnDecisionTreeClassifier,)
+    )
+    backend_test_classifier_type_check_fail(
+        AttributeInferenceWhiteBoxDecisionTree, (ScikitlearnDecisionTreeClassifier,)
+    )

--- a/tests/attacks/inference/attribute_inference/test_black_box.py
+++ b/tests/attacks/inference/attribute_inference/test_black_box.py
@@ -33,6 +33,7 @@ from art.attacks.inference.attribute_inference.white_box_lifestyle_decision_tree
 from art.estimators.classification.pytorch import PyTorchClassifier
 from art.estimators.estimator import BaseEstimator
 from art.estimators.classification import ClassifierMixin
+from art.estimators.classification.scikitlearn import ScikitlearnDecisionTreeClassifier
 
 from tests.attacks.utils import backend_test_classifier_type_check_fail
 from tests.utils import ARTTestException
@@ -209,62 +210,6 @@ def test_black_box_one_hot(art_warning, get_iris_dataset):
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("dl_frameworks")
-def test_white_box(art_warning, decision_tree_estimator, get_iris_dataset):
-    try:
-        attack_feature = 2  # petal length
-        values = [0.14, 0.42, 0.71]  # rounded down
-        priors = [50 / 150, 54 / 150, 46 / 150]
-
-        (x_train_iris, y_train_iris), (x_test_iris, y_test_iris) = get_iris_dataset
-        x_train_for_attack = np.delete(x_train_iris, attack_feature, 1)
-        x_train_feature = x_train_iris[:, attack_feature]
-        x_test_for_attack = np.delete(x_test_iris, attack_feature, 1)
-        x_test_feature = x_test_iris[:, attack_feature]
-
-        classifier = decision_tree_estimator()
-
-        attack = AttributeInferenceWhiteBoxDecisionTree(classifier, attack_feature=attack_feature)
-        x_train_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_train_iris)]).reshape(-1, 1)
-        x_test_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_test_iris)]).reshape(-1, 1)
-        inferred_train = attack.infer(x_train_for_attack, x_train_predictions, values=values, priors=priors)
-        inferred_test = attack.infer(x_test_for_attack, x_test_predictions, values=values, priors=priors)
-        train_diff = np.abs(inferred_train - x_train_feature.reshape(1, -1))
-        test_diff = np.abs(inferred_test - x_test_feature.reshape(1, -1))
-        assert np.sum(train_diff) / len(inferred_train) == pytest.approx(0.2108, abs=0.03)
-        assert np.sum(test_diff) / len(inferred_test) == pytest.approx(0.1988, abs=0.03)
-    except ARTTestException as e:
-        art_warning(e)
-
-
-@pytest.mark.skipMlFramework("dl_frameworks")
-def test_white_box_lifestyle(art_warning, decision_tree_estimator, get_iris_dataset):
-    try:
-        attack_feature = 2  # petal length
-        values = [0.14, 0.42, 0.71]  # rounded down
-        priors = [50 / 150, 54 / 150, 46 / 150]
-
-        (x_train_iris, y_train_iris), (x_test_iris, y_test_iris) = get_iris_dataset
-        x_train_for_attack = np.delete(x_train_iris, attack_feature, 1)
-        x_train_feature = x_train_iris[:, attack_feature]
-        x_test_for_attack = np.delete(x_test_iris, attack_feature, 1)
-        x_test_feature = x_test_iris[:, attack_feature]
-
-        classifier = decision_tree_estimator()
-        attack = AttributeInferenceWhiteBoxLifestyleDecisionTree(classifier, attack_feature=attack_feature)
-        x_train_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_train_iris)]).reshape(-1, 1)
-        x_test_predictions = np.array([np.argmax(arr) for arr in classifier.predict(x_test_iris)]).reshape(-1, 1)
-        inferred_train = attack.infer(x_train_for_attack, x_train_predictions, values=values, priors=priors)
-        inferred_test = attack.infer(x_test_for_attack, x_test_predictions, values=values, priors=priors)
-        train_diff = np.abs(inferred_train - x_train_feature.reshape(1, -1))
-        test_diff = np.abs(inferred_test - x_test_feature.reshape(1, -1))
-        assert np.sum(train_diff) / len(inferred_train) == pytest.approx(0.3357, abs=0.03)
-        assert np.sum(test_diff) / len(inferred_test) == pytest.approx(0.3149, abs=0.03)
-        # assert np.sum(train_diff) / len(inferred_train) < np.sum(test_diff) / len(inferred_test)
-    except ARTTestException as e:
-        art_warning(e)
-
-
 def test_errors(art_warning, tabular_dl_estimator_for_attack, get_iris_dataset):
     try:
         classifier = tabular_dl_estimator_for_attack(AttributeInferenceBlackBox)
@@ -290,9 +235,3 @@ def test_errors(art_warning, tabular_dl_estimator_for_attack, get_iris_dataset):
 
 def test_classifier_type_check_fail():
     backend_test_classifier_type_check_fail(AttributeInferenceBlackBox, (BaseEstimator, ClassifierMixin))
-    backend_test_classifier_type_check_fail(
-        AttributeInferenceWhiteBoxLifestyleDecisionTree, (ScikitlearnDecisionTreeClassifier,)
-    )
-    backend_test_classifier_type_check_fail(
-        AttributeInferenceWhiteBoxDecisionTree, (ScikitlearnDecisionTreeClassifier,)
-    )

--- a/tests/attacks/inference/attribute_inference/test_black_box.py
+++ b/tests/attacks/inference/attribute_inference/test_black_box.py
@@ -275,11 +275,12 @@ def test_errors(art_warning, tabular_dl_estimator_for_attack, get_iris_dataset):
             AttributeInferenceBlackBox(classifier, attack_feature="a")
         with pytest.raises(ValueError):
             AttributeInferenceBlackBox(classifier, attack_feature=-3)
+        attack = AttributeInferenceBlackBox(classifier, attack_feature=8)
+        with pytest.raises(ValueError):
+            attack.fit(x_train)
         attack = AttributeInferenceBlackBox(classifier)
         with pytest.raises(ValueError):
             attack.fit(np.delete(x_train, 1, 1))
-        with pytest.raises(ValueError):
-            attack.fit(x_train, 8)
         with pytest.raises(ValueError):
             attack.infer(x_train, y_test)
         with pytest.raises(ValueError):


### PR DESCRIPTION
# Description

Add support for one-hot encoded features in black-box attribute inference attack.

## Type of change

Please check all relevant options.

- [X] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

All unit test pass + new test for new feature

**Test Configuration**:
- OS: MacOS 10.14.6
- Python version: 3.7
- TensorFlow / Keras / PyTorch

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
