### PR TITLE
Add backward compatibility for TensorFlow v2 to v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,34 +25,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: TensorFlow 1.15.4 (Keras 2.2.5 Python 3.7)
+          - name: TensorFlow 1.15.5 (Keras 2.2.5 Python 3.7)
             framework: tensorflow
             python: 3.7
-            tensorflow: 1.15.4
+            tensorflow: 1.15.5
             tf_version: v1
             keras: 2.2.5
-          - name: TensorFlow 2.2.0 (Keras 2.3.1 Python 3.7)
-            framework: tensorflow
-            python: 3.7
-            tensorflow: 2.2.0
-            tf_version: v2
-            keras: 2.3.1
-          - name: TensorFlow 2.2.0v1 (Keras 2.3.1 Python 3.7)
-            framework: tensorflow2v1
-            python: 3.7
-            tensorflow: 2.2.0
-            tf_version: v2
-            keras: 2.3.1
           - name: TensorFlow 2.3.1 (Keras 2.4.3 Python 3.7)
             framework: tensorflow
             python: 3.7
             tensorflow: 2.3.1
             tf_version: v2
             keras: 2.4.3
-          - name: TensorFlow 2.4.0rc3 (Keras 2.4.3 Python 3.8)
+          - name: TensorFlow 2.4.1v1 (Keras 2.4.3 Python 3.8)
+            framework: tensorflow2v1
+            python: 3.8
+            tensorflow: 2.4.1
+            tf_version: v2
+            keras: 2.4.3
+          - name: TensorFlow 2.4.1 (Keras 2.4.3 Python 3.8)
             framework: tensorflow
             python: 3.8
-            tensorflow: 2.4.0rc3
+            tensorflow: 2.4.1
             tf_version: v2
             keras: 2.4.3
           - name: Keras 2.3.1 (TensorFlow 2.2.1 Python 3.7)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
         run: |
           pip install tensorflow==${{ matrix.tensorflow }}
           pip install lingvo==${{ matrix.lingvo }}
+          pip install tensorflow-addons==0.9.1
           pip list
       - name: Run ${{ matrix.name }} Tests
         run: ./run_tests.sh ${{ matrix.framework }}

--- a/art/estimators/encoding/tensorflow.py
+++ b/art/estimators/encoding/tensorflow.py
@@ -29,7 +29,7 @@ from art.estimators.tensorflow import TensorFlowEstimator
 if TYPE_CHECKING:
     # pylint: disable=C0412
     import numpy as np
-    import tensorflow as tf
+    import tensorflow.compat.v1 as tf
 
     from art.utils import CLIP_VALUES_TYPE, PREPROCESSING_TYPE
     from art.defences.preprocessor import Preprocessor
@@ -77,7 +77,7 @@ class TensorFlowEncoder(EncoderMixin, TensorFlowEstimator):  # lgtm [py/missing-
         :param feed_dict: A feed dictionary for the session run evaluating the classifier. This dictionary includes all
                           additionally required placeholders except the placeholders defined in this class.
         """
-        import tensorflow as tf  # lgtm [py/repeated-import]
+        import tensorflow.compat.v1 as tf  # lgtm [py/repeated-import]
 
         super().__init__(
             model=model,

--- a/art/estimators/generation/tensorflow.py
+++ b/art/estimators/generation/tensorflow.py
@@ -29,7 +29,7 @@ from art.estimators.tensorflow import TensorFlowEstimator
 if TYPE_CHECKING:
     # pylint: disable=C0412
     import numpy as np
-    import tensorflow as tf
+    import tensorflow.compat.v1 as tf
 
     from art.utils import CLIP_VALUES_TYPE, PREPROCESSING_TYPE
     from art.defences.preprocessor import Preprocessor
@@ -77,7 +77,7 @@ class TensorFlowGenerator(GeneratorMixin, TensorFlowEstimator):  # lgtm [py/miss
         :param feed_dict: A feed dictionary for the session run evaluating the classifier. This dictionary includes all
                           additionally required placeholders except the placeholders defined in this class.
         """
-        import tensorflow as tf  # lgtm [py/repeated-import]
+        import tensorflow.compat.v1 as tf  # lgtm [py/repeated-import]
 
         super().__init__(
             model=model,

--- a/art/estimators/object_detection/tensorflow_faster_rcnn.py
+++ b/art/estimators/object_detection/tensorflow_faster_rcnn.py
@@ -30,7 +30,7 @@ from art import config
 
 if TYPE_CHECKING:
     # pylint: disable=C0412
-    import tensorflow as tf
+    import tensorflow.compat.v1 as tf
     from object_detection.meta_architectures.faster_rcnn_meta_arch import FasterRCNNMetaArch
     from tensorflow.python.framework.ops import Tensor
     from tensorflow.python.client.session import Session
@@ -100,7 +100,7 @@ class TensorFlowFasterRCNN(ObjectDetectorMixin, TensorFlowEstimator):
                               `first_stage_localization_loss`, `first_stage_objectness_loss`,
                               `second_stage_localization_loss`, `second_stage_classification_loss`.
         """
-        import tensorflow as tf  # lgtm [py/repeated-import]
+        import tensorflow.compat.v1 as tf  # lgtm [py/repeated-import]
 
         # Super initialization
         super().__init__(
@@ -246,7 +246,7 @@ class TensorFlowFasterRCNN(ObjectDetectorMixin, TensorFlowEstimator):
                               corresponding loss values.
                     - detections: a dictionary containing final detection results.
         """
-        import tensorflow as tf  # lgtm [py/repeated-import]
+        import tensorflow.compat.v1 as tf  # lgtm [py/repeated-import]
         from object_detection.utils import variables_helper
 
         if obj_detection_model is None:
@@ -330,7 +330,7 @@ class TensorFlowFasterRCNN(ObjectDetectorMixin, TensorFlowEstimator):
                     weights for groundtruth boxes.
         :return: Loss gradients of the same shape as `x`.
         """
-        import tensorflow as tf  # lgtm [py/repeated-import]
+        import tensorflow.compat.v1 as tf  # lgtm [py/repeated-import]
 
         # Only do loss_gradient if is_training is False
         if self.is_training:

--- a/examples/get_started_tensorflow.py
+++ b/examples/get_started_tensorflow.py
@@ -4,7 +4,7 @@ dataset and creates adversarial examples using the Fast Gradient Sign Method. He
 the model, it would also be possible to provide a pretrained model to the ART classifier.
 The parameters are chosen for reduced computational requirements of the script and not optimised for accuracy.
 """
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import numpy as np
 
 from art.attacks.evasion import FastGradientMethod
@@ -24,7 +24,7 @@ x = tf.layers.conv2d(input_ph, filters=4, kernel_size=5, activation=tf.nn.relu)
 x = tf.layers.max_pooling2d(x, 2, 2)
 x = tf.layers.conv2d(x, filters=10, kernel_size=5, activation=tf.nn.relu)
 x = tf.layers.max_pooling2d(x, 2, 2)
-x = tf.contrib.layers.flatten(x)
+x = tf.layers.flatten(x)
 x = tf.layers.dense(x, 100, activation=tf.nn.relu)
 logits = tf.layers.dense(x, 10)
 

--- a/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
@@ -47,7 +47,6 @@ def test_spatial_smoothing_median_filter_call_expected_behavior(art_warning):
     try:
         test_input = np.array([[[[1], [2]], [[3], [4]]]])
         test_output = np.array([[[[2], [2]], [[2], [2]]]])
-        print(test_input.shape)
         spatial_smoothing = SpatialSmoothingTensorFlowV2(channels_first=False, window_size=2)
 
         assert_array_equal(spatial_smoothing(test_input)[0], test_output)

--- a/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing_tensorflow.py
@@ -103,7 +103,7 @@ def test_spatial_smoothing_video_data(art_warning, video_batch, channels_first):
         art_warning(e)
 
 
-@pytest.mark.only_with_platform("tensorflow")
+@pytest.mark.only_with_platform("tensorflow", "tensorflow2v1")
 def test_non_spatial_data_error(art_warning, tabular_batch):
     try:
         test_input = tabular_batch

--- a/tests/defences/test_adversarial_trainer_FBF.py
+++ b/tests/defences/test_adversarial_trainer_FBF.py
@@ -30,7 +30,7 @@ def get_adv_trainer(framework, image_dl_estimator):
 
         if framework == "keras":
             trainer = None
-        if framework == "tensorflow":
+        if framework in ["tensorflow", "tensorflow2v1"]:
             trainer = None
         if framework == "pytorch":
             classifier = image_dl_estimator()[0][0]

--- a/tests/estimators/classification/test_deeplearning_specific.py
+++ b/tests/estimators/classification/test_deeplearning_specific.py
@@ -147,7 +147,7 @@ def test_pickle(art_warning, get_default_mnist_subset, image_dl_estimator):
 
 
 @pytest.mark.skip_module("apex.amp")
-@pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
 def test_loss_gradient_amp(
     art_warning, get_default_mnist_subset, image_dl_estimator, expected_values, mnist_shape, device_type,

--- a/tests/estimators/speech_recognition/test_pytorch_deep_speech.py
+++ b/tests/estimators/speech_recognition/test_pytorch_deep_speech.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_module("apex.amp", "deepspeech_pytorch")
-@pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("use_amp", [False, True])
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
 def test_pytorch_deep_speech(art_warning, expected_values, use_amp, device_type):

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -60,7 +60,7 @@ class TestMetrics(unittest.TestCase):
         # Compute minimal perturbations
         params = {"eps_step": 1.0, "eps": 1.0}
         emp_robust = empirical_robustness(classifier, x_train, str("fgsm"), params)
-        self.assertAlmostEqual(emp_robust, 1.000369094488189, 4)
+        self.assertAlmostEqual(emp_robust, 1.000369094488189, 3)
 
         params = {"eps_step": 0.1, "eps": 0.2}
         emp_robust = empirical_robustness(classifier, x_train, str("fgsm"), params)

--- a/tests/preprocessing/audio/test_l_filter_pytorch.py
+++ b/tests/preprocessing/audio/test_l_filter_pytorch.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_module("torchaudio")
-@pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("fir_filter", [False, True])
 def test_audio_filter(fir_filter, art_warning, expected_values):
     try:
@@ -78,7 +78,7 @@ def test_audio_filter(fir_filter, art_warning, expected_values):
 
 
 @pytest.mark.skip_module("torchaudio")
-@pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 def test_default(art_warning):
     try:
         # Small data for testing
@@ -99,7 +99,7 @@ def test_default(art_warning):
 
 
 @pytest.mark.skip_module("torchaudio")
-@pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 def test_triple_clip_values_error(art_warning):
     try:
         exc_msg = "`clip_values` should be a tuple of 2 floats containing the allowed data range."
@@ -115,7 +115,7 @@ def test_triple_clip_values_error(art_warning):
 
 
 @pytest.mark.skip_module("torchaudio")
-@pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 def test_relation_clip_values_error(art_warning):
     try:
         exc_msg = "Invalid `clip_values`: min >= max."

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,7 +37,7 @@ from art.utils import load_dataset
 logger = logging.getLogger(__name__)
 
 # ----------------------------------------------------------------------------------------------------- TEST BASE CLASS
-art_supported_frameworks = ["keras", "tensorflow", "pytorch", "scikitlearn"]
+art_supported_frameworks = ["keras", "tensorflow", "tensorflow2v1", "pytorch", "scikitlearn"]
 
 
 class TestBase(unittest.TestCase):


### PR DESCRIPTION
# Description

This pull request add backward compatibility for TensorFlow v2 to v1.

Fixes #665 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
