### PR TITLE
Update numpy version to avoid error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,34 +25,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: TensorFlow 1.15.4 (Keras 2.2.5 Python 3.7)
+          - name: TensorFlow 1.15.5 (Keras 2.2.5 Python 3.7)
             framework: tensorflow
             python: 3.7
-            tensorflow: 1.15.4
+            tensorflow: 1.15.5
             tf_version: v1
             keras: 2.2.5
-          - name: TensorFlow 2.2.0 (Keras 2.3.1 Python 3.7)
+          - name: TensorFlow 2.2.2 (Keras 2.3.1 Python 3.7)
             framework: tensorflow
             python: 3.7
-            tensorflow: 2.2.0
+            tensorflow: 2.2.2
             tf_version: v2
             keras: 2.3.1
-          - name: TensorFlow 2.2.0v1 (Keras 2.3.1 Python 3.7)
+          - name: TensorFlow 2.2.2v1 (Keras 2.3.1 Python 3.7)
             framework: tensorflow2v1
             python: 3.7
-            tensorflow: 2.2.0
+            tensorflow: 2.2.2
             tf_version: v2
             keras: 2.3.1
-          - name: TensorFlow 2.3.1 (Keras 2.4.3 Python 3.7)
+          - name: TensorFlow 2.3.2 (Keras 2.4.3 Python 3.7)
             framework: tensorflow
             python: 3.7
-            tensorflow: 2.3.1
+            tensorflow: 2.3.2
             tf_version: v2
             keras: 2.4.3
-          - name: TensorFlow 2.4.0rc3 (Keras 2.4.3 Python 3.8)
+          - name: TensorFlow 2.4.1 (Keras 2.4.3 Python 3.8)
             framework: tensorflow
             python: 3.8
-            tensorflow: 2.4.0rc3
+            tensorflow: 2.4.1
             tf_version: v2
             keras: 2.4.3
           - name: Keras 2.3.1 (TensorFlow 2.2.1 Python 3.7)
@@ -60,10 +60,10 @@ jobs:
             python: 3.7
             tensorflow: 2.2.1
             keras: 2.3.1
-          - name: TensorFlow-Keras 2.3.1 (Keras 2.4.3 Python 3.7)
+          - name: TensorFlow-Keras 2.3.2 (Keras 2.4.3 Python 3.7)
             framework: kerastf
             python: 3.7
-            tensorflow: 2.3.1
+            tensorflow: 2.3.2
             keras: 2.4.3
           - name: PyTorch (Python 3.7)
             framework: pytorch
@@ -85,10 +85,10 @@ jobs:
             tensorflow: 2.2.1
             keras: 2.3.1
             scikit-learn: 0.22.2
-          - name: legacy (TensorFlow 2.3.1 Keras 2.4.3 scikit-learn 0.23.2 Python 3.8)
+          - name: legacy (TensorFlow 2.3.2 Keras 2.4.3 scikit-learn 0.23.2 Python 3.8)
             framework: legacy
             python: 3.8
-            tensorflow: 2.3.1
+            tensorflow: 2.3.2
             keras: 2.4.3
             scikit-learn: 0.23.2
 
@@ -143,7 +143,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y -q install ffmpeg libavcodec-extra
-          pip install tensorflow==2.2.0
+          pip install tensorflow==2.2.2
           pip install keras==2.3.1
       - name: Install Dependencies
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # base
-numpy==1.19.2
+numpy==1.20.0
 scipy==1.4.1
 matplotlib==3.3.3
 scikit-learn>=0.22.2,==0.23.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # base
-numpy==1.20.0
+numpy>=1.18.0
 scipy==1.4.1
 matplotlib==3.3.3
 scikit-learn>=0.22.2,==0.23.*


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request increases Numpy version for CI to 1.20.0 to avoid:

```
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
```

that started appearing yesterday as discussed in this and similar threads https://github.com/scikit-learn-contrib/hdbscan/issues/457

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
