### PR TITLE
Ensure that mean and standard deviation are broadcastable in standardization preprocessors

### DIFF
--- a/art/estimators/certification/randomized_smoothing/pytorch.py
+++ b/art/estimators/certification/randomized_smoothing/pytorch.py
@@ -63,7 +63,7 @@ class PyTorchRandomizedSmoothing(RandomizedSmoothingMixin, PyTorchClassifier):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         device_type: str = "gpu",
         sample_size: int = 32,
         scale: float = 0.1,

--- a/art/estimators/certification/randomized_smoothing/tensorflow.py
+++ b/art/estimators/certification/randomized_smoothing/tensorflow.py
@@ -62,7 +62,7 @@ class TensorFlowV2RandomizedSmoothing(RandomizedSmoothingMixin, TensorFlowV2Clas
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         sample_size: int = 32,
         scale: float = 0.1,
         alpha: float = 0.001,

--- a/art/estimators/classification/GPy.py
+++ b/art/estimators/classification/GPy.py
@@ -52,7 +52,7 @@ class GPyGaussianProcessClassifier(ClassifierClassLossGradients):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Classifier` instance GPY Gaussian Process classification models.

--- a/art/estimators/classification/blackbox.py
+++ b/art/estimators/classification/blackbox.py
@@ -51,7 +51,7 @@ class BlackBoxClassifier(ClassifierMixin, BaseEstimator):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ):
         """
         Create a `Classifier` instance for a black-box model.

--- a/art/estimators/classification/catboost.py
+++ b/art/estimators/classification/catboost.py
@@ -53,7 +53,7 @@ class CatBoostARTClassifier(ClassifierDecisionTree):
         model: Optional["CatBoostClassifier"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         nb_features: Optional[int] = None,
     ) -> None:

--- a/art/estimators/classification/detector_classifier.py
+++ b/art/estimators/classification/detector_classifier.py
@@ -53,7 +53,7 @@ class DetectorClassifier(ClassifierNeuralNetwork):
         detector: ClassifierNeuralNetwork,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Initialization for the DetectorClassifier.

--- a/art/estimators/classification/ensemble.py
+++ b/art/estimators/classification/ensemble.py
@@ -56,7 +56,7 @@ class EnsembleClassifier(ClassifierNeuralNetwork):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Initialize a :class:`.EnsembleClassifier` object. The data range values and colour channel index have to

--- a/art/estimators/classification/keras.py
+++ b/art/estimators/classification/keras.py
@@ -80,7 +80,7 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         input_layer: int = 0,
         output_layer: int = 0,
     ) -> None:

--- a/art/estimators/classification/lightgbm.py
+++ b/art/estimators/classification/lightgbm.py
@@ -54,7 +54,7 @@ class LightGBMClassifier(ClassifierDecisionTree):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Classifier` instance from a LightGBM model.

--- a/art/estimators/classification/mxnet.py
+++ b/art/estimators/classification/mxnet.py
@@ -67,7 +67,7 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Initialize an `MXClassifier` object. Assumes the `model` passed as parameter is a Gluon model.

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -75,7 +75,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         device_type: str = "gpu",
     ) -> None:
         """

--- a/art/estimators/classification/scikitlearn.py
+++ b/art/estimators/classification/scikitlearn.py
@@ -56,7 +56,7 @@ def SklearnClassifier(
     clip_values: Optional["CLIP_VALUES_TYPE"] = None,
     preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
     postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-    preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+    preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     use_logits: bool = False,
 ) -> "ScikitlearnClassifier":
     """
@@ -103,7 +103,7 @@ class ScikitlearnClassifier(ClassifierMixin, ScikitlearnEstimator):  # lgtm [py/
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         use_logits: bool = False,
     ) -> None:
         """
@@ -271,7 +271,7 @@ class ScikitlearnDecisionTreeClassifier(ScikitlearnClassifier):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Classifier` instance from a scikit-learn Decision Tree Classifier model.
@@ -417,7 +417,7 @@ class ScikitlearnDecisionTreeRegressor(ScikitlearnDecisionTreeClassifier):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Regressor` instance from a scikit-learn Decision Tree Regressor model.
@@ -507,7 +507,7 @@ class ScikitlearnExtraTreeClassifier(ScikitlearnDecisionTreeClassifier):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Classifier` instance from a scikit-learn Extra TreeClassifier Classifier model.
@@ -546,7 +546,7 @@ class ScikitlearnAdaBoostClassifier(ScikitlearnClassifier):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Classifier` instance from a scikit-learn AdaBoost Classifier model.
@@ -585,7 +585,7 @@ class ScikitlearnBaggingClassifier(ScikitlearnClassifier):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Classifier` instance from a scikit-learn Bagging Classifier model.
@@ -625,7 +625,7 @@ class ScikitlearnExtraTreesClassifier(ScikitlearnClassifier, DecisionTreeMixin):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ):
         """
         Create a `Classifier` instance from a scikit-learn Extra Trees Classifier model.
@@ -698,7 +698,7 @@ class ScikitlearnGradientBoostingClassifier(ScikitlearnClassifier, DecisionTreeM
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Classifier` instance from a scikit-learn Gradient Boosting Classifier model.
@@ -772,7 +772,7 @@ class ScikitlearnRandomForestClassifier(ScikitlearnClassifier):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Classifier` instance from a scikit-learn Random Forest Classifier model.
@@ -845,7 +845,7 @@ class ScikitlearnLogisticRegression(ClassGradientsMixin, LossGradientsMixin, Sci
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Classifier` instance from a scikit-learn Logistic Regression model.
@@ -1040,7 +1040,7 @@ class ScikitlearnGaussianNB(ScikitlearnClassifier):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Classifier` instance from a scikit-learn Gaussian Naive Bayes (GaussianNB) model.
@@ -1089,7 +1089,7 @@ class ScikitlearnSVC(ClassGradientsMixin, LossGradientsMixin, ScikitlearnClassif
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Create a `Classifier` instance from a scikit-learn C-Support Vector Classification model.

--- a/art/estimators/classification/tensorflow.py
+++ b/art/estimators/classification/tensorflow.py
@@ -71,7 +71,7 @@ class TensorFlowClassifier(ClassGradientsMixin, ClassifierMixin, TensorFlowEstim
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         feed_dict: Optional[Dict[Any, Any]] = None,
     ) -> None:
         """
@@ -771,7 +771,7 @@ class TensorFlowV2Classifier(ClassGradientsMixin, ClassifierMixin, TensorFlowV2E
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
     ) -> None:
         """
         Initialization specific to TensorFlow v2 models.

--- a/art/estimators/classification/xgboost.py
+++ b/art/estimators/classification/xgboost.py
@@ -60,7 +60,7 @@ class XGBoostClassifier(ClassifierDecisionTree):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         nb_features: Optional[int] = None,
         nb_classes: Optional[int] = None,
     ) -> None:

--- a/art/estimators/encoding/tensorflow.py
+++ b/art/estimators/encoding/tensorflow.py
@@ -61,7 +61,7 @@ class TensorFlowEncoder(EncoderMixin, TensorFlowEstimator):  # lgtm [py/missing-
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         feed_dict: Optional[Dict[Any, Any]] = None,
     ):
         """

--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -55,7 +55,7 @@ class BaseEstimator(ABC):
         clip_values: Optional["CLIP_VALUES_TYPE"],
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: Union["PREPROCESSING_TYPE", "Preprocessor"] = (0, 1),
+        preprocessing: Union["PREPROCESSING_TYPE", "Preprocessor"] = (0.0, 1.0),
     ):
         """
         Initialize a `BaseEstimator` object.

--- a/art/estimators/generation/tensorflow.py
+++ b/art/estimators/generation/tensorflow.py
@@ -60,7 +60,7 @@ class TensorFlowGenerator(GeneratorMixin, TensorFlowEstimator):  # lgtm [py/miss
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         feed_dict: Optional[Dict[Any, Any]] = None,
     ):
         """

--- a/art/estimators/object_detection/tensorflow_faster_rcnn.py
+++ b/art/estimators/object_detection/tensorflow_faster_rcnn.py
@@ -61,7 +61,7 @@ class TensorFlowFasterRCNN(ObjectDetectorMixin, TensorFlowEstimator):
         channels_first: bool = False,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         attack_losses: Tuple[str, ...] = (
             "Loss/RPNLoss/localization_loss",
             "Loss/RPNLoss/objectness_loss",

--- a/art/estimators/poison_mitigation/neural_cleanse/keras.py
+++ b/art/estimators/poison_mitigation/neural_cleanse/keras.py
@@ -72,7 +72,7 @@ class KerasNeuralCleanse(NeuralCleanseMixin, KerasClassifier):
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
-        preprocessing: "PREPROCESSING_TYPE" = (0, 1),
+        preprocessing: "PREPROCESSING_TYPE" = (0.0, 1.0),
         input_layer: int = 0,
         output_layer: int = 0,
         steps: int = 1000,

--- a/art/preprocessing/standardisation_mean_std/numpy.py
+++ b/art/preprocessing/standardisation_mean_std/numpy.py
@@ -19,13 +19,13 @@
 This module implements the standardisation with mean and standard deviation.
 """
 import logging
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import numpy as np
 
 from art.config import ART_NUMPY_DTYPE
 from art.preprocessing.preprocessing import Preprocessor
-
+from art.preprocessing.standardisation_mean_std.utils import broadcastable_mean_std
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,11 @@ class StandardisationMeanStd(Preprocessor):
     params = ["mean", "std", "apply_fit", "apply_predict"]
 
     def __init__(
-        self, mean: float = 0.0, std: float = 1.0, apply_fit: bool = True, apply_predict: bool = True,
+        self,
+        mean: Union[float, np.ndarray] = 0.0,
+        std: Union[float, np.ndarray] = 1.0,
+        apply_fit: bool = True,
+        apply_predict: bool = True,
     ):
         """
         Create an instance of StandardisationMeanStd.
@@ -47,9 +51,13 @@ class StandardisationMeanStd(Preprocessor):
         :param std: Standard Deviation.
         """
         super().__init__(is_fitted=True, apply_fit=apply_fit, apply_predict=apply_predict)
-        self.mean = mean
-        self.std = std
+        self.mean = np.asarray(mean, dtype=ART_NUMPY_DTYPE)
+        self.std = np.asarray(std, dtype=ART_NUMPY_DTYPE)
         self._check_params()
+
+        # init broadcastable mean and std for lazy loading
+        self._broadcastable_mean = None
+        self._broadcastable_std = None
 
     def __call__(self, x: np.ndarray, y: Optional[np.ndarray] = None,) -> Tuple[np.ndarray, Optional[np.ndarray]]:
         """
@@ -66,18 +74,26 @@ class StandardisationMeanStd(Preprocessor):
                 "np.float32.".format(x.dtype)
             )
 
-        mean = np.asarray(self.mean, dtype=ART_NUMPY_DTYPE)
-        std = np.asarray(self.std, dtype=ART_NUMPY_DTYPE)
+        if self._broadcastable_mean is None:
+            self._broadcastable_mean, self._broadcastable_std = broadcastable_mean_std(x, self.mean, self.std)
 
-        x_norm = x - mean
-        x_norm = x_norm / std
+        x_norm = x - self._broadcastable_mean
+        x_norm = x_norm / self._broadcastable_std
         x_norm = x_norm.astype(ART_NUMPY_DTYPE)
 
         return x_norm, y
 
     def estimate_gradient(self, x: np.ndarray, gradient: np.ndarray) -> np.ndarray:
+        """
+        Provide an estimate of the gradients of preprocessor for the backward pass. If the preprocessor is not
+        differentiable, this is an estimate of the gradient, most often replacing the computation performed by the
+        preprocessor with the identity function (the default).
 
-        std = np.asarray(self.std, dtype=ART_NUMPY_DTYPE)
+        :param x: Input data for which the gradient is estimated. First dimension is the batch size.
+        :param grad: Gradient value so far.
+        :return: The gradient (estimate) of the defence.
+        """
+        _, std = broadcastable_mean_std(x, self.mean, self.std)
         gradient_back = gradient / std
 
         return gradient_back

--- a/art/preprocessing/standardisation_mean_std/numpy.py
+++ b/art/preprocessing/standardisation_mean_std/numpy.py
@@ -63,7 +63,7 @@ class StandardisationMeanStd(Preprocessor):
         """
         Apply StandardisationMeanStd inputs `x`.
 
-        :param x: Input samples to standardise of shapes `NCHW`, `NHWC`, `NCFHW` or `NFHWC`.
+        :param x: Input samples to standardise.
         :param y: Label data, will not be affected by this preprocessing.
         :return: Standardise input samples and unmodified labels.
         """

--- a/art/preprocessing/standardisation_mean_std/pytorch.py
+++ b/art/preprocessing/standardisation_mean_std/pytorch.py
@@ -78,7 +78,7 @@ class StandardisationMeanStdPyTorch(PreprocessorPyTorch):
         """
         Apply standardisation with mean and standard deviation to input `x`.
 
-        :param x: Input samples to standardise of shapes `NCHW`, `NHWC`, `NCFHW` or `NFHWC`.
+        :param x: Input samples to standardise.
         :param y: Label data, will not be affected by this preprocessing.
         :return: Standardised input samples and unmodified labels.
         """

--- a/art/preprocessing/standardisation_mean_std/tensorflow.py
+++ b/art/preprocessing/standardisation_mean_std/tensorflow.py
@@ -66,7 +66,7 @@ class StandardisationMeanStdTensorFlow(PreprocessorTensorFlowV2):
         """
         Apply standardisation with mean and standard deviation to input `x`.
 
-        :param x: Input samples to standardise of shapes `NCHW`, `NHWC`, `NCFHW` or `NFHWC`.
+        :param x: Input samples to standardise.
         :param y: Label data, will not be affected by this preprocessing.
         :return: Standardised input samples and unmodified labels.
         """

--- a/art/preprocessing/standardisation_mean_std/utils.py
+++ b/art/preprocessing/standardisation_mean_std/utils.py
@@ -1,0 +1,48 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2021
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+This module implements utilities for standardisation with mean and standard deviation.
+"""
+
+from typing import Tuple
+
+import numpy as np
+
+
+def broadcastable_mean_std(x: np.ndarray, mean: np.ndarray, std: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Ensure that the mean and standard deviation are broadcastable with respect to input `x`.
+
+    :param x: Input samples to standardise of shapes `NCHW`, `NHWC`, `NCFHW` or `NFHWC`.
+    :param mean: Mean.
+    :param std: Standard Deviation.
+    """
+    if mean.shape != std.shape:
+        raise ValueError("The shape of mean and the standard deviation must be identical.")
+
+    # catch non-broadcastable input, when mean and std are vectors
+    if mean.ndim == 1 and mean.shape[0] > 1 and mean.shape[0] != x.shape[-1]:
+        # allow input shapes NC* (batch) and C* (non-batch)
+        channel_idx = 1 if x.shape[1] == mean.shape[0] else 0
+        broadcastable_shape = [1] * x.ndim
+        broadcastable_shape[channel_idx] = mean.shape[0]
+
+        # expand mean and std to new shape
+        mean = mean.reshape(broadcastable_shape)
+        std = std.reshape(broadcastable_shape)
+    return mean, std

--- a/art/preprocessing/standardisation_mean_std/utils.py
+++ b/art/preprocessing/standardisation_mean_std/utils.py
@@ -28,7 +28,7 @@ def broadcastable_mean_std(x: np.ndarray, mean: np.ndarray, std: np.ndarray) -> 
     """
     Ensure that the mean and standard deviation are broadcastable with respect to input `x`.
 
-    :param x: Input samples to standardise of shapes `NCHW`, `NHWC`, `NCFHW` or `NFHWC`.
+    :param x: Input samples to standardise.
     :param mean: Mean.
     :param std: Standard Deviation.
     """

--- a/conftest.py
+++ b/conftest.py
@@ -421,7 +421,7 @@ def get_image_classifier_mx_instance(get_image_classifier_mx_model, mnist_shape)
             clip_values=(0, 1),
             preprocessing_defences=None,
             postprocessing_defences=None,
-            preprocessing=(0, 1),
+            preprocessing=(0.0, 1.0),
         )
 
         return mxc

--- a/examples/get_started_mxnet.py
+++ b/examples/get_started_mxnet.py
@@ -49,7 +49,7 @@ classifier = MXClassifier(
     ctx=None,
     channels_first=True,
     preprocessing_defences=None,
-    preprocessing=(0, 1),
+    preprocessing=(0.0, 1.0),
 )
 
 # Step 4: Train the ART classifier

--- a/tests/defences/preprocessor/conftest.py
+++ b/tests/defences/preprocessor/conftest.py
@@ -1,3 +1,20 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 import numpy as np
 import pytest
 

--- a/tests/estimators/classification/test_blackbox.py
+++ b/tests/estimators/classification/test_blackbox.py
@@ -90,7 +90,9 @@ class TestBlackBoxClassifier(TestBase):
         self.assertIn("BlackBoxClassifier", repr_)
         self.assertIn("clip_values=[  0. 255.]", repr_)
         self.assertIn("defences=None", repr_)
-        self.assertIn("preprocessing=StandardisationMeanStd(mean=0, std=1, apply_fit=True, apply_predict=True)", repr_)
+        self.assertIn(
+            "preprocessing=StandardisationMeanStd(mean=0.0, std=1.0, apply_fit=True, apply_predict=True)", repr_
+        )
 
 
 if __name__ == "__main__":

--- a/tests/estimators/classification/test_classifier.py
+++ b/tests/estimators/classification/test_classifier.py
@@ -122,7 +122,9 @@ class TestClassifier(TestBase):
         self.assertIn("ClassifierInstance", repr_)
         self.assertIn("clip_values=None", repr_)
         self.assertIn("defences=None", repr_)
-        self.assertIn("preprocessing=StandardisationMeanStd(mean=0, std=1, apply_fit=True, apply_predict=True)", repr_)
+        self.assertIn(
+            "preprocessing=StandardisationMeanStd(mean=0.0, std=1.0, apply_fit=True, apply_predict=True)", repr_
+        )
 
 
 class TestClassifierNeuralNetwork(TestBase):
@@ -149,7 +151,9 @@ class TestClassifierNeuralNetwork(TestBase):
         self.assertIn(f"channels_first=True", repr_)
         self.assertIn("clip_values=[0. 1.]", repr_)
         self.assertIn("defences=None", repr_)
-        self.assertIn("preprocessing=StandardisationMeanStd(mean=0, std=1, apply_fit=True, apply_predict=True)", repr_)
+        self.assertIn(
+            "preprocessing=StandardisationMeanStd(mean=0.0, std=1.0, apply_fit=True, apply_predict=True)", repr_
+        )
 
 
 if __name__ == "__main__":

--- a/tests/estimators/classification/test_deeplearning_common.json
+++ b/tests/estimators/classification/test_deeplearning_common.json
@@ -392,7 +392,7 @@
         "train_step=<function get_image_classifier_tf_v2.<locals>.train_step",
         "channels_first=False, ",
         "clip_values=array([0., 1.], dtype=float32), ",
-        "preprocessing_defences=None, postprocessing_defences=None, preprocessing=StandardisationMeanStdTensorFlow(mean=0, std=1, apply_fit=True, apply_predict=True)"
+        "preprocessing_defences=None, postprocessing_defences=None, preprocessing=StandardisationMeanStdTensorFlow(mean=0.0, std=1.0, apply_fit=True, apply_predict=True)"
     ],
     "test_repr_tensorflow1": [
         "TensorFlowClassifier",
@@ -406,7 +406,7 @@
         "channels_first=False",
         "clip_values=array([0., 1.], dtype=float32)",
         "preprocessing_defences=None, postprocessing_defences=None",
-        "preprocessing=StandardisationMeanStd(mean=0, std=1, apply_fit=True, apply_predict=True)"
+        "preprocessing=StandardisationMeanStd(mean=0.0, std=1.0, apply_fit=True, apply_predict=True)"
     ],
     "test_repr_pytorch": [
         "art.estimators.classification.pytorch.PyTorchClassifier",
@@ -416,7 +416,7 @@
         "loss=CrossEntropyLoss(), optimizer=Adam",
         "input_shape=(1, 28, 28), nb_classes=10",
         "clip_values=array([0., 1.], dtype=float32",
-        "preprocessing_defences=None, postprocessing_defences=None, preprocessing=StandardisationMeanStdPyTorch(mean=0, std=1, apply_fit=True, apply_predict=True, device=cpu)"
+        "preprocessing_defences=None, postprocessing_defences=None, preprocessing=StandardisationMeanStdPyTorch(mean=0.0, std=1.0, apply_fit=True, apply_predict=True, device=cpu)"
     ],
     "test_repr_keras": [
         "art.estimators.classification.keras.KerasClassifier",
@@ -424,7 +424,7 @@
         "channels_first=False",
         "clip_values=array([0., 1.], dtype=float32)",
         "preprocessing_defences=None",
-        "preprocessing=StandardisationMeanStd(mean=0, std=1, apply_fit=True, apply_predict=True)",
+        "preprocessing=StandardisationMeanStd(mean=0.0, std=1.0, apply_fit=True, apply_predict=True)",
         "input_layer=0, output_layer=0"
     ],
     "test_repr_kerastf": [
@@ -433,14 +433,14 @@
         "channels_first=False",
         "clip_values=array([0., 1.], dtype=float32)",
         "preprocessing_defences=None",
-        "preprocessing=StandardisationMeanStd(mean=0, std=1, apply_fit=True, apply_predict=True)",
+        "preprocessing=StandardisationMeanStd(mean=0.0, std=1.0, apply_fit=True, apply_predict=True)",
         "input_layer=0, output_layer=0"
     ],
     "test_repr_mxnet": [
         "art.estimators.classification.mxnet.MXClassifier",
         "input_shape=(1, 28, 28), nb_classes=10",
         "channels_first=True, clip_values=array([0., 1.], dtype=float32)",
-        "defences=None, preprocessing=StandardisationMeanStd(mean=0, std=1, apply_fit=True, apply_predict=True)"
+        "defences=None, preprocessing=StandardisationMeanStd(mean=0.0, std=1.0, apply_fit=True, apply_predict=True)"
     ],
     "test_predict_mxnet": [
         [

--- a/tests/estimators/classification/test_detector_classifier.py
+++ b/tests/estimators/classification/test_detector_classifier.py
@@ -167,7 +167,9 @@ class TestDetectorClassifier(TestBase):
     def test_repr(self):
         repr_ = repr(self.detector_classifier)
         self.assertIn("art.estimators.classification.detector_classifier.DetectorClassifier", repr_)
-        self.assertIn("preprocessing=StandardisationMeanStd(mean=0, std=1, apply_fit=True, apply_predict=True)", repr_)
+        self.assertIn(
+            "preprocessing=StandardisationMeanStd(mean=0.0, std=1.0, apply_fit=True, apply_predict=True)", repr_
+        )
 
 
 if __name__ == "__main__":

--- a/tests/estimators/classification/test_ensemble.py
+++ b/tests/estimators/classification/test_ensemble.py
@@ -254,8 +254,8 @@ class TestEnsembleClassifier(TestBase):
         self.assertIn("classifier_weights=array([0.5, 0.5])", repr_)
         self.assertIn(
             f"channels_first=False, clip_values=array([0., 1.], dtype=float32), "
-            "preprocessing_defences=None, postprocessing_defences=None, preprocessing=StandardisationMeanStd(mean=0, "
-            "std=1, apply_fit=True, apply_predict=True)",
+            "preprocessing_defences=None, postprocessing_defences=None, preprocessing=StandardisationMeanStd(mean=0.0, "
+            "std=1.0, apply_fit=True, apply_predict=True)",
             repr_,
         )
 

--- a/tests/preprocessing/test_standardisation_mean_std.py
+++ b/tests/preprocessing/test_standardisation_mean_std.py
@@ -27,46 +27,67 @@ from art.preprocessing.standardisation_mean_std import (
     StandardisationMeanStdPyTorch,
     StandardisationMeanStdTensorFlow,
 )
-
+from art.preprocessing.standardisation_mean_std.utils import broadcastable_mean_std
 from tests.utils import ARTTestException
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(params=[True, False], ids=["channels_first", "channels_last"])
+def image_batch(request):
+    """
+    Create image fixture of shape NFHWC and NCFHW.
+    """
+    channels_first = request.param
+    test_input = np.ones((2, 3, 32, 32))
+    if not channels_first:
+        test_input = np.transpose(test_input, (0, 2, 3, 1))
+    test_mean = [0] * 3
+    test_std = [1] * 3
+    test_output = test_input.copy()
+    return test_input, test_output, test_mean, test_std
+
+
 @pytest.mark.framework_agnostic
-def test_standardisation_mean_std(art_warning):
+def test_broadcastable_mean_std(art_warning):
     try:
-        x = np.ones(shape=(32, 32, 3)) * 5
-        mean = 2.5
-        std = 1.5
+        mean, std = broadcastable_mean_std(np.ones((1, 3, 20, 20)), np.ones(3), np.ones(3))
+        assert mean.shape == std.shape == (1, 3, 1, 1)
+    except ARTTestException as e:
+        art_warning(e)
+
+
+@pytest.mark.framework_agnostic
+def test_standardisation_mean_std(art_warning, image_batch):
+    try:
+        x, x_expected, mean, std = image_batch
         standard = StandardisationMeanStd(mean=mean, std=std)
+
         x_preprocessed, _ = standard(x=x, y=None)
-        np.testing.assert_array_equal(x_preprocessed, np.ones_like(x_preprocessed) * (5 - mean) / std)
+        np.testing.assert_array_equal(x_preprocessed, x_expected)
     except ARTTestException as e:
         art_warning(e)
 
 
 @pytest.mark.only_with_platform("pytorch")
-def test_standardisation_mean_std_pytorch(art_warning):
+def test_standardisation_mean_std_pytorch(art_warning, image_batch):
     try:
-        x = np.ones(shape=(32, 32, 3)) * 5
-        mean = 2.5
-        std = 1.5
+        x, x_expected, mean, std = image_batch
         standard = StandardisationMeanStdPyTorch(mean=mean, std=std)
+
         x_preprocessed, _ = standard(x=x, y=None)
-        np.testing.assert_array_equal(x_preprocessed, np.ones_like(x_preprocessed) * (5 - mean) / std)
+        np.testing.assert_array_equal(x_preprocessed, x_expected)
     except ARTTestException as e:
         art_warning(e)
 
 
 @pytest.mark.only_with_platform("tensorflow2")
-def test_standardisation_mean_std_tensorflow_v2(art_warning):
+def test_standardisation_mean_std_tensorflow_v2(art_warning, image_batch):
     try:
-        x = np.ones(shape=(32, 32, 3)) * 5
-        mean = 2.5
-        std = 1.5
+        x, x_expected, mean, std = image_batch
         standard = StandardisationMeanStdTensorFlow(mean=mean, std=std)
+
         x_preprocessed, _ = standard(x=x, y=None)
-        np.testing.assert_array_equal(x_preprocessed, np.ones_like(x_preprocessed) * (5 - mean) / std)
+        np.testing.assert_array_equal(x_preprocessed, x_expected)
     except ARTTestException as e:
         art_warning(e)


### PR DESCRIPTION
# Description

This PR adds functionality that aims to catch situations where the mean and standard deviation are not broadcastable w.r.t. to the input batch. It then reshapes the mean and standard deviation such that addition and division operations in the standardization preprocessors work properly.

Fixes #268, #569

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)

# Testing


**Test Configuration**:
- Fedora 33
- Python 3.8.7
- ART 1.6.0 development

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
