### PR TITLE
Add numba as dependency and apply in BrendelBethgeAttack

### DIFF
--- a/art/attacks/evasion/brendel_bethge.py
+++ b/art/attacks/evasion/brendel_bethge.py
@@ -40,9 +40,10 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from typing import Union, Optional, Tuple, TYPE_CHECKING
+import logging
 
 import numpy as np
-import logging
+from numba.experimental import jitclass
 
 from art import config
 from art.utils import get_labels_np_array, check_and_transform_label_format, is_probability
@@ -58,6 +59,7 @@ EPS = 1e-10
 logger = logging.getLogger(__name__)
 
 
+@jitclass(spec=[])
 class BFGSB(object):
     def __init__(self):
         pass
@@ -839,6 +841,10 @@ class Optimizer(object):
         return _delta
 
 
+spec = [("bfgsb", BFGSB.class_type.instance_type)]  # type: ignore
+
+
+@jitclass(spec=spec)
 class L2Optimizer(Optimizer):
     def optimize_distance_s_t_boundary_and_trustregion(self, x0, x, b, min_, max_, c, r):  # noqa: C901
         """
@@ -1029,6 +1035,7 @@ class L2Optimizer(Optimizer):
         return np.linalg.norm(x0 - x) ** 2
 
 
+@jitclass(spec=spec)
 class L1Optimizer(Optimizer):
     def fun_and_jac(self, params, x0, x, b, min_, max_, c, r):
         lam, mu = params
@@ -1172,6 +1179,7 @@ class L1Optimizer(Optimizer):
         return np.abs(x0 - x).sum()
 
 
+@jitclass(spec=spec)
 class LinfOptimizer(Optimizer):
     def optimize_distance_s_t_boundary_and_trustregion(self, x0, x, b, min_, max_, c, r):
         """
@@ -1356,6 +1364,7 @@ class LinfOptimizer(Optimizer):
         return np.abs(x0 - x).max()
 
 
+@jitclass(spec=spec)
 class L0Optimizer(Optimizer):
     def optimize_distance_s_t_boundary_and_trustregion(self, x0, x, b, min_, max_, c, r):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ resampy==0.2.2
 ffmpeg-python==0.2.0
 cma==3.0.3
 pandas==1.1.4
+numba~=0.52.0
 
 # frameworks
 h5py==2.10.0

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ install_requires = [
     "ffmpeg-python",
     "cma",
     "mypy",
+    "numba~=0.52.0"
 ]
 
 docs_require = [


### PR DESCRIPTION
# Description

This pull request add `numba` as dependency of ART and applies it to `BrendelBethgeAttack` following its reference implementation.

Fixes #819

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
