### PR TITLE
Create copies of inputs to protect against overwriting inputs

### DIFF
--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
@@ -238,9 +238,11 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
         :param eps_step: Attack step size (input variation) at each iteration.
         :return: Adversarial examples.
         """
+        import torch  # lgtm [py/repeated-import]
+
         inputs = x.to(self.estimator.device)
         targets = targets.to(self.estimator.device)
-        adv_x = inputs
+        adv_x = torch.clone(inputs)
 
         if mask is not None:
             mask = mask.to(self.estimator.device)

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
@@ -234,7 +234,10 @@ class ProjectedGradientDescentTensorFlowV2(ProjectedGradientDescentCommon):
         :param eps_step: Attack step size (input variation) at each iteration.
         :return: Adversarial examples.
         """
-        adv_x = x
+        import tensorflow as tf  # lgtm [py/repeated-import]
+
+        adv_x = tf.identity(x)
+
         for i_max_iter in range(self.max_iter):
             adv_x = self._compute_tf(
                 adv_x, x, targets, mask, eps, eps_step, self.num_random_init > 0 and i_max_iter == 0,


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adapts the PyTorch and TensorFlow specific implementations of ProjectedGradientDescent attack (`ProjectedGradientDescentPyTorch` and `ProjectedGradientDescentTensorFlow`) to create copies of input batches to protect them against unexpected modifications during the attack following the pattern of `ProjectedGradientDescentNumpy`.

@lcadalzo Thank you for identifying this issue.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
