### PR TITLE
Use auto tqdm imports for notebook support

### DIFF
--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
@@ -30,7 +30,7 @@ from typing import Optional, Union, Tuple, TYPE_CHECKING
 import random
 import numpy as np
 from scipy.ndimage import rotate, shift, zoom
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.attacks.attack import EvasionAttack
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
@@ -28,7 +28,7 @@ import math
 from typing import Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.attacks.attack import EvasionAttack
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin

--- a/art/attacks/evasion/boundary.py
+++ b/art/attacks/evasion/boundary.py
@@ -27,7 +27,7 @@ import logging
 from typing import Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from tqdm import tqdm, trange
+from tqdm.auto import tqdm, trange
 
 from art.attacks.attack import EvasionAttack
 from art.config import ART_NUMPY_DTYPE

--- a/art/attacks/evasion/carlini.py
+++ b/art/attacks/evasion/carlini.py
@@ -30,7 +30,7 @@ import logging
 from typing import Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
 from art.estimators.estimator import BaseEstimator

--- a/art/attacks/evasion/decision_tree_attack.py
+++ b/art/attacks/evasion/decision_tree_attack.py
@@ -24,7 +24,7 @@ import logging
 from typing import List, Optional, Union
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.attacks.attack import EvasionAttack
 from art.estimators.classification.scikitlearn import ScikitlearnDecisionTreeClassifier

--- a/art/attacks/evasion/deepfool.py
+++ b/art/attacks/evasion/deepfool.py
@@ -26,7 +26,7 @@ import logging
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
 from art.estimators.estimator import BaseEstimator

--- a/art/attacks/evasion/dpatch.py
+++ b/art/attacks/evasion/dpatch.py
@@ -26,7 +26,7 @@ import random
 from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.attacks.attack import EvasionAttack
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin

--- a/art/attacks/evasion/dpatch_robust.py
+++ b/art/attacks/evasion/dpatch_robust.py
@@ -30,7 +30,7 @@ import random
 from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.attacks.attack import EvasionAttack
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin

--- a/art/attacks/evasion/elastic_net.py
+++ b/art/attacks/evasion/elastic_net.py
@@ -27,7 +27,7 @@ from typing import Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 import six
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
 from art.attacks.attack import EvasionAttack

--- a/art/attacks/evasion/frame_saliency.py
+++ b/art/attacks/evasion/frame_saliency.py
@@ -27,7 +27,7 @@ import logging
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin

--- a/art/attacks/evasion/hclu.py
+++ b/art/attacks/evasion/hclu.py
@@ -28,7 +28,7 @@ from typing import Optional
 
 import numpy as np
 from scipy.optimize import minimize
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.attacks.attack import EvasionAttack
 from art.estimators.classification.GPy import GPyGaussianProcessClassifier

--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -27,7 +27,7 @@ import logging
 from typing import Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.attacks.attack import EvasionAttack

--- a/art/attacks/evasion/newtonfool.py
+++ b/art/attacks/evasion/newtonfool.py
@@ -26,7 +26,7 @@ import logging
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.attacks.attack import EvasionAttack
 from art.config import ART_NUMPY_DTYPE

--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -43,7 +43,7 @@ from six import string_types
 from scipy._lib._util import check_random_state
 from scipy.optimize.optimize import _status_message
 from scipy.optimize import OptimizeResult, minimize
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.attacks.attack import EvasionAttack
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
@@ -30,7 +30,7 @@ from typing import Optional, Union, TYPE_CHECKING
 
 import numpy as np
 from scipy.stats import truncnorm
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.attacks.evasion.fast_gradient import FastGradientMethod
 from art.config import ART_NUMPY_DTYPE

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
@@ -29,7 +29,7 @@ import logging
 from typing import Optional, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
@@ -29,7 +29,7 @@ import logging
 from typing import Optional, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin

--- a/art/attacks/evasion/saliency_map.py
+++ b/art/attacks/evasion/saliency_map.py
@@ -26,7 +26,7 @@ import logging
 from typing import Optional, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.attacks.attack import EvasionAttack
 from art.config import ART_NUMPY_DTYPE

--- a/art/attacks/evasion/shadow_attack.py
+++ b/art/attacks/evasion/shadow_attack.py
@@ -24,7 +24,7 @@ import logging
 from typing import Optional, Union
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin

--- a/art/attacks/evasion/spatial_transformation.py
+++ b/art/attacks/evasion/spatial_transformation.py
@@ -29,7 +29,7 @@ from typing import Optional, TYPE_CHECKING
 
 import numpy as np
 from scipy.ndimage import rotate, shift
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.attacks.attack import EvasionAttack
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin

--- a/art/attacks/evasion/spatial_transformation.py
+++ b/art/attacks/evasion/spatial_transformation.py
@@ -118,11 +118,23 @@ class SpatialTransformation(EvasionAttack):
 
             grid_trans_x = [
                 int(round(g))
-                for g in list(np.linspace(-max_num_pixel_trans_x, max_num_pixel_trans_x, num=self.num_translations,))
+                for g in list(
+                    np.linspace(
+                        -max_num_pixel_trans_x,
+                        max_num_pixel_trans_x,
+                        num=self.num_translations,
+                    )
+                )
             ]
             grid_trans_y = [
                 int(round(g))
-                for g in list(np.linspace(-max_num_pixel_trans_y, max_num_pixel_trans_y, num=self.num_translations,))
+                for g in list(
+                    np.linspace(
+                        -max_num_pixel_trans_y,
+                        max_num_pixel_trans_y,
+                        num=self.num_translations,
+                    )
+                )
             ]
             grid_rot = list(np.linspace(-self.max_rotation, self.max_rotation, num=self.num_rotations))
 
@@ -144,7 +156,7 @@ class SpatialTransformation(EvasionAttack):
 
             # Initialize progress bar
             pbar = tqdm(
-                len(grid_trans_x) * len(grid_trans_y) * len(grid_rot),
+                total=len(grid_trans_x) * len(grid_trans_y) * len(grid_rot),
                 desc="Spatial transformation",
                 disable=not self.verbose,
             )
@@ -175,7 +187,8 @@ class SpatialTransformation(EvasionAttack):
             self.attack_rot = rot
 
             logger.info(
-                "Success rate of spatial transformation attack: %.2f%%", 100 * self.fooling_rate,
+                "Success rate of spatial transformation attack: %.2f%%",
+                100 * self.fooling_rate,
             )
             logger.info("Attack-translation in x: %.2f%%", self.attack_trans_x)
             logger.info("Attack-translation in y: %.2f%%", self.attack_trans_y)
@@ -198,7 +211,10 @@ class SpatialTransformation(EvasionAttack):
 
         if self.estimator.clip_values is not None:
             np.clip(
-                x_adv, self.estimator.clip_values[0], self.estimator.clip_values[1], out=x_adv,
+                x_adv,
+                self.estimator.clip_values[0],
+                self.estimator.clip_values[1],
+                out=x_adv,
             )
 
         return x_adv

--- a/art/attacks/evasion/universal_perturbation.py
+++ b/art/attacks/evasion/universal_perturbation.py
@@ -29,7 +29,7 @@ import types
 from typing import Any, Dict, Optional, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.attacks.attack import EvasionAttack
 from art.estimators.estimator import BaseEstimator

--- a/art/attacks/evasion/universal_perturbation.py
+++ b/art/attacks/evasion/universal_perturbation.py
@@ -172,7 +172,7 @@ class UniversalPerturbation(EvasionAttack):
 
         # Generate the adversarial examples
         nb_iter = 0
-        pbar = tqdm(self.max_iter, desc="Universal perturbation", disable=not self.verbose)
+        pbar = tqdm(total=self.max_iter, desc="Universal perturbation", disable=not self.verbose)
 
         while fooling_rate < 1.0 - self.delta and nb_iter < self.max_iter:
             # Go through all the examples randomly

--- a/art/attacks/evasion/virtual_adversarial.py
+++ b/art/attacks/evasion/virtual_adversarial.py
@@ -26,7 +26,7 @@ import logging
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.attacks.attack import EvasionAttack
 from art.config import ART_NUMPY_DTYPE

--- a/art/attacks/evasion/wasserstein.py
+++ b/art/attacks/evasion/wasserstein.py
@@ -27,7 +27,7 @@ from typing import Optional, TYPE_CHECKING
 
 import numpy as np
 from scipy.special import lambertw
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin

--- a/art/attacks/evasion/zoo.py
+++ b/art/attacks/evasion/zoo.py
@@ -29,7 +29,7 @@ from typing import Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 from scipy.ndimage import zoom
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
 from art.attacks.attack import EvasionAttack

--- a/art/attacks/extraction/knockoff_nets.py
+++ b/art/attacks/extraction/knockoff_nets.py
@@ -26,7 +26,7 @@ import logging
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
 from art.attacks.attack import ExtractionAttack

--- a/art/attacks/inference/model_inversion/mi_face.py
+++ b/art/attacks/inference/model_inversion/mi_face.py
@@ -26,7 +26,7 @@ import logging
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
 from art.estimators.classification.classifier import ClassifierMixin, ClassGradientsMixin

--- a/art/attacks/poisoning/feature_collision_attack.py
+++ b/art/attacks/poisoning/feature_collision_attack.py
@@ -25,7 +25,7 @@ import logging
 from typing import Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.attacks.attack import PoisoningAttackWhiteBox
 from art.estimators import BaseEstimator, NeuralNetworkMixin

--- a/art/attacks/poisoning/poisoning_attack_svm.py
+++ b/art/attacks/poisoning/poisoning_attack_svm.py
@@ -24,7 +24,7 @@ import logging
 from typing import Optional, Tuple
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.attacks.attack import PoisoningAttackWhiteBox
 from art.estimators.classification.scikitlearn import ScikitlearnSVC

--- a/art/defences/detector/evasion/subsetscanning/detector.py
+++ b/art/defences/detector/evasion/subsetscanning/detector.py
@@ -151,7 +151,7 @@ class SubsetScanningDetector(ClassifierNeuralNetwork):
         if clean_size is None and advs_size is None:
             # Individual scan
             with tqdm(
-                len(clean_pvalranges) + len(adv_pvalranges), desc="Subset scanning", disable=not self.verbose
+                total=len(clean_pvalranges) + len(adv_pvalranges), desc="Subset scanning", disable=not self.verbose
             ) as pbar:
                 for j, c_p in enumerate(clean_pvalranges):
                     best_score, _, _, _ = Scanner.fgss_individ_for_nets(c_p)

--- a/art/defences/detector/evasion/subsetscanning/detector.py
+++ b/art/defences/detector/evasion/subsetscanning/detector.py
@@ -27,7 +27,7 @@ from typing import List, Optional, Tuple, Union, TYPE_CHECKING
 # pylint: disable=E0001
 import numpy as np
 from sklearn import metrics
-from tqdm import trange, tqdm
+from tqdm.auto import trange, tqdm
 
 from art.defences.detector.evasion.subsetscanning.scanner import Scanner
 from art.estimators.classification.classifier import ClassifierNeuralNetwork

--- a/art/defences/preprocessor/jpeg_compression.py
+++ b/art/defences/preprocessor/jpeg_compression.py
@@ -31,7 +31,7 @@ import logging
 from typing import Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.defences.preprocessor.preprocessor import Preprocessor

--- a/art/defences/preprocessor/mp3_compression.py
+++ b/art/defences/preprocessor/mp3_compression.py
@@ -30,7 +30,7 @@ from io import BytesIO
 from typing import Optional, Tuple
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.defences.preprocessor.preprocessor import Preprocessor
 from art.utils import Deprecated, deprecated_keyword_arg

--- a/art/defences/preprocessor/pixel_defend.py
+++ b/art/defences/preprocessor/pixel_defend.py
@@ -31,7 +31,7 @@ import logging
 from typing import Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.defences.preprocessor.preprocessor import Preprocessor

--- a/art/defences/preprocessor/variance_minimization.py
+++ b/art/defences/preprocessor/variance_minimization.py
@@ -31,7 +31,7 @@ from typing import Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 from scipy.optimize import minimize
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.defences.preprocessor.preprocessor import Preprocessor

--- a/art/defences/preprocessor/video_compression.py
+++ b/art/defences/preprocessor/video_compression.py
@@ -29,7 +29,7 @@ from tempfile import TemporaryDirectory
 from typing import Optional, Tuple
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art import config
 from art.defences.preprocessor.preprocessor import Preprocessor

--- a/art/defences/trainer/adversarial_trainer.py
+++ b/art/defences/trainer/adversarial_trainer.py
@@ -37,7 +37,7 @@ import logging
 from typing import List, Optional, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange, tqdm
+from tqdm.auto import trange, tqdm
 
 from art.defences.trainer.trainer import Trainer
 

--- a/art/defences/trainer/adversarial_trainer_fbf_pytorch.py
+++ b/art/defences/trainer/adversarial_trainer_fbf_pytorch.py
@@ -27,7 +27,7 @@ import time
 from typing import Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
 from art.defences.trainer.adversarial_trainer_fbf import AdversarialTrainerFBF

--- a/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
+++ b/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
@@ -28,7 +28,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 from scipy.stats import norm
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.defences.preprocessor.gaussian_augmentation import GaussianAugmentation

--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -22,7 +22,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
 from art.utils import Deprecated, deprecated, deprecated_keyword_arg

--- a/art/estimators/poison_mitigation/neural_cleanse/keras.py
+++ b/art/estimators/poison_mitigation/neural_cleanse/keras.py
@@ -27,7 +27,7 @@ import logging
 from typing import List, Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.estimators.poison_mitigation.neural_cleanse.neural_cleanse import NeuralCleanseMixin

--- a/art/estimators/poison_mitigation/strip/strip.py
+++ b/art/estimators/poison_mitigation/strip/strip.py
@@ -27,7 +27,7 @@ from typing import Callable, Optional
 
 import numpy as np
 from scipy.stats import entropy, norm
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.estimators.certification.abstain import AbstainPredictorMixin
 

--- a/art/metrics/gradient_check.py
+++ b/art/metrics/gradient_check.py
@@ -21,7 +21,7 @@ This module implements gradient check functions for estimators
 from typing import TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 if TYPE_CHECKING:
     from art.estimators.estimator import LossGradientsMixin

--- a/art/metrics/metrics.py
+++ b/art/metrics/metrics.py
@@ -29,7 +29,7 @@ import numpy as np
 import numpy.linalg as la
 from scipy.optimize import fmin as scipy_optimizer
 from scipy.stats import weibull_min
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.attacks.evasion.fast_gradient import FastGradientMethod

--- a/art/metrics/verification_decisions_trees.py
+++ b/art/metrics/verification_decisions_trees.py
@@ -24,7 +24,7 @@ import logging
 from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
-from tqdm import trange
+from tqdm.auto import trange
 
 if TYPE_CHECKING:
     from art.estimators.classification.classifier import ClassifierDecisionTree

--- a/art/preprocessing/audio/l_filter/l_filter.py
+++ b/art/preprocessing/audio/l_filter/l_filter.py
@@ -27,7 +27,7 @@ from typing import Optional, Tuple, TYPE_CHECKING
 
 from scipy.signal import lfilter
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.preprocessing.preprocessing import Preprocessor

--- a/art/preprocessing/audio/l_filter/l_filter_pytorch.py
+++ b/art/preprocessing/audio/l_filter/l_filter_pytorch.py
@@ -26,7 +26,7 @@ import logging
 from typing import Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art.preprocessing.preprocessing import PreprocessorPyTorch
 from art.config import ART_NUMPY_DTYPE

--- a/art/utils.py
+++ b/art/utils.py
@@ -35,7 +35,7 @@ import zipfile
 import numpy as np
 from scipy.special import gammainc
 import six
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from art import config
 


### PR DESCRIPTION
# Description

When running art attacks in a jupyter notebook the progress bars from art attacks display as plain text, instead of jupyter widgets. This PR changes tqdm imports to use their notebook detection so that jupyter widgets will be correctly displayed where supported.

Fixes #798

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

None, CI should catch any errors (this is just a straight find/replace).

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] New and existing unit tests pass locally with my changes
