### PR TITLE
fix max_iters issue in SVM notebook

### DIFF
--- a/notebooks/poisoning_attack_svm.ipynb
+++ b/notebooks/poisoning_attack_svm.ipynb
@@ -142,7 +142,7 @@
     "    art_classifier.fit(x_train, y_train)\n",
     "    init_attack = np.copy(x_train[attack_idx])\n",
     "    y_attack = np.array([1, 1]) - np.copy(y_train[attack_idx])\n",
-    "    attack = PoisoningAttackSVM(art_classifier, 0.001, 1.0, x_train, y_train, x_val, y_val, max_iters=100)\n",
+    "    attack = PoisoningAttackSVM(art_classifier, 0.001, 1.0, x_train, y_train, x_val, y_val, max_iter=100)\n",
     "    final_attack, _ = attack.poison(np.array([init_attack]), y=np.array([y_attack]))\n",
     "    return final_attack, art_classifier"
    ]


### PR DESCRIPTION
# Description

Fix an issue with the SVM poisoning notebook where the wrong argument is used (`max_iters` instead of `max_iter`)

Fixes #777

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
