### PR TITLE
Add Carlini and Wagner audio attack on ASR systems 

### DIFF
--- a/art/attacks/evasion/adversarial_asr.py
+++ b/art/attacks/evasion/adversarial_asr.py
@@ -1,0 +1,85 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+This module implements the audio adversarial attack on automatic speech recognition systems of Carlini and Wagner
+(2018). It generates an adversarial audio example.
+
+| Paper link: https://arxiv.org/abs/1801.01944
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+from typing import TYPE_CHECKING
+
+from art.attacks.attack import EvasionAttack
+from art.attacks.evasion.imperceptible_asr.imperceptible_asr import ImperceptibleASR
+
+if TYPE_CHECKING:
+    from art.utils import SPEECH_RECOGNIZER_TYPE
+
+logger = logging.getLogger(__name__)
+
+
+class CarliniWagnerASR(ImperceptibleASR):
+    """
+    Implementation of the Carlini and Wagner audio adversarial attack against a speech recognition model.
+
+    | Paper link: https://arxiv.org/abs/1801.01944
+    """
+
+    attack_params = EvasionAttack.attack_params + [
+        "eps",
+        "learning_rate",
+        "max_iter",
+        "batch_size",
+    ]
+
+    def __init__(
+        self,
+        estimator: "SPEECH_RECOGNIZER_TYPE",
+        eps: float = 2000.0,
+        learning_rate: float = 100.0,
+        max_iter: int = 1000,
+        batch_size: int = 16,
+    ):
+        """
+        Create an instance of the :class:`.CarliniWagnerASR`.
+
+        :param estimator: A trained speech recognition estimator.
+        :param eps: Initial max norm bound for adversarial perturbation.
+        :param learning_rate: Learning rate of attack.
+        :param max_iter: Number of iterations.
+        :param batch_size: Batch size.
+        """
+        # pylint: disable=W0231
+
+        # re-implement init such that inherrited methods work
+        EvasionAttack.__init__(self, estimator=estimator)  # pylint: disable=W0233
+        self.masker = None
+        self.eps = eps
+        self.learning_rate_1 = learning_rate
+        self.max_iter_1 = max_iter
+        self.max_iter_2 = 0
+        self._targeted = True
+        self.batch_size = batch_size
+
+        # set remaining stage 2 params to some random values
+        self.alpha = 0.1
+        self.learning_rate_2 = 0.1
+
+        self._check_params()

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr.py
@@ -24,7 +24,7 @@ This module implements the adversarial and imperceptible attack on automatic spe
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from typing import TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import numpy as np
 import scipy.signal as ss
@@ -68,7 +68,7 @@ class ImperceptibleASR(EvasionAttack):
     def __init__(
         self,
         estimator: "SPEECH_RECOGNIZER_TYPE",
-        masker: "PsychoacousticMasker",
+        masker: Optional["PsychoacousticMasker"],
         eps: float = 2000.0,
         learning_rate_1: float = 100.0,
         max_iter_1: int = 1000,

--- a/tests/attacks/evasion/conftest.py
+++ b/tests/attacks/evasion/conftest.py
@@ -69,7 +69,7 @@ def audio_batch_padded():
 def asr_dummy_estimator(framework):
     def _asr_dummy_estimator(**kwargs):
         asr_dummy = None
-        if framework == "tensorflow2v1":
+        if framework in ("tensorflow2v1", "tensorflow2"):
 
             class TensorFlowV2ASRDummy(TensorFlowV2Estimator, SpeechRecognizerMixin):
                 def get_activations():

--- a/tests/attacks/evasion/test_adversarial_asr.py
+++ b/tests/attacks/evasion/test_adversarial_asr.py
@@ -1,0 +1,79 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+import pytest
+from numpy.testing import assert_array_equal
+
+from art.attacks.attack import EvasionAttack
+from art.attacks.evasion.adversarial_asr import CarliniWagnerASR
+from art.attacks.evasion.imperceptible_asr.imperceptible_asr import ImperceptibleASR
+from art.estimators.estimator import BaseEstimator, LossGradientsMixin, NeuralNetworkMixin
+from art.estimators.speech_recognition.speech_recognizer import SpeechRecognizerMixin
+from tests.attacks.utils import backend_test_classifier_type_check_fail
+from tests.utils import ARTTestException
+
+logger = logging.getLogger(__name__)
+
+
+class TestImperceptibleASR:
+    """
+    Test the ImperceptibleASR attack.
+    """
+
+    @pytest.mark.framework_agnostic
+    def test_is_subclass(self, art_warning):
+        try:
+            assert issubclass(CarliniWagnerASR, (ImperceptibleASR, EvasionAttack))
+        except ARTTestException as e:
+            art_warning(e)
+
+    @pytest.mark.skipMlFramework("tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_implements_abstract_methods(self, art_warning, asr_dummy_estimator):
+        try:
+            CarliniWagnerASR(estimator=asr_dummy_estimator())
+        except ARTTestException as e:
+            art_warning(e)
+
+    @pytest.mark.framework_agnostic
+    def test_classifier_type_check_fail(self, art_warning):
+        try:
+            backend_test_classifier_type_check_fail(
+                CarliniWagnerASR, [NeuralNetworkMixin, LossGradientsMixin, BaseEstimator, SpeechRecognizerMixin]
+            )
+        except ARTTestException as e:
+            art_warning(e)
+
+    @pytest.mark.skipMlFramework("tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_generate_batch(self, art_warning, mocker, asr_dummy_estimator, audio_data):
+        try:
+            test_input, test_target = audio_data
+
+            # mock _create_adversarial and test if result gets passed unchanged through _create_imperceptible
+            mocker.patch.object(CarliniWagnerASR, "_create_adversarial", return_value=test_input)
+
+            carlini_asr = CarliniWagnerASR(estimator=asr_dummy_estimator())
+            adversarial = carlini_asr._generate_batch(test_input, test_target)
+
+            carlini_asr._create_adversarial.assert_called()
+            for a, t in zip(adversarial, test_input):
+                assert_array_equal(a, t)
+        except ARTTestException as e:
+            art_warning(e)

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -134,28 +134,17 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
-    def test_loss_gradient_masking_threshold(self, art_warning, asr_dummy_estimator, audio_batch_padded):
+    @pytest.mark.skipMlFramework("tensorflow", "mxnet", "kerastf", "non_dl_frameworks")
+    def test_loss_gradient_masking_threshold(self, art_warning, asr_dummy_estimator, audio_data):
         try:
-            import tensorflow.compat.v1 as tf1
+            test_input, _ = audio_data
+            test_delta = test_input * 0
 
-            tf1.reset_default_graph()
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
+            loss_gradient, loss = imperceptible_asr._loss_gradient_masking_threshold(test_delta, test_input)
 
-            test_delta = audio_batch_padded
-            test_psd_maximum = np.ones((test_delta.shape[0], 28))
-            test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
-
-            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(),)
-            feed_dict = {
-                imperceptible_asr._delta: test_delta,
-                imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maximum,
-                imperceptible_asr._masking_threshold_tf: test_masking_threshold,
-            }
-            with tf1.Session() as sess:
-                loss_gradient, loss = sess.run(imperceptible_asr._loss_gradient_masking_threshold_op_tf, feed_dict)
-
-            assert loss_gradient.shape == test_delta.shape
-            assert loss.ndim == 1 and loss.shape[0] == test_delta.shape[0]
+            assert [g.shape for g in loss_gradient] == [d.shape for d in test_delta]
+            assert loss.ndim == 1 and loss.shape == test_delta.shape
         except ARTTestException as e:
             art_warning(e)
 
@@ -170,7 +159,7 @@ class TestImperceptibleASR:
             test_psd_maximum = np.ones((test_delta.shape[0], 28))
             test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
 
-            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(),)
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
             feed_dict = {
                 imperceptible_asr._delta: test_delta,
                 imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maximum,
@@ -191,11 +180,10 @@ class TestImperceptibleASR:
             test_psd_maximum = np.ones((test_delta.shape[0], 28))
             test_masking_threshold = np.zeros((test_delta.shape[0], 1025, 28))
 
-            imperceptible_asr = ImperceptibleASR(
-                estimator=asr_dummy_estimator(), masker=PsychoacousticMasker(),
-            )
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
             loss_gradient, loss = imperceptible_asr._loss_gradient_masking_threshold_torch(
-                test_delta, test_psd_maximum, test_masking_threshold)
+                test_delta, test_psd_maximum, test_masking_threshold
+            )
 
             assert loss_gradient.shape == test_delta.shape
             assert loss.ndim == 1 and loss.shape[0] == test_delta.shape[0]
@@ -213,7 +201,7 @@ class TestImperceptibleASR:
             test_psd_maximum = np.ones((test_delta.shape[0], 28))
 
             masker = PsychoacousticMasker()
-            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=masker,)
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=masker)
             feed_dict = {
                 imperceptible_asr._delta: test_delta,
                 imperceptible_asr._power_spectral_density_maximum_tf: test_psd_maximum,
@@ -240,9 +228,7 @@ class TestImperceptibleASR:
             test_psd_maximum = np.ones((test_delta.shape[0], 28))
 
             masker = PsychoacousticMasker()
-            imperceptible_asr = ImperceptibleASR(
-                estimator=asr_dummy_estimator(), masker=masker,
-            )
+            imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=masker)
             approximate_psd_torch = imperceptible_asr._approximate_power_spectral_density_torch(
                 torch.from_numpy(test_delta), torch.from_numpy(test_psd_maximum)
             )

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -34,21 +34,21 @@ class TestImperceptibleASR:
     Test the ImperceptibleASR attack.
     """
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_is_subclass(self, art_warning):
         try:
             assert issubclass(ImperceptibleASR, EvasionAttack)
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_implements_abstract_methods(self, art_warning, asr_dummy_estimator):
         try:
             ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_generate(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -64,7 +64,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_generate_batch(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -80,7 +80,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_adversarial(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -107,7 +107,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_imperceptible(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -53,14 +53,12 @@ class TestImperceptibleASR:
         try:
             test_input, test_target = audio_data
 
-            mocker.patch.object(ImperceptibleASR, "_create_adversarial")
-            mocker.patch.object(ImperceptibleASR, "_create_imperceptible")
+            mocker.patch.object(ImperceptibleASR, "_generate_batch")
 
             imperceptible_asr = ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
-            _ = imperceptible_asr._generate_batch(test_input, test_target)
+            _ = imperceptible_asr.generate(test_input, test_target)
 
-            imperceptible_asr._create_adversarial.assert_called()
-            imperceptible_asr._create_imperceptible.assert_called()
+            imperceptible_asr._generate_batch.assert_called()
         except ARTTestException as e:
             art_warning(e)
 


### PR DESCRIPTION
# Description

This PR adds the `CarliniWagnerASR` attack module. It is implemented as a special case of the `ImperceptibleASR`, where `max_iter_stage_2` is zero by default. Thus skipping the second stage of that attack.

Furthermore, the PR includes some commits from #760 that were not correctly applied during the 1.5 release. 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [x] New feature (non-breaking)


# Testing

Several tests have been added to the test suite.

**Test Configuration**:
- Fedora 33
- Python 3.8.6
- ART 1.5.1 development

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
