### PR TITLE
Add passing of kwargs in AutoAttack.generate

### DIFF
--- a/art/attacks/evasion/auto_attack.py
+++ b/art/attacks/evasion/auto_attack.py
@@ -157,8 +157,6 @@ class AutoAttack(EvasionAttack):
         :type mask: `np.ndarray`
         :return: An array holding the adversarial examples.
         """
-        mask = kwargs.get("mask")
-
         x_adv = x.astype(ART_NUMPY_DTYPE)
         y = check_and_transform_label_format(y, self.estimator.nb_classes)
 
@@ -180,7 +178,7 @@ class AutoAttack(EvasionAttack):
                 attack.set_params(targeted=False)
 
             x_adv, sample_is_robust = self._run_attack(
-                x=x_adv, y=y, mask=mask, sample_is_robust=sample_is_robust, attack=attack
+                x=x_adv, y=y, sample_is_robust=sample_is_robust, attack=attack, **kwargs,
             )
 
         # Targeted attacks
@@ -207,22 +205,19 @@ class AutoAttack(EvasionAttack):
                         target = check_and_transform_label_format(targeted_labels[:, i], self.estimator.nb_classes)
 
                         x_adv, sample_is_robust = self._run_attack(
-                            x=x_adv, y=target, mask=mask, sample_is_robust=sample_is_robust, attack=attack
+                            x=x_adv, y=target, sample_is_robust=sample_is_robust, attack=attack, **kwargs,
                         )
 
         return x_adv
 
     def _run_attack(
-        self, x: np.ndarray, y: np.ndarray, mask: np.ndarray, sample_is_robust: np.ndarray, attack: EvasionAttack,
+        self, x: np.ndarray, y: np.ndarray, sample_is_robust: np.ndarray, attack: EvasionAttack, **kwargs,
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Run attack.
 
         :param x: An array of the original inputs.
         :param y: An array of the labels.
-        :param mask: An array with a mask broadcastable to input `x` defining where to apply adversarial perturbations.
-                     Shape needs to be broadcastable to the shape of x and can also be of the same shape as `x`. Any
-                     features for which the mask is zero will not be adversarially perturbed.
         :param sample_is_robust: Store the initial robustness of examples.
         :param attack: Evasion attack to run.
         :return: An array holding the adversarial examples.
@@ -232,7 +227,7 @@ class AutoAttack(EvasionAttack):
         y_robust = y[sample_is_robust]
 
         # Generate adversarial examples
-        x_robust_adv = attack.generate(x=x_robust, y=y_robust, mask=mask)
+        x_robust_adv = attack.generate(x=x_robust, y=y_robust, **kwargs)
         y_pred_robust_adv = self.estimator_orig.predict(x_robust_adv)
 
         # Check and update successful examples


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request changes `AutoAttack.generate` to pass `kwargs` to calls to `generate` of its internal attacks.

Fixes #835

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
