### PR TITLE
Fixing search_space initialization on JSMA

### DIFF
--- a/art/attacks/evasion/saliency_map.py
+++ b/art/attacks/evasion/saliency_map.py
@@ -119,7 +119,6 @@ class SaliencyMapMethod(EvasionAttack):
             else:
                 search_space = np.ones(batch.shape)
 
-
             # Get current predictions
             current_pred = preds[batch_index_1:batch_index_2]
             target = targets[batch_index_1:batch_index_2]

--- a/art/attacks/evasion/saliency_map.py
+++ b/art/attacks/evasion/saliency_map.py
@@ -109,8 +109,9 @@ class SaliencyMapMethod(EvasionAttack):
 
             # Main algorithm for each batch
             # Initialize the search space; optimize to remove features that can't be changed
-            search_space = np.zeros(batch.shape)
+            search_space = np.ones(batch.shape)
             if self.estimator.clip_values is not None:
+                search_space = np.zeros(batch.shape)
                 clip_min, clip_max = self.estimator.clip_values
                 if self.theta > 0:
                     search_space[batch < clip_max] = 1

--- a/art/attacks/evasion/saliency_map.py
+++ b/art/attacks/evasion/saliency_map.py
@@ -109,7 +109,6 @@ class SaliencyMapMethod(EvasionAttack):
 
             # Main algorithm for each batch
             # Initialize the search space; optimize to remove features that can't be changed
-            search_space = np.ones(batch.shape)
             if self.estimator.clip_values is not None:
                 search_space = np.zeros(batch.shape)
                 clip_min, clip_max = self.estimator.clip_values
@@ -117,6 +116,9 @@ class SaliencyMapMethod(EvasionAttack):
                     search_space[batch < clip_max] = 1
                 else:
                     search_space[batch > clip_min] = 1
+            else:
+                search_space = np.ones(batch.shape)
+
 
             # Get current predictions
             current_pred = preds[batch_index_1:batch_index_2]


### PR DESCRIPTION
# Description
   ####
Changing the initialization of `search_space` in JSMA to prevent it from stopping after only one iteration when `clip_value` is not set.

Fixes #841 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Generating adversarial examples on the intrusion detection dataset NSL-KDD.
- [x] Generating adversarial examples on the intrusion detection dataset CIDDS-001.

**Test Configuration**:
- Fedora 31 (Linux 5.3.7-301.fc31.x86_64)
- Python version 3.7.9
- ART dev_1.6.0
- PyTorch version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
