### PR TITLE
Increase precision for exponentiation in Wasserstein

### DIFF
--- a/art/attacks/evasion/wasserstein.py
+++ b/art/attacks/evasion/wasserstein.py
@@ -738,8 +738,10 @@ class Wasserstein(EvasionAttack):
         if self.eps_step <= 0:
             raise ValueError("The perturbation step-size `eps_step` has to be positive.")
 
-        if self.eps_step > self.eps:
-            raise ValueError("The iteration step `eps_step` has to be smaller than the total attack `eps`.")
+        if self.norm == "inf" and self.eps_step > self.eps:
+            raise ValueError(
+                "The iteration step `eps_step` has to be smaller than or equal to the total attack budget `eps`."
+            )
 
         if self.eps_iter <= 0:
             raise ValueError("The number of epsilon iterations `eps_iter` has to be a positive integer.")

--- a/art/attacks/evasion/wasserstein.py
+++ b/art/attacks/evasion/wasserstein.py
@@ -377,6 +377,7 @@ class Wasserstein(EvasionAttack):
         exp_alpha = np.exp(-alpha)
 
         beta = -self.regularization * grad
+        beta = beta.astype(np.float64)
         exp_beta = np.exp(-beta)
 
         # Check for overflow

--- a/art/attacks/evasion/wasserstein.py
+++ b/art/attacks/evasion/wasserstein.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+EPS_LOG = 10 ** -10
+
 
 class Wasserstein(EvasionAttack):
     """
@@ -400,6 +402,7 @@ class Wasserstein(EvasionAttack):
 
         for _ in range(self.conjugate_sinkhorn_max_iter):
             # Block coordinate descent iterates
+            x[x == 0.0] = EPS_LOG  # Prevent divide by zero in np.log
             alpha[I_nonzero_] = (np.log(self._local_transport(K, exp_beta, self.kernel_size)) - np.log(x))[I_nonzero_]
             exp_alpha = np.exp(-alpha)
 
@@ -475,6 +478,7 @@ class Wasserstein(EvasionAttack):
 
         for _ in range(self.projected_sinkhorn_max_iter):
             # Block coordinate descent iterates
+            x_init[x_init == 0.0] = EPS_LOG  # Prevent divide by zero in np.log
             alpha = np.log(self._local_transport(K, exp_beta, self.kernel_size)) - np.log(x_init)
             exp_alpha = np.exp(-alpha)
 


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request increases the precision for exponentiation to avoid infinite returns.

Fixes #776 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
