### PR TITLE
Add Lingvo test runner to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,13 @@ jobs:
           - name: mxnet (Python 3.7)
             framework: mxnet
             python: 3.7
+          - name: TensorFlow+Lingvo 2.1.0v1 (Keras 2.3.1 Python 3.6)
+            framework: tensorflow2v1
+            python: 3.6
+            tensorflow: 2.1.0
+            tf_version: v2
+            keras: 2.3.1
+            lingvo: 0.6.4
           - name: legacy (TensorFlow 2.2.1 Keras 2.3.1 scikit-learn 0.22.2 Python 3.7)
             framework: legacy
             python: 3.7
@@ -115,7 +122,7 @@ jobs:
           pip install scikit-learn==${{ matrix.scikit-learn }}
           pip list
       - name: Pre-install tensorflow
-        if: ${{ matrix.framework == 'tensorflow' || matrix.framework == 'keras' || matrix.framework == 'kerastf' }}
+        if: ${{ matrix.framework == 'tensorflow' || matrix.framework == 'keras' || matrix.framework == 'kerastf' || matrix.framework == 'tensorflow2v1' }}
         run: |
           pip install tensorflow==${{ matrix.tensorflow }}
           pip install keras==${{ matrix.keras }}
@@ -124,6 +131,12 @@ jobs:
         if: ${{ matrix.framework == 'scikitlearn' }}
         run: |
           pip install scikit-learn==${{ matrix.scikit-learn }}
+          pip list
+      - name: Pre-install Lingvo ASR
+        if: ${{ matrix.tensorflow == '2.1.0' }}
+        run: |
+          pip install tensorflow==${{ matrix.tensorflow }}
+          pip install lingvo==${{ matrix.lingvo }}
           pip list
       - name: Run ${{ matrix.name }} Tests
         run: ./run_tests.sh ${{ matrix.framework }}

--- a/conftest.py
+++ b/conftest.py
@@ -176,6 +176,11 @@ def setup_tear_down_framework(framework):
 
         if tf.__version__[0] != "2":
             tf.reset_default_graph()
+
+    if framework == "tensorflow2v1":
+        import tensorflow.compat.v1 as tf1
+
+        tf1.reset_default_graph()
     yield True
 
     # Ran after each test

--- a/conftest.py
+++ b/conftest.py
@@ -15,26 +15,39 @@
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import importlib
 import json
 import logging
 import os
 import shutil
 import tempfile
+import warnings
 
 import numpy as np
 import pytest
 import requests
-import warnings
 
-from art.data_generators import PyTorchDataGenerator, TensorFlowDataGenerator, KerasDataGenerator, MXDataGenerator
+from art.data_generators import KerasDataGenerator, MXDataGenerator, PyTorchDataGenerator, TensorFlowDataGenerator
 from art.defences.preprocessor import FeatureSqueezing, JpegCompression, SpatialSmoothing
 from art.estimators.classification import KerasClassifier
-from tests.utils import master_seed, get_image_classifier_kr, get_image_classifier_tf, get_image_classifier_pt
-from tests.utils import get_tabular_classifier_kr, get_tabular_classifier_tf, get_tabular_classifier_pt
-from tests.utils import get_tabular_classifier_scikit_list, load_dataset, get_image_classifier_kr_tf
-from tests.utils import get_image_classifier_mxnet_custom_ini, get_image_classifier_kr_tf_with_wildcard
-from tests.utils import get_image_classifier_kr_tf_functional, get_image_classifier_kr_functional
-from tests.utils import ARTTestFixtureNotImplemented, get_attack_classifier_pt
+from tests.utils import (
+    ARTTestFixtureNotImplemented,
+    get_attack_classifier_pt,
+    get_image_classifier_kr,
+    get_image_classifier_kr_functional,
+    get_image_classifier_kr_tf,
+    get_image_classifier_kr_tf_functional,
+    get_image_classifier_kr_tf_with_wildcard,
+    get_image_classifier_mxnet_custom_ini,
+    get_image_classifier_pt,
+    get_image_classifier_tf,
+    get_tabular_classifier_kr,
+    get_tabular_classifier_pt,
+    get_tabular_classifier_scikit_list,
+    get_tabular_classifier_tf,
+    load_dataset,
+    master_seed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -795,39 +808,22 @@ def framework_agnostic(request, framework):
 
 
 # ART test fixture to skip test for specific required modules
-# eg: @pytest.mark.skipModule("deepspeech_pytorch", "apex.amp", "object_detection")
+# eg: @pytest.mark.skip_module("deepspeech_pytorch", "apex.amp", "object_detection")
 @pytest.fixture(autouse=True)
 def skip_by_module(request):
-    import importlib
+    if request.node.get_closest_marker("skip_module"):
+        modules_from_args = request.node.get_closest_marker("skip_module").args
 
-    if request.node.get_closest_marker("skipModule"):
-        module_to_skip_list = list(request.node.get_closest_marker("skipModule").args)
+        # separate possible parent modules and test them first
+        modules_parents = [m.split(".", 1)[0] for m in modules_from_args]
 
-        if "deepspeech_pytorch" in module_to_skip_list:
-            deepspeech_pytorch_spec = importlib.util.find_spec("deepspeech_pytorch")
-            deepspeech_pytorch_found = deepspeech_pytorch_spec is not None
+        # merge with modules including submodules (Note: sort ensures that parent comes first)
+        modules_full = sorted(set(modules_parents).union(modules_from_args))
 
-            if not deepspeech_pytorch_found:
-                pytest.skip(
-                    "Skip unittests if the `deepspeech_pytorch` module is not found because of pre-trained model."
-                )
+        for module in modules_full:
+            if module in modules_full:
+                module_spec = importlib.util.find_spec(module)
+                module_found = module_spec is not None
 
-        if "object_detection" in module_to_skip_list:
-            object_detection_spec = importlib.util.find_spec("object_detection")
-            object_detection_found = object_detection_spec is not None
-
-            if not object_detection_found:
-                pytest.skip(
-                    "Skip unittests if the `object_detection` module is not found because of pre-trained model."
-                )
-
-        if "apex.amp" in module_to_skip_list:
-            apex_spec = importlib.util.find_spec("apex")
-            if apex_spec is not None:
-                amp_spec = importlib.util.find_spec("apex.amp")
-            else:
-                amp_spec = None
-            amp_found = amp_spec is not None
-
-            if not amp_found:
-                pytest.skip("Skip unittests if the `apex.amp` module is not found.")
+                if not module_found:
+                    pytest.skip(f"Test skipped because package {module} not available.")

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ markers =
     only_with_platform: DEPRECATED only used for legacy tests. Use skipMlFramework instead. marks a test to be performed only for a specific mlFramework values
     framework_agnostic: marks a test to be agnostic to frameworks and run only for one default framework
     skip_travis: Skips a test marked with this decorator if the command line argument skip_travis is set to true
+    skip_module: Skip the test if a module is not available in the current environment
 
 [mypy]
 ignore_missing_imports = True

--- a/tests/attacks/evasion/test_imperceptible_asr_pytorch.py
+++ b/tests/attacks/evasion/test_imperceptible_asr_pytorch.py
@@ -28,7 +28,7 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipModule("apex.amp", "deepspeech_pytorch", "torchaudio")
+@pytest.mark.skip_module("apex.amp", "deepspeech_pytorch", "torchaudio")
 @pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("use_amp", [False, True])
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])

--- a/tests/estimators/classification/test_deeplearning_specific.py
+++ b/tests/estimators/classification/test_deeplearning_specific.py
@@ -146,7 +146,7 @@ def test_pickle(art_warning, get_default_mnist_subset, image_dl_estimator):
         art_warning(e)
 
 
-@pytest.mark.skipModule("apex.amp")
+@pytest.mark.skip_module("apex.amp")
 @pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
 def test_loss_gradient_amp(

--- a/tests/estimators/speech_recognition/test_pytorch_deep_speech.py
+++ b/tests/estimators/speech_recognition/test_pytorch_deep_speech.py
@@ -28,7 +28,7 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipModule("apex.amp", "deepspeech_pytorch")
+@pytest.mark.skip_module("apex.amp", "deepspeech_pytorch")
 @pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("use_amp", [False, True])
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])

--- a/tests/estimators/speech_recognition/test_tensorflow_lingvo.py
+++ b/tests/estimators/speech_recognition/test_tensorflow_lingvo.py
@@ -39,32 +39,29 @@ class TestTensorFlowLingvoASR:
     Test the TensorFlowLingvoASR estimator.
     """
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_is_subclass(self, art_warning):
         try:
             assert issubclass(TensorFlowLingvoASR, (SpeechRecognizerMixin, TensorFlowV2Estimator))
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_implements_abstract_methods(self, art_warning):
         try:
             import tensorflow.compat.v1 as tf1
 
-            tf1.reset_default_graph()
             TensorFlowLingvoASR()
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_load_model(self, art_warning):
         try:
             import tensorflow.compat.v1 as tf1
-
-            tf1.reset_default_graph()
 
             TensorFlowLingvoASR()
             graph = tf1.get_default_graph()
@@ -72,13 +69,11 @@ class TestTensorFlowLingvoASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_decoder_input(self, art_warning, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
-
-            tf1.reset_default_graph()
 
             test_input, test_mask_frequency = audio_batch_padded
             test_target_dummy = np.array(["DUMMY"] * test_input.shape[0])
@@ -100,13 +95,11 @@ class TestTensorFlowLingvoASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_log_mel_features(self, art_warning, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
-
-            tf1.reset_default_graph()
 
             test_input, _ = audio_batch_padded
             lingvo = TensorFlowLingvoASR()
@@ -118,13 +111,11 @@ class TestTensorFlowLingvoASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_pad_audio_input(self, art_warning):
         try:
             import tensorflow.compat.v1 as tf1
-
-            tf1.reset_default_graph()
 
             test_input = np.array([np.array([1]), np.array([2] * 480)], dtype=object)
             test_mask = np.array([[True] + [False] * 479, [True] * 480])
@@ -137,13 +128,11 @@ class TestTensorFlowLingvoASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_predict_batch(self, art_warning, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
-
-            tf1.reset_default_graph()
 
             test_input, test_mask_frequency = audio_batch_padded
             test_target_dummy = np.array(["DUMMY"] * test_input.shape[0])
@@ -174,13 +163,11 @@ class TestTensorFlowLingvoASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_predict(self, art_warning, audio_data):
         try:
             import tensorflow.compat.v1 as tf1
-
-            tf1.reset_default_graph()
 
             test_input = audio_data
 
@@ -191,13 +178,11 @@ class TestTensorFlowLingvoASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_loss_gradient_tensor(self, art_warning, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
-
-            tf1.reset_default_graph()
 
             test_input, test_mask_frequency = audio_batch_padded
             test_target_dummy = np.array(["DUMMY"] * test_input.shape[0])
@@ -214,14 +199,12 @@ class TestTensorFlowLingvoASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     @pytest.mark.parametrize("batch_mode", [True, False])
     def test_loss_gradient_batch_mode(self, art_warning, batch_mode, audio_data):
         try:
             import tensorflow.compat.v1 as tf1
-
-            tf1.reset_default_graph()
 
             test_input = audio_data
             test_target = np.array(["This", "is", "a dummy", "a dummy"])
@@ -277,13 +260,11 @@ class TestTensorFlowLingvoASRLibriSpeechSamples:
         },
     }
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_predict(self, art_warning):
         try:
             import tensorflow.compat.v1 as tf1
-
-            tf1.reset_default_graph()
 
             transcripts = list()
             audios = list()
@@ -301,14 +282,12 @@ class TestTensorFlowLingvoASRLibriSpeechSamples:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipif(tf.__version__ != "2.1.0", reason="requires TensorFlow 2.1.0")
-    @pytest.mark.skipMlFramework("pytorch", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_module("lingvo")
+    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     @pytest.mark.xfail(reason="Known issue that needs further investigation")
     def test_loss_gradient(self, art_warning):
         try:
             import tensorflow.compat.v1 as tf1
-
-            tf1.reset_default_graph()
 
             transcripts = list()
             audios = list()

--- a/tests/preprocessing/audio/test_l_filter_pytorch.py
+++ b/tests/preprocessing/audio/test_l_filter_pytorch.py
@@ -29,7 +29,7 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipModule("torchaudio")
+@pytest.mark.skip_module("torchaudio")
 @pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("fir_filter", [False, True])
 def test_audio_filter(fir_filter, art_warning, expected_values):
@@ -77,7 +77,7 @@ def test_audio_filter(fir_filter, art_warning, expected_values):
         art_warning(e)
 
 
-@pytest.mark.skipModule("torchaudio")
+@pytest.mark.skip_module("torchaudio")
 @pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 def test_default(art_warning):
     try:
@@ -98,7 +98,7 @@ def test_default(art_warning):
         art_warning(e)
 
 
-@pytest.mark.skipModule("torchaudio")
+@pytest.mark.skip_module("torchaudio")
 @pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 def test_triple_clip_values_error(art_warning):
     try:
@@ -114,7 +114,7 @@ def test_triple_clip_values_error(art_warning):
         art_warning(e)
 
 
-@pytest.mark.skipModule("torchaudio")
+@pytest.mark.skip_module("torchaudio")
 @pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 def test_relation_clip_values_error(art_warning):
     try:


### PR DESCRIPTION
# Description

This PR adds a Lingvo test runner to the CI pipeline. All tests related to Lingvo, require a specific version of `tensorflow` (`2.1.0`), Lingvo (`0.6.4`) and Python 3.6.

Note, the new test runner will run all `tensorflow2v1` flagged tests.

Fixes #707

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)

**Test Configuration**:

- Fedora 33
- Python 3.6

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
