### PR TITLE
Remove deprecated channel_index argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
           pip install tensorflow==${{ matrix.tensorflow }}
           pip install lingvo==${{ matrix.lingvo }}
           pip install tensorflow-addons==0.9.1
+          pip install model-pruning-google-research==0.0.3
           pip list
       - name: Run ${{ matrix.name }} Tests
         run: ./run_tests.sh ${{ matrix.framework }}

--- a/art/attacks/evasion/dpatch.py
+++ b/art/attacks/evasion/dpatch.py
@@ -31,7 +31,6 @@ from tqdm.auto import trange
 from art.attacks.attack import EvasionAttack
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin
 from art.estimators.object_detection.object_detector import ObjectDetectorMixin
-from art.utils import Deprecated, deprecated_keyword_arg
 from art import config
 
 if TYPE_CHECKING:
@@ -225,13 +224,11 @@ class DPatch(EvasionAttack):
         return self._patch
 
     @staticmethod
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def _augment_images_with_patch(
         x: np.ndarray,
         patch: np.ndarray,
         random_location: bool,
         channels_first: bool,
-        channel_index=Deprecated,
         mask: Optional[np.ndarray] = None,
     ) -> Tuple[np.ndarray, List[Dict[str, int]]]:
         """
@@ -242,21 +239,11 @@ class DPatch(EvasionAttack):
         :param random_location: If True apply patch at randomly shifted locations, otherwise place patch at origin
                                 (top-left corner).
         :param channels_first: Set channels first or last.
-        :param channel_index: Index of the color channel.
-        :type channel_index: `int`
         :param mask: An boolean array of shape equal to the shape of a single samples (1, H, W) or the shape of `x`
                      (N, H, W) without their channel dimensions. Any features for which the mask is True can be the
                      center location of the patch during sampling.
         :type mask: `np.ndarray`
         """
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         transformations = list()
         x_copy = x.copy()
         patch_copy = patch.copy()

--- a/art/defences/detector/evasion/detector.py
+++ b/art/defences/detector/evasion/detector.py
@@ -28,7 +28,6 @@ import numpy as np
 
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin, LossGradientsMixin
 from art.estimators.classification.classifier import ClassifierMixin, ClassGradientsMixin
-from art.utils import deprecated
 
 if TYPE_CHECKING:
     from art.utils import CLIP_VALUES_TYPE
@@ -53,7 +52,6 @@ class BinaryInputDetector(ClassGradientsMixin, ClassifierMixin, LossGradientsMix
         super().__init__(
             model=None,
             clip_values=detector.clip_values,
-            channel_index=detector.channel_index,
             channels_first=detector.channels_first,
             preprocessing_defences=detector.preprocessing_defences,
             preprocessing=detector.preprocessing,
@@ -117,11 +115,6 @@ class BinaryInputDetector(ClassGradientsMixin, ClassifierMixin, LossGradientsMix
     def clip_values(self) -> Optional["CLIP_VALUES_TYPE"]:
         return self.detector.clip_values
 
-    @property  # type: ignore
-    @deprecated(end_version="1.6.0", replaced_by="channels_first")
-    def channel_index(self) -> Optional[int]:
-        return self.detector.channel_index
-
     @property
     def channels_first(self) -> Optional[bool]:
         """
@@ -180,7 +173,6 @@ class BinaryActivationDetector(
         super().__init__(
             model=None,
             clip_values=detector.clip_values,
-            channel_index=detector.channel_index,
             channels_first=detector.channels_first,
             preprocessing_defences=detector.preprocessing_defences,
             preprocessing=detector.preprocessing,
@@ -260,11 +252,6 @@ class BinaryActivationDetector(
     @property
     def clip_values(self) -> Optional["CLIP_VALUES_TYPE"]:
         return self.detector.clip_values
-
-    @property  # type: ignore
-    @deprecated(end_version="1.6.0", replaced_by="channels_first")
-    def channel_index(self) -> Optional[int]:
-        return self.detector.channel_index
 
     @property
     def channels_first(self) -> Optional[bool]:

--- a/art/defences/detector/evasion/subsetscanning/detector.py
+++ b/art/defences/detector/evasion/subsetscanning/detector.py
@@ -31,7 +31,6 @@ from tqdm.auto import trange, tqdm
 
 from art.defences.detector.evasion.subsetscanning.scanner import Scanner
 from art.estimators.classification.classifier import ClassifierNeuralNetwork
-from art.utils import deprecated
 
 
 if TYPE_CHECKING:
@@ -62,7 +61,6 @@ class SubsetScanningDetector(ClassifierNeuralNetwork):
         super().__init__(
             model=None,
             clip_values=classifier.clip_values,
-            channel_index=classifier.channel_index,
             channels_first=classifier.channels_first,
             preprocessing_defences=classifier.preprocessing_defences,
             preprocessing=classifier.preprocessing,
@@ -237,11 +235,6 @@ class SubsetScanningDetector(ClassifierNeuralNetwork):
     @property
     def clip_values(self) -> Optional["CLIP_VALUES_TYPE"]:
         return self.detector.clip_values
-
-    @property  # type: ignore
-    @deprecated(end_version="1.6.0", replaced_by="channels_first")
-    def channel_index(self) -> Optional[int]:
-        return self.detector.channel_index
 
     @property
     def channels_first(self) -> bool:

--- a/art/defences/preprocessor/jpeg_compression.py
+++ b/art/defences/preprocessor/jpeg_compression.py
@@ -35,7 +35,6 @@ from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.defences.preprocessor.preprocessor import Preprocessor
-from art.utils import Deprecated, deprecated_keyword_arg
 
 if TYPE_CHECKING:
     from art.utils import CLIP_VALUES_TYPE
@@ -59,14 +58,12 @@ class JpegCompression(Preprocessor):
         https://arxiv.org/abs/1902.06705
     """
 
-    params = ["quality", "channel_index", "channels_first", "clip_values", "verbose"]
+    params = ["quality", "channels_first", "clip_values", "verbose"]
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         clip_values: "CLIP_VALUES_TYPE",
         quality: int = 50,
-        channel_index=Deprecated,
         channels_first: bool = False,
         apply_fit: bool = True,
         apply_predict: bool = True,
@@ -78,24 +75,14 @@ class JpegCompression(Preprocessor):
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :param quality: The image quality, on a scale from 1 (worst) to 95 (best). Values above 95 should be avoided.
-        :param channel_index: Index of the axis in data containing the color channels or features.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param apply_fit: True if applied during fitting/training.
         :param apply_predict: True if applied during predicting.
         :param verbose: Show progress bars.
         """
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
 
         super().__init__(is_fitted=True, apply_fit=apply_fit, apply_predict=apply_predict)
         self.quality = quality
-        self.channel_index = channel_index
         self.channels_first = channels_first
         self.clip_values = clip_values
         self.verbose = verbose

--- a/art/defences/preprocessor/mp3_compression.py
+++ b/art/defences/preprocessor/mp3_compression.py
@@ -33,7 +33,6 @@ import numpy as np
 from tqdm.auto import tqdm
 
 from art.defences.preprocessor.preprocessor import Preprocessor
-from art.utils import Deprecated, deprecated_keyword_arg
 
 logger = logging.getLogger(__name__)
 
@@ -43,13 +42,11 @@ class Mp3Compression(Preprocessor):
     Implement the MP3 compression defense approach.
     """
 
-    params = ["channel_index", "channels_first", "sample_rate", "verbose"]
+    params = ["channels_first", "sample_rate", "verbose"]
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         sample_rate: int,
-        channel_index=Deprecated,
         channels_first: bool = False,
         apply_fit: bool = False,
         apply_predict: bool = True,
@@ -59,23 +56,12 @@ class Mp3Compression(Preprocessor):
         Create an instance of MP3 compression.
 
         :param sample_rate: Specifies the sampling rate of sample.
-        :param channel_index: Index of the axis containing the audio channels.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param apply_fit: True if applied during fitting/training.
         :param apply_predict: True if applied during predicting.
         :param verbose: Show progress bars.
         """
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         super().__init__(is_fitted=True, apply_fit=apply_fit, apply_predict=apply_predict)
-        self.channel_index = channel_index
         self.channels_first = channels_first
         self.sample_rate = sample_rate
         self.verbose = verbose

--- a/art/defences/preprocessor/resample.py
+++ b/art/defences/preprocessor/resample.py
@@ -29,7 +29,6 @@ from typing import Optional, Tuple
 import numpy as np
 
 from art.defences.preprocessor.preprocessor import Preprocessor
-from art.utils import Deprecated, deprecated_keyword_arg
 
 logger = logging.getLogger(__name__)
 
@@ -42,14 +41,12 @@ class Resample(Preprocessor):
     implementation is a Windowed Sinc Interpolation function.
     """
 
-    params = ["sr_original", "sr_new", "channel_index", "channels_first"]
+    params = ["sr_original", "sr_new", "channels_first"]
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         sr_original: int,
         sr_new: int,
-        channel_index=Deprecated,
         channels_first: bool = False,
         apply_fit: bool = False,
         apply_predict: bool = True,
@@ -59,24 +56,13 @@ class Resample(Preprocessor):
 
         :param sr_original: Original sampling rate of sample.
         :param sr_new: New sampling rate of sample.
-        :param channel_index: Index of the axis containing the audio channels.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param apply_fit: True if applied during fitting/training.
         :param apply_predict: True if applied during predicting.
         """
-        # Remove in 1.6.0
-        if channel_index == 2:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         super().__init__(is_fitted=True, apply_fit=apply_fit, apply_predict=apply_predict)
         self.sr_original = sr_original
         self.sr_new = sr_new
-        self.channel_index = channel_index
         self.channels_first = channels_first
         self._check_params()
 

--- a/art/defences/preprocessor/spatial_smoothing.py
+++ b/art/defences/preprocessor/spatial_smoothing.py
@@ -34,7 +34,6 @@ from scipy.ndimage.filters import median_filter
 
 from art.utils import CLIP_VALUES_TYPE
 from art.defences.preprocessor.preprocessor import Preprocessor
-from art.utils import Deprecated, deprecated_keyword_arg
 
 logger = logging.getLogger(__name__)
 
@@ -50,13 +49,11 @@ class SpatialSmoothing(Preprocessor):
         https://arxiv.org/abs/1902.06705
     """
 
-    params = ["window_size", "channel_index", "channels_first", "clip_values"]
+    params = ["window_size", "channels_first", "clip_values"]
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         window_size: int = 3,
-        channel_index=Deprecated,
         channels_first: bool = False,
         clip_values: Optional[CLIP_VALUES_TYPE] = None,
         apply_fit: bool = False,
@@ -65,8 +62,6 @@ class SpatialSmoothing(Preprocessor):
         """
         Create an instance of local spatial smoothing.
 
-        :param channel_index: Index of the axis in data containing the color channels or features.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param window_size: The size of the sliding window.
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
@@ -74,17 +69,8 @@ class SpatialSmoothing(Preprocessor):
         :param apply_fit: True if applied during fitting/training.
         :param apply_predict: True if applied during predicting.
         """
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         super().__init__(is_fitted=True, apply_fit=apply_fit, apply_predict=apply_predict)
 
-        self.channel_index = channel_index
         self.channels_first = channels_first
         self.window_size = window_size
         self.clip_values = clip_values

--- a/art/defences/preprocessor/thermometer_encoding.py
+++ b/art/defences/preprocessor/thermometer_encoding.py
@@ -33,7 +33,7 @@ import numpy as np
 
 from art.config import ART_NUMPY_DTYPE
 from art.defences.preprocessor.preprocessor import Preprocessor
-from art.utils import Deprecated, deprecated_keyword_arg, to_categorical
+from art.utils import to_categorical
 
 if TYPE_CHECKING:
     from art.utils import CLIP_VALUES_TYPE
@@ -52,14 +52,12 @@ class ThermometerEncoding(Preprocessor):
         https://arxiv.org/abs/1902.06705
     """
 
-    params = ["clip_values", "num_space", "channel_index", "channels_first"]
+    params = ["clip_values", "num_space", "channels_first"]
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         clip_values: "CLIP_VALUES_TYPE",
         num_space: int = 10,
-        channel_index=Deprecated,
         channels_first: bool = False,
         apply_fit: bool = True,
         apply_predict: bool = True,
@@ -70,24 +68,13 @@ class ThermometerEncoding(Preprocessor):
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :param num_space: Number of evenly spaced levels within the interval of minimum and maximum clip values.
-        :param channel_index: Index of the axis in data containing the color channels or features.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param apply_fit: True if applied during fitting/training.
         :param apply_predict: True if applied during predicting.
         """
-        # Remove in 1.6.0
-        if channel_index == 2:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         super().__init__(is_fitted=True, apply_fit=apply_fit, apply_predict=apply_predict)
         self.clip_values = clip_values
         self.num_space = num_space
-        self.channel_index = channel_index
         self.channels_first = channels_first
         self._check_params()
 

--- a/art/estimators/classification/detector_classifier.py
+++ b/art/estimators/classification/detector_classifier.py
@@ -72,7 +72,6 @@ class DetectorClassifier(ClassifierNeuralNetwork):
             model=None,
             clip_values=classifier.clip_values,
             preprocessing=preprocessing,
-            channel_index=classifier.channel_index,
             channels_first=classifier.channels_first,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,

--- a/art/estimators/classification/ensemble.py
+++ b/art/estimators/classification/ensemble.py
@@ -27,7 +27,6 @@ import numpy as np
 
 from art.estimators.classification.classifier import ClassifierNeuralNetwork
 from art.estimators.estimator import NeuralNetworkMixin
-from art.utils import Deprecated, deprecated_keyword_arg
 
 if TYPE_CHECKING:
     from art.utils import CLIP_VALUES_TYPE, PREPROCESSING_TYPE
@@ -44,12 +43,10 @@ class EnsembleClassifier(ClassifierNeuralNetwork):
     trained when the ensemble is created and no training procedures are provided through this class.
     """
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         classifiers: List[ClassifierNeuralNetwork],
         classifier_weights: Union[list, np.ndarray, None] = None,
-        channel_index=Deprecated,
         channels_first: bool = False,
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
@@ -63,8 +60,6 @@ class EnsembleClassifier(ClassifierNeuralNetwork):
         :param classifiers: List of :class:`.Classifier` instances to be ensembled together.
         :param classifier_weights: List of weights, one scalar per classifier, to assign to their prediction when
                aggregating results. If `None`, all classifiers are assigned the same weight.
-        :param channel_index: Index of the axis in data containing the color channels or features.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
                maximum values allowed for features. If floats are provided, these will be used as the range of all
@@ -80,18 +75,9 @@ class EnsembleClassifier(ClassifierNeuralNetwork):
         if preprocessing_defences is not None:
             raise NotImplementedError("Preprocessing is not applicable in this classifier.")
 
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         super().__init__(
             model=None,
             clip_values=clip_values,
-            channel_index=channel_index,
             channels_first=channels_first,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
@@ -291,13 +277,12 @@ class EnsembleClassifier(ClassifierNeuralNetwork):
 
     def __repr__(self):
         repr_ = (
-            "%s(classifiers=%r, classifier_weights=%r, channel_index=%r, channels_first=%r, clip_values=%r, "
+            "%s(classifiers=%r, classifier_weights=%r, channels_first=%r, clip_values=%r, "
             "preprocessing_defences=%r, postprocessing_defences=%r, preprocessing=%r)"
             % (
                 self.__module__ + "." + self.__class__.__name__,
                 self._classifiers,
                 self._classifier_weights,
-                self.channel_index,
                 self.channels_first,
                 self.clip_values,
                 self.preprocessing_defences,

--- a/art/estimators/classification/keras.py
+++ b/art/estimators/classification/keras.py
@@ -44,7 +44,7 @@ from art.estimators.classification.classifier import (
     ClassifierMixin,
     ClassGradientsMixin,
 )
-from art.utils import Deprecated, deprecated_keyword_arg, check_and_transform_label_format
+from art.utils import check_and_transform_label_format
 
 if TYPE_CHECKING:
     # pylint: disable=C0412
@@ -66,12 +66,10 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
     Wrapper class for importing Keras models.
     """
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         model: KERAS_MODEL_TYPE,
         use_logits: bool = False,
-        channel_index=Deprecated,
         channels_first: bool = False,
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
@@ -86,8 +84,6 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
         :param model: Keras model, neural network or other.
         :param use_logits: True if the output of the model are logits; false for probabilities or any other type of
                outputs. Logits output should be favored when possible to ensure attack efficiency.
-        :param channel_index: Index of the axis in data containing the color channels or features.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
                maximum values allowed for features. If floats are provided, these will be used as the range of all
@@ -105,21 +101,12 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
                              with this index will be considered for computing gradients. For models with only one output
                              layer this values is not required.
         """
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         super().__init__(
             model=model,
             clip_values=clip_values,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
             preprocessing=preprocessing,
-            channel_index=channel_index,
             channels_first=channels_first,
         )
 
@@ -790,13 +777,12 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
 
     def __repr__(self):
         repr_ = (
-            "%s(model=%r, use_logits=%r, channel_index=%r, channels_first=%r, clip_values=%r, preprocessing_defences=%r"
+            "%s(model=%r, use_logits=%r, channels_first=%r, clip_values=%r, preprocessing_defences=%r"
             ", postprocessing_defences=%r, preprocessing=%r, input_layer=%r, output_layer=%r)"
             % (
                 self.__module__ + "." + self.__class__.__name__,
                 self._model,
                 self._use_logits,
-                self.channel_index,
                 self.channels_first,
                 self.clip_values,
                 self.preprocessing_defences,

--- a/art/estimators/classification/mxnet.py
+++ b/art/estimators/classification/mxnet.py
@@ -30,7 +30,7 @@ import six
 from art import config
 from art.estimators.mxnet import MXEstimator
 from art.estimators.classification.classifier import ClassGradientsMixin, ClassifierMixin
-from art.utils import Deprecated, deprecated_keyword_arg, check_and_transform_label_format
+from art.utils import check_and_transform_label_format
 
 if TYPE_CHECKING:
     # pylint: disable=C0412
@@ -49,7 +49,6 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
     Wrapper class for importing MXNet Gluon models.
     """
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         model: "mx.gluon.Block",
@@ -58,7 +57,6 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
         nb_classes: int,
         optimizer: Optional["mx.gluon.Trainer"] = None,
         ctx: Optional["mx.context.Context"] = None,
-        channel_index=Deprecated,
         channels_first: bool = True,
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
@@ -76,8 +74,6 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
         :param optimizer: The optimizer used to train the classifier. This parameter is only required if fitting will
                           be done with method fit.
         :param ctx: The device on which the model runs (CPU or GPU). If not provided, CPU is assumed.
-        :param channel_index: Index of the axis in data containing the color channels or features.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
                maximum values allowed for features. If floats are provided, these will be used as the range of all
@@ -91,18 +87,9 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
         """
         import mxnet as mx  # lgtm [py/repeated-import]
 
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         super().__init__(
             model=model,
             clip_values=clip_values,
-            channel_index=channel_index,
             channels_first=channels_first,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
@@ -496,7 +483,7 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
 
     def __repr__(self):
         repr_ = (
-            "%s(model=%r, loss=%r, input_shape=%r, nb_classes=%r, optimizer=%r, ctx=%r, channel_index=%r,"
+            "%s(model=%r, loss=%r, input_shape=%r, nb_classes=%r, optimizer=%r, ctx=%r, "
             " channels_first=%r, clip_values=%r, preprocessing=%r, postprocessing_defences=%r,"
             " preprocessing=%r)"
             % (
@@ -507,7 +494,6 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
                 self.nb_classes,
                 self._optimizer,
                 self._ctx,
-                self.channel_index,
                 self.channels_first,
                 self.clip_values,
                 self.preprocessing,

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -36,7 +36,7 @@ from art.estimators.classification.classifier import (
     ClassifierMixin,
 )
 from art.estimators.pytorch import PyTorchEstimator
-from art.utils import Deprecated, deprecated_keyword_arg, check_and_transform_label_format
+from art.utils import check_and_transform_label_format
 
 if TYPE_CHECKING:
     # pylint: disable=C0412
@@ -55,7 +55,6 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
     This class implements a classifier with the PyTorch framework.
     """
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         model: "torch.nn.Module",
@@ -66,7 +65,6 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         use_amp: bool = False,
         opt_level: str = "O1",
         loss_scale: Optional[Union[float, str]] = "dynamic",
-        channel_index=Deprecated,
         channels_first: bool = True,
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
@@ -92,8 +90,6 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
                            representing a number, e.g., “1.0”, or the string “dynamic”.
         :param nb_classes: The number of classes of the model.
         :param optimizer: The optimizer used to train the classifier.
-        :param channel_index: Index of the axis in data containing the color channels or features.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
                maximum values allowed for features. If floats are provided, these will be used as the range of all
@@ -108,18 +104,9 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         """
         import torch  # lgtm [py/repeated-import]
 
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         super().__init__(
             model=model,
             clip_values=clip_values,
-            channel_index=channel_index,
             channels_first=channels_first,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
@@ -709,7 +696,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
 
     def __repr__(self):
         repr_ = (
-            "%s(model=%r, loss=%r, optimizer=%r, input_shape=%r, nb_classes=%r, channel_index=%r, channels_first=%r, "
+            "%s(model=%r, loss=%r, optimizer=%r, input_shape=%r, nb_classes=%r, channels_first=%r, "
             "clip_values=%r, preprocessing_defences=%r, postprocessing_defences=%r, preprocessing=%r)"
             % (
                 self.__module__ + "." + self.__class__.__name__,
@@ -718,7 +705,6 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
                 self._optimizer,
                 self._input_shape,
                 self.nb_classes,
-                self.channel_index,
                 self.channels_first,
                 self.clip_values,
                 self.preprocessing_defences,

--- a/art/estimators/classification/tensorflow.py
+++ b/art/estimators/classification/tensorflow.py
@@ -33,7 +33,7 @@ import six
 from art import config
 from art.estimators.classification.classifier import ClassGradientsMixin, ClassifierMixin
 from art.estimators.tensorflow import TensorFlowEstimator, TensorFlowV2Estimator
-from art.utils import Deprecated, deprecated_keyword_arg, check_and_transform_label_format
+from art.utils import check_and_transform_label_format
 
 if TYPE_CHECKING:
     # pylint: disable=C0412
@@ -52,7 +52,6 @@ class TensorFlowClassifier(ClassGradientsMixin, ClassifierMixin, TensorFlowEstim
     This class implements a classifier with the TensorFlow framework.
     """
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         input_ph: "tf.Placeholder",
@@ -62,7 +61,6 @@ class TensorFlowClassifier(ClassGradientsMixin, ClassifierMixin, TensorFlowEstim
         loss: Optional["tf.Tensor"] = None,
         learning: Optional["tf.Placeholder"] = None,
         sess: Optional["tf.Session"] = None,
-        channel_index=Deprecated,
         channels_first: bool = False,
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
@@ -84,8 +82,6 @@ class TensorFlowClassifier(ClassGradientsMixin, ClassifierMixin, TensorFlowEstim
                model and when computing gradients w.r.t. the loss function.
         :param learning: The placeholder to indicate if the model is training.
         :param sess: Computation session.
-        :param channel_index: Index of the axis in data containing the color channels or features.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
                maximum values allowed for features. If floats are provided, these will be used as the range of all
@@ -102,18 +98,9 @@ class TensorFlowClassifier(ClassGradientsMixin, ClassifierMixin, TensorFlowEstim
         # pylint: disable=E0401
         import tensorflow as tf  # lgtm [py/repeated-import]
 
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         super().__init__(
             model=None,
             clip_values=clip_values,
-            channel_index=channel_index,
             channels_first=channels_first,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
@@ -666,7 +653,7 @@ class TensorFlowClassifier(ClassGradientsMixin, ClassifierMixin, TensorFlowEstim
 
     def __repr__(self):
         repr_ = (
-            "%s(input_ph=%r, output=%r, labels_ph=%r, train=%r, loss=%r, learning=%r, sess=%r, channel_index=%r, "
+            "%s(input_ph=%r, output=%r, labels_ph=%r, train=%r, loss=%r, learning=%r, sess=%r, "
             "channels_first=%r, clip_values=%r, preprocessing_defences=%r, postprocessing_defences=%r, "
             "preprocessing=%r)"
             % (
@@ -678,7 +665,6 @@ class TensorFlowClassifier(ClassGradientsMixin, ClassifierMixin, TensorFlowEstim
                 self._loss,
                 self._learning,
                 self._sess,
-                self.channel_index,
                 self.channels_first,
                 self.clip_values,
                 self.preprocessing_defences,
@@ -699,7 +685,6 @@ class TensorFlowV2Classifier(ClassGradientsMixin, ClassifierMixin, TensorFlowV2E
     This class implements a classifier with the TensorFlow v2 framework.
     """
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         model: Callable,
@@ -707,7 +692,6 @@ class TensorFlowV2Classifier(ClassGradientsMixin, ClassifierMixin, TensorFlowV2E
         input_shape: Tuple[int, ...],
         loss_object: Optional["tf.keras.losses.Loss"] = None,
         train_step: Optional[Callable] = None,
-        channel_index=Deprecated,
         channels_first: bool = False,
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
@@ -725,8 +709,6 @@ class TensorFlowV2Classifier(ClassGradientsMixin, ClassifierMixin, TensorFlowV2E
         :type loss_object: `tf.keras.losses`
         :param train_step: A function that applies a gradient update to the trainable variables with signature
                            train_step(model, images, labels).
-        :param channel_index: Index of the axis in data containing the color channels or features.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
                maximum values allowed for features. If floats are provided, these will be used as the range of all
@@ -740,18 +722,9 @@ class TensorFlowV2Classifier(ClassGradientsMixin, ClassifierMixin, TensorFlowV2E
         """
         import tensorflow as tf  # lgtm [py/repeated-import]
 
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         super().__init__(
             model=model,
             clip_values=clip_values,
-            channel_index=channel_index,
             channels_first=channels_first,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
@@ -1164,7 +1137,7 @@ class TensorFlowV2Classifier(ClassGradientsMixin, ClassifierMixin, TensorFlowV2E
 
     def __repr__(self):
         repr_ = (
-            "%s(model=%r, nb_classes=%r, input_shape=%r, loss_object=%r, train_step=%r, channel_index=%r, "
+            "%s(model=%r, nb_classes=%r, input_shape=%r, loss_object=%r, train_step=%r, "
             "channels_first=%r, clip_values=%r, preprocessing_defences=%r, postprocessing_defences=%r, "
             "preprocessing=%r)"
             % (
@@ -1174,7 +1147,6 @@ class TensorFlowV2Classifier(ClassGradientsMixin, ClassifierMixin, TensorFlowV2E
                 self._input_shape,
                 self._loss_object,
                 self._train_step,
-                self.channel_index,
                 self.channels_first,
                 self.clip_values,
                 self.preprocessing_defences,

--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -25,7 +25,6 @@ import numpy as np
 from tqdm.auto import trange
 
 from art.config import ART_NUMPY_DTYPE
-from art.utils import Deprecated, deprecated, deprecated_keyword_arg
 
 if TYPE_CHECKING:
     # pylint: disable=R0401
@@ -340,24 +339,12 @@ class NeuralNetworkMixin(ABC):
     has to be mixed in with class `BaseEstimator`.
     """
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
-    def __init__(self, channels_first: Optional[bool], channel_index=Deprecated, **kwargs) -> None:
+    def __init__(self, channels_first: Optional[bool], **kwargs) -> None:
         """
         Initialize a neural network attributes.
 
-        :param channel_index: Index of the axis in samples `x` representing the color channels.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         """
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
-        self._channel_index = channel_index
         self._channels_first: Optional[bool] = channels_first
         super().__init__(**kwargs)
 
@@ -454,14 +441,6 @@ class NeuralNetworkMixin(ABC):
         :rtype: Format as expected by the `model`
         """
         raise NotImplementedError
-
-    @property  # type: ignore
-    @deprecated(end_version="1.6.0", replaced_by="channels_first")
-    def channel_index(self) -> Optional[int]:
-        """
-        :return: Index of the axis containing the color channels in the samples `x`.
-        """
-        return self._channel_index
 
     @property
     def channels_first(self) -> Optional[bool]:

--- a/art/estimators/object_detection/pytorch_faster_rcnn.py
+++ b/art/estimators/object_detection/pytorch_faster_rcnn.py
@@ -25,7 +25,6 @@ import numpy as np
 
 from art.estimators.object_detection.object_detector import ObjectDetectorMixin
 from art.estimators.pytorch import PyTorchEstimator
-from art.utils import Deprecated, deprecated_keyword_arg
 
 if TYPE_CHECKING:
     # pylint: disable=C0412
@@ -44,12 +43,10 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
     This class implements a model-specific object detector using Faster-RCNN and PyTorch.
     """
 
-    @deprecated_keyword_arg("channel_index", end_version="1.6.0", replaced_by="channels_first")
     def __init__(
         self,
         model: Optional["torchvision.models.detection.fasterrcnn_resnet50_fpn"] = None,
         clip_values: Optional["CLIP_VALUES_TYPE"] = None,
-        channel_index=Deprecated,
         channels_first: Optional[bool] = None,
         preprocessing_defences: Union["Preprocessor", List["Preprocessor"], None] = None,
         postprocessing_defences: Union["Postprocessor", List["Postprocessor"], None] = None,
@@ -71,8 +68,6 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
                maximum values allowed for features. If floats are provided, these will be used as the range of all
                features. If arrays are provided, each value will be considered the bound for a feature, thus
                the shape of clip values needs to match the total number of features.
-        :param channel_index: Index of the axis in data containing the color channels or features.
-        :type channel_index: `int`
         :param channels_first: Set channels first or last.
         :param preprocessing_defences: Preprocessing defence(s) to be applied by the classifier.
         :param postprocessing_defences: Postprocessing defence(s) to be applied by the classifier.
@@ -86,18 +81,9 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
         """
         import torch  # lgtm [py/repeated-import]
 
-        # Remove in 1.6.0
-        if channel_index == 3:
-            channels_first = False
-        elif channel_index == 1:
-            channels_first = True
-        elif channel_index is not Deprecated:
-            raise ValueError("Not a proper channel_index. Use channels_first.")
-
         super().__init__(
             model=model,
             clip_values=clip_values,
-            channel_index=channel_index,
             channels_first=channels_first,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,

--- a/tests/estimators/classification/test_classifier.py
+++ b/tests/estimators/classification/test_classifier.py
@@ -24,7 +24,6 @@ import numpy as np
 
 from art.estimators.classification.classifier import ClassGradientsMixin, ClassifierMixin
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin, NeuralNetworkMixin
-from art.utils import Deprecated
 from tests.utils import TestBase, master_seed
 
 logger = logging.getLogger(__name__)
@@ -143,7 +142,7 @@ class TestClassifierNeuralNetwork(TestBase):
         classifier = ClassifierNeuralNetworkInstance((0, 1))
         repr_ = repr(classifier)
         self.assertIn("ClassifierNeuralNetworkInstance", repr_)
-        self.assertIn(f"channel_index={Deprecated}, channels_first=True", repr_)
+        self.assertIn(f"channels_first=True", repr_)
         self.assertIn("clip_values=[0. 1.]", repr_)
         self.assertIn("defences=None", repr_)
         self.assertIn(

--- a/tests/estimators/classification/test_deeplearning_common.json
+++ b/tests/estimators/classification/test_deeplearning_common.json
@@ -414,7 +414,7 @@
         "(pool): MaxPool2d(kernel_size=4, stride=4, padding=0, dilation=1, ceil_mode=False)",
         "(fullyconnected): Linear(in_features=25, out_features=10, bias=True)",
         "loss=CrossEntropyLoss(), optimizer=Adam",
-        "input_shape=(1, 28, 28), nb_classes=10, channel_index",
+        "input_shape=(1, 28, 28), nb_classes=10",
         "clip_values=array([0., 1.], dtype=float32",
         "preprocessing_defences=None, postprocessing_defences=None, preprocessing=[StandardisationMeanStdPyTorch(mean=0, std=1, apply_fit=True, apply_predict=True, device=cpu)]"
     ],
@@ -429,7 +429,7 @@
     ],
     "test_repr_kerastf": [
         "art.estimators.classification.keras.KerasClassifier",
-        "use_logits=True, channel_index",
+        "use_logits=True",
         "channels_first=False",
         "clip_values=array([0., 1.], dtype=float32)",
         "preprocessing_defences=None",

--- a/tests/estimators/classification/test_deeplearning_common.py
+++ b/tests/estimators/classification/test_deeplearning_common.py
@@ -168,7 +168,7 @@ def test_pickle(art_warning, image_dl_estimator, image_dl_estimator_defended, tm
             loaded = pickle.load(load_file)
 
         assert (classifier._clip_values == loaded._clip_values).all()
-        assert classifier._channel_index == loaded._channel_index
+        assert classifier._channels_first == loaded._channels_first
         assert classifier._use_logits == loaded._use_logits
         assert classifier._input_layer == loaded._input_layer
     except ARTTestException as e:

--- a/tests/estimators/classification/test_deeplearning_specific.py
+++ b/tests/estimators/classification/test_deeplearning_specific.py
@@ -133,7 +133,7 @@ def test_pickle(art_warning, get_default_mnist_subset, image_dl_estimator):
         with open(full_path, "rb") as f:
             loaded_model = pickle.load(f)
             np.testing.assert_equal(myclassifier_2._clip_values, loaded_model._clip_values)
-            assert myclassifier_2._channel_index == loaded_model._channel_index
+            assert myclassifier_2._channels_first == loaded_model._channels_first
             assert set(myclassifier_2.__dict__.keys()) == set(loaded_model.__dict__.keys())
 
         # Test predict

--- a/tests/estimators/classification/test_ensemble.py
+++ b/tests/estimators/classification/test_ensemble.py
@@ -24,7 +24,6 @@ import keras.backend as k
 import numpy as np
 
 from art.estimators.classification.ensemble import EnsembleClassifier
-from art.utils import Deprecated
 from tests.utils import TestBase, get_image_classifier_kr
 
 logger = logging.getLogger(__name__)
@@ -254,7 +253,7 @@ class TestEnsembleClassifier(TestBase):
         self.assertIn("art.estimators.classification.ensemble.EnsembleClassifier", repr_)
         self.assertIn("classifier_weights=array([0.5, 0.5])", repr_)
         self.assertIn(
-            f"channel_index={Deprecated}, channels_first=False, clip_values=array([0., 1.], dtype=float32), "
+            f"channels_first=False, clip_values=array([0., 1.], dtype=float32), "
             "preprocessing_defences=None, postprocessing_defences=None, preprocessing=[StandardisationMeanStd(mean=0, "
             "std=1, apply_fit=True, apply_predict=True)]",
             repr_,

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -60,7 +60,7 @@ class TestMetrics(unittest.TestCase):
         # Compute minimal perturbations
         params = {"eps_step": 1.0, "eps": 1.0}
         emp_robust = empirical_robustness(classifier, x_train, str("fgsm"), params)
-        self.assertAlmostEqual(emp_robust, 1.000369094488189, 4)
+        self.assertAlmostEqual(emp_robust, 1.000369094488189, 3)
 
         params = {"eps_step": 0.1, "eps": 0.2}
         emp_robust = empirical_robustness(classifier, x_train, str("fgsm"), params)


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request remove the deprecated argument `channel_index`.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
