### PR TITLE
Define dtype in SquareAttack with norm=2

### DIFF
--- a/art/attacks/evasion/square_attack.py
+++ b/art/attacks/evasion/square_attack.py
@@ -259,7 +259,7 @@ class SquareAttack(EvasionAttack):
 
                     return delta
 
-                delta_init = np.zeros(x_robust.shape)
+                delta_init = np.zeros(x_robust.shape, dtype=ART_NUMPY_DTYPE)
 
                 height_start = 0
                 for _ in range(n_tiles):

--- a/tests/attacks/evasion/test_square_attack.py
+++ b/tests/attacks/evasion/test_square_attack.py
@@ -50,8 +50,15 @@ def test_generate(art_warning, fix_get_mnist_subset, image_dl_estimator_for_atta
 
         x_train_mnist_adv = attack.generate(x=x_train_mnist, y=y_train_mnist)
 
-        assert np.mean(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(0.053533513, abs=0.025)
-        assert np.max(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(0.3, abs=0.05)
+        if norm == "inf":
+            expected_mean = 0.053533513
+            expected_max = 0.3
+        elif norm == 2:
+            expected_mean = 0.00073682
+            expected_max = 0.3
+
+        assert np.mean(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(expected_mean, abs=0.025)
+        assert np.max(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(expected_max, abs=0.05)
     except ARTTestException as e:
         art_warning(e)
 

--- a/tests/attacks/evasion/test_square_attack.py
+++ b/tests/attacks/evasion/test_square_attack.py
@@ -39,11 +39,12 @@ def fix_get_mnist_subset(get_mnist_dataset):
 
 
 @pytest.mark.framework_agnostic
-def test_generate(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
+@pytest.mark.parametrize("norm", [2, "inf"])
+def test_generate(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack, norm):
     try:
         classifier = image_dl_estimator_for_attack(SquareAttack)
 
-        attack = SquareAttack(estimator=classifier, norm=np.inf, max_iter=5, eps=0.3, p_init=0.8, nb_restarts=1)
+        attack = SquareAttack(estimator=classifier, norm=norm, max_iter=5, eps=0.3, p_init=0.8, nb_restarts=1)
 
         (x_train_mnist, y_train_mnist, x_test_mnist, y_test_mnist) = fix_get_mnist_subset
 

--- a/tests/attacks/evasion/test_square_attack.py
+++ b/tests/attacks/evasion/test_square_attack.py
@@ -57,8 +57,6 @@ def test_generate(art_warning, fix_get_mnist_subset, image_dl_estimator_for_atta
             expected_mean = 0.00073682
             expected_max = 0.25
 
-        print(np.max(np.abs(x_train_mnist_adv - x_train_mnist)) )
-
         assert np.mean(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(expected_mean, abs=0.025)
         assert np.max(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(expected_max, abs=0.05)
     except ARTTestException as e:

--- a/tests/attacks/evasion/test_square_attack.py
+++ b/tests/attacks/evasion/test_square_attack.py
@@ -55,7 +55,9 @@ def test_generate(art_warning, fix_get_mnist_subset, image_dl_estimator_for_atta
             expected_max = 0.3
         elif norm == 2:
             expected_mean = 0.00073682
-            expected_max = 0.3
+            expected_max = 0.25
+
+        print(np.max(np.abs(x_train_mnist_adv - x_train_mnist)) )
 
         assert np.mean(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(expected_mean, abs=0.025)
         assert np.max(np.abs(x_train_mnist_adv - x_train_mnist)) == pytest.approx(expected_max, abs=0.05)


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds a definition of dtype in SquareAttack with norm=2 to support PyTorch estimators.

Fixes #874 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
