### PR TITLE
Expand range of eps_step and eps in PGD attacks

### DIFF
--- a/art/attacks/evasion/fast_gradient.py
+++ b/art/attacks/evasion/fast_gradient.py
@@ -281,24 +281,33 @@ class FastGradientMethod(EvasionAttack):
         return adv_x_best
 
     def _check_params(self) -> None:
-        # Check if order of the norm is acceptable given current implementation
+
         if self.norm not in [1, 2, np.inf, "inf"]:
             raise ValueError('Norm order must be either 1, 2, `np.inf` or "inf".')
 
-        if (not (isinstance(self.eps, (int, float, np.ndarray)) and isinstance(self.eps_step, (int, float)))) and (
-            hasattr(self, "minimal")
-            and self.minimal
-            and not (isinstance(self.eps, np.ndarray) and isinstance(self.eps_step, np.ndarray))
+        if not (
+            isinstance(self.eps, (int, float))
+            and isinstance(self.eps_step, (int, float))
+            or isinstance(self.eps, np.ndarray)
+            and isinstance(self.eps_step, np.ndarray)
         ):
             raise TypeError(
-                "The perturbation size `eps` and the perturbation step-size `eps_step` must have the same type."
+                "The perturbation size `eps` and the perturbation step-size `eps_step` must have the same type of `int`"
+                ", `float`, or `np.ndarray`."
             )
 
+        if (
+            hasattr(self, "minimal")
+            and self.minimal
+            and (isinstance(self.eps, np.ndarray) or isinstance(self.eps_step, np.ndarray))
+        ):
+            raise TypeError("The `minimal` FGM attack only supports `eps` and `eps_step` of types `int` or `float`.")
+
         if isinstance(self.eps, (int, float)):
-            if self.eps <= 0:
+            if self.eps < 0:
                 raise ValueError("The perturbation size `eps` has to be positive.")
         else:
-            if (self.eps <= 0).any():
+            if (self.eps < 0).any():
                 raise ValueError("The perturbation size `eps` has to be positive.")
 
         if isinstance(self.eps_step, (int, float)):
@@ -308,14 +317,11 @@ class FastGradientMethod(EvasionAttack):
             if (self.eps_step <= 0).any():
                 raise ValueError("The perturbation step-size `eps_step` has to be positive.")
 
-        if (
-            isinstance(self.eps, np.ndarray)
-            and isinstance(self.eps_step, np.ndarray)
-            and self.eps.shape != self.eps_step.shape
-        ):
-            raise ValueError(
-                "The perturbation size `eps` and the perturbation step-size `eps_step` must have the same shape."
-            )
+        if isinstance(self.eps, np.ndarray) and isinstance(self.eps_step, np.ndarray):
+            if self.eps.shape != self.eps_step.shape:
+                raise ValueError(
+                    "The perturbation size `eps` and the perturbation step-size `eps_step` must have the same shape."
+                )
 
         if not isinstance(self.targeted, bool):
             raise ValueError("The flag `targeted` has to be of type bool.")
@@ -377,11 +383,16 @@ class FastGradientMethod(EvasionAttack):
     def _apply_perturbation(
         self, batch: np.ndarray, perturbation: np.ndarray, eps_step: Union[int, float, np.ndarray]
     ) -> np.ndarray:
-        batch = batch + eps_step * perturbation
 
-        if self.estimator.clip_values is not None:
+        if eps_step == np.inf:
             clip_min, clip_max = self.estimator.clip_values
-            batch = np.clip(batch, clip_min, clip_max)
+            batch[perturbation < 0.0] = clip_min
+            batch[perturbation > 0.0] = clip_max
+        else:
+            batch = batch + eps_step * perturbation
+            if self.estimator.clip_values is not None:
+                clip_min, clip_max = self.estimator.clip_values
+                batch = np.clip(batch, clip_min, clip_max)
 
         return batch
 

--- a/art/attacks/evasion/fast_gradient.py
+++ b/art/attacks/evasion/fast_gradient.py
@@ -377,15 +377,12 @@ class FastGradientMethod(EvasionAttack):
         self, batch: np.ndarray, perturbation: np.ndarray, eps_step: Union[int, float, np.ndarray]
     ) -> np.ndarray:
 
-        if isinstance(eps_step, (int, float)) and eps_step == np.inf:
+        perturbation_step = eps_step * perturbation
+        perturbation_step[np.isnan(perturbation_step)] = 0
+        batch = batch + perturbation_step
+        if self.estimator.clip_values is not None:
             clip_min, clip_max = self.estimator.clip_values
-            batch[perturbation < 0.0] = clip_min
-            batch[perturbation > 0.0] = clip_max
-        else:
-            batch = batch + eps_step * perturbation
-            if self.estimator.clip_values is not None:
-                clip_min, clip_max = self.estimator.clip_values
-                batch = np.clip(batch, clip_min, clip_max)
+            batch = np.clip(batch, clip_min, clip_max)
 
         return batch
 

--- a/art/attacks/evasion/fast_gradient.py
+++ b/art/attacks/evasion/fast_gradient.py
@@ -298,10 +298,10 @@ class FastGradientMethod(EvasionAttack):
 
         if isinstance(self.eps, (int, float)):
             if self.eps < 0:
-                raise ValueError("The perturbation size `eps` has to be positive.")
+                raise ValueError("The perturbation size `eps` has to be nonnegative.")
         else:
             if (self.eps < 0).any():
-                raise ValueError("The perturbation size `eps` has to be positive.")
+                raise ValueError("The perturbation size `eps` has to be nonnegative.")
 
         if isinstance(self.eps_step, (int, float)):
             if self.eps_step <= 0:

--- a/art/attacks/evasion/fast_gradient.py
+++ b/art/attacks/evasion/fast_gradient.py
@@ -296,13 +296,6 @@ class FastGradientMethod(EvasionAttack):
                 ", `float`, or `np.ndarray`."
             )
 
-        if (
-            hasattr(self, "minimal")
-            and self.minimal
-            and (isinstance(self.eps, np.ndarray) or isinstance(self.eps_step, np.ndarray))
-        ):
-            raise TypeError("The `minimal` FGM attack only supports `eps` and `eps_step` of types `int` or `float`.")
-
         if isinstance(self.eps, (int, float)):
             if self.eps < 0:
                 raise ValueError("The perturbation size `eps` has to be positive.")
@@ -384,7 +377,7 @@ class FastGradientMethod(EvasionAttack):
         self, batch: np.ndarray, perturbation: np.ndarray, eps_step: Union[int, float, np.ndarray]
     ) -> np.ndarray:
 
-        if eps_step == np.inf:
+        if isinstance(eps_step, (int, float)) and eps_step == np.inf:
             clip_min, clip_max = self.estimator.clip_values
             batch[perturbation < 0.0] = clip_min
             batch[perturbation > 0.0] = clip_max

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
@@ -185,20 +185,26 @@ class ProjectedGradientDescent(EvasionAttack):
         self._attack.set_params(**kwargs)
 
     def _check_params(self) -> None:
-        # Check if order of the norm is acceptable given current implementation
+
         if self.norm not in [1, 2, np.inf, "inf"]:
             raise ValueError('Norm order must be either 1, 2, `np.inf` or "inf".')
 
-        if not (isinstance(self.eps, (int, float, np.ndarray)) and isinstance(self.eps_step, (int, float, np.ndarray))):
+        if not (
+            isinstance(self.eps, (int, float))
+            and isinstance(self.eps_step, (int, float))
+            or isinstance(self.eps, np.ndarray)
+            and isinstance(self.eps_step, np.ndarray)
+        ):
             raise TypeError(
-                "The perturbation size `eps` and the perturbation step-size `eps_step` must have the same type."
+                "The perturbation size `eps` and the perturbation step-size `eps_step` must have the same type of `int`"
+                ", `float`, or `np.ndarray`."
             )
 
         if isinstance(self.eps, (int, float)):
-            if self.eps <= 0:
+            if self.eps < 0:
                 raise ValueError("The perturbation size `eps` has to be positive.")
         else:
-            if (self.eps <= 0).any():
+            if (self.eps < 0).any():
                 raise ValueError("The perturbation size `eps` has to be positive.")
 
         if isinstance(self.eps_step, (int, float)):
@@ -213,13 +219,6 @@ class ProjectedGradientDescent(EvasionAttack):
                 raise ValueError(
                     "The perturbation size `eps` and the perturbation step-size `eps_step` must have the same shape."
                 )
-
-            if self.norm in ["inf", np.inf] and (self.eps_step > self.eps).any():
-                raise ValueError("The iteration step `eps_step` has to be smaller than the total attack `eps`.")
-
-        else:
-            if self.norm in ["inf", np.inf] and self.eps_step > self.eps:
-                raise ValueError("The iteration step `eps_step` has to be smaller than the total attack `eps`.")
 
         if not isinstance(self.targeted, bool):
             raise ValueError("The flag `targeted` has to be of type bool.")

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent.py
@@ -202,10 +202,10 @@ class ProjectedGradientDescent(EvasionAttack):
 
         if isinstance(self.eps, (int, float)):
             if self.eps < 0:
-                raise ValueError("The perturbation size `eps` has to be positive.")
+                raise ValueError("The perturbation size `eps` has to be nonnegative.")
         else:
             if (self.eps < 0).any():
-                raise ValueError("The perturbation size `eps` has to be positive.")
+                raise ValueError("The perturbation size `eps` has to be nonnegative.")
 
         if isinstance(self.eps_step, (int, float)):
             if self.eps_step <= 0:
@@ -232,8 +232,8 @@ class ProjectedGradientDescent(EvasionAttack):
         if self.batch_size <= 0:
             raise ValueError("The batch size `batch_size` has to be positive.")
 
-        if self.max_iter <= 0:
-            raise ValueError("The number of iterations `max_iter` has to be a positive integer.")
+        if self.max_iter < 0:
+            raise ValueError("The number of iterations `max_iter` has to be a nonnegative integer.")
 
         if not isinstance(self.verbose, bool):
             raise ValueError("The verbose has to be a Boolean.")

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
@@ -158,6 +158,60 @@ class ProjectedGradientDescentCommon(FastGradientMethod):
 
         return targets
 
+    def _check_params(self) -> None:
+
+        if self.norm not in [1, 2, np.inf, "inf"]:
+            raise ValueError('Norm order must be either 1, 2, `np.inf` or "inf".')
+
+        if not (
+            isinstance(self.eps, (int, float))
+            and isinstance(self.eps_step, (int, float))
+            or isinstance(self.eps, np.ndarray)
+            and isinstance(self.eps_step, np.ndarray)
+        ):
+            raise TypeError(
+                "The perturbation size `eps` and the perturbation step-size `eps_step` must have the same type of `int`"
+                ", `float`, or `np.ndarray`."
+            )
+
+        if isinstance(self.eps, (int, float)):
+            if self.eps < 0:
+                raise ValueError("The perturbation size `eps` has to be nonnegative.")
+        else:
+            if (self.eps < 0).any():
+                raise ValueError("The perturbation size `eps` has to be nonnegative.")
+
+        if isinstance(self.eps_step, (int, float)):
+            if self.eps_step <= 0:
+                raise ValueError("The perturbation step-size `eps_step` has to be positive.")
+        else:
+            if (self.eps_step <= 0).any():
+                raise ValueError("The perturbation step-size `eps_step` has to be positive.")
+
+        if isinstance(self.eps, np.ndarray) and isinstance(self.eps_step, np.ndarray):
+            if self.eps.shape != self.eps_step.shape:
+                raise ValueError(
+                    "The perturbation size `eps` and the perturbation step-size `eps_step` must have the same shape."
+                )
+
+        if not isinstance(self.targeted, bool):
+            raise ValueError("The flag `targeted` has to be of type bool.")
+
+        if not isinstance(self.num_random_init, (int, np.int)):
+            raise TypeError("The number of random initialisations has to be of type integer.")
+
+        if self.num_random_init < 0:
+            raise ValueError("The number of random initialisations `random_init` has to be greater than or equal to 0.")
+
+        if self.batch_size <= 0:
+            raise ValueError("The batch size `batch_size` has to be positive.")
+
+        if self.max_iter < 0:
+            raise ValueError("The number of iterations `max_iter` has to be a nonnegative integer.")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The verbose has to be a Boolean.")
+
 
 class ProjectedGradientDescentNumpy(ProjectedGradientDescentCommon):
     """

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_numpy.py
@@ -158,18 +158,6 @@ class ProjectedGradientDescentCommon(FastGradientMethod):
 
         return targets
 
-    def _check_params(self) -> None:
-        super(ProjectedGradientDescentCommon, self)._check_params()
-
-        if (self.norm in ["inf", np.inf]) and (
-            (isinstance(self.eps, (int, float)) and self.eps_step > self.eps)
-            or (isinstance(self.eps, np.ndarray) and (self.eps_step > self.eps).any())
-        ):
-            raise ValueError("The iteration step `eps_step` has to be smaller than the total attack `eps`.")
-
-        if self.max_iter <= 0:
-            raise ValueError("The number of iterations `max_iter` has to be a positive integer.")
-
 
 class ProjectedGradientDescentNumpy(ProjectedGradientDescentCommon):
     """

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
@@ -311,20 +311,16 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
         """
         import torch  # lgtm [py/repeated-import]
 
-        if isinstance(eps_step, (int, float)) and eps_step == np.inf:
+        eps_step = np.array(eps_step, dtype=ART_NUMPY_DTYPE)
+        perturbation_step = torch.tensor(eps_step).to(self.estimator.device) * perturbation
+        perturbation_step[torch.isnan(perturbation_step)] = 0
+        x = x + perturbation_step
+        if self.estimator.clip_values is not None:
             clip_min, clip_max = self.estimator.clip_values
-            x[perturbation < 0.0] = float(clip_min)
-            x[perturbation > 0.0] = float(clip_max)
-        else:
-            eps_step = np.array(eps_step, dtype=ART_NUMPY_DTYPE)
-            x = x + torch.tensor(eps_step).to(self.estimator.device) * perturbation
-
-            if self.estimator.clip_values is not None:
-                clip_min, clip_max = self.estimator.clip_values
-                x = torch.max(
-                    torch.min(x, torch.tensor(clip_max).to(self.estimator.device)),
-                    torch.tensor(clip_min).to(self.estimator.device),
-                )
+            x = torch.max(
+                torch.min(x, torch.tensor(clip_max).to(self.estimator.device)),
+                torch.tensor(clip_min).to(self.estimator.device),
+            )
 
         return x
 

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
@@ -311,7 +311,7 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
         """
         import torch  # lgtm [py/repeated-import]
 
-        if eps_step == np.inf:
+        if isinstance(eps_step, (int, float)) and eps_step == np.inf:
             clip_min, clip_max = self.estimator.clip_values
             x[perturbation < 0.0] = float(clip_min)
             x[perturbation > 0.0] = float(clip_max)

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
@@ -311,15 +311,20 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
         """
         import torch  # lgtm [py/repeated-import]
 
-        eps_step = np.array(eps_step, dtype=ART_NUMPY_DTYPE)
-        x = x + torch.tensor(eps_step).to(self.estimator.device) * perturbation
-
-        if self.estimator.clip_values is not None:
+        if eps_step == np.inf:
             clip_min, clip_max = self.estimator.clip_values
-            x = torch.max(
-                torch.min(x, torch.tensor(clip_max).to(self.estimator.device)),
-                torch.tensor(clip_min).to(self.estimator.device),
-            )
+            x[perturbation < 0.0] = float(clip_min)
+            x[perturbation > 0.0] = float(clip_max)
+        else:
+            eps_step = np.array(eps_step, dtype=ART_NUMPY_DTYPE)
+            x = x + torch.tensor(eps_step).to(self.estimator.device) * perturbation
+
+            if self.estimator.clip_values is not None:
+                clip_min, clip_max = self.estimator.clip_values
+                x = torch.max(
+                    torch.min(x, torch.tensor(clip_max).to(self.estimator.device)),
+                    torch.tensor(clip_min).to(self.estimator.device),
+                )
 
         return x
 

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
@@ -304,16 +304,12 @@ class ProjectedGradientDescentTensorFlowV2(ProjectedGradientDescentCommon):
         """
         import tensorflow as tf  # lgtm [py/repeated-import]
 
-        if isinstance(eps_step, (int, float)) and eps_step == np.inf:
+        perturbation_step = eps_step * perturbation
+        perturbation_step = tf.where(tf.math.is_nan(perturbation_step), 0, perturbation_step)
+        x = x + perturbation_step
+        if self.estimator.clip_values is not None:
             clip_min, clip_max = self.estimator.clip_values
-            x = tf.where(perturbation < 0.0, clip_min, x)
-            x = tf.where(perturbation > 0.0, clip_max, x)
-        else:
-            x = x + tf.constant(eps_step, dtype=ART_NUMPY_DTYPE) * perturbation
-
-            if self.estimator.clip_values is not None:
-                clip_min, clip_max = self.estimator.clip_values
-                x = tf.clip_by_value(x, clip_min, clip_max)
+            x = tf.clip_by_value(x, clip_value_min=clip_min, clip_value_max=clip_max)
 
         return x
 

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
@@ -304,7 +304,7 @@ class ProjectedGradientDescentTensorFlowV2(ProjectedGradientDescentCommon):
         """
         import tensorflow as tf  # lgtm [py/repeated-import]
 
-        perturbation_step = eps_step * perturbation
+        perturbation_step = tf.constant(eps_step, dtype=ART_NUMPY_DTYPE) * perturbation
         perturbation_step = tf.where(tf.math.is_nan(perturbation_step), 0, perturbation_step)
         x = x + perturbation_step
         if self.estimator.clip_values is not None:

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
@@ -304,11 +304,16 @@ class ProjectedGradientDescentTensorFlowV2(ProjectedGradientDescentCommon):
         """
         import tensorflow as tf  # lgtm [py/repeated-import]
 
-        x = x + tf.constant(eps_step, dtype=ART_NUMPY_DTYPE) * perturbation
-
-        if self.estimator.clip_values is not None:
+        if eps_step == np.inf:
             clip_min, clip_max = self.estimator.clip_values
-            x = tf.clip_by_value(x, clip_min, clip_max)
+            x = tf.where(perturbation < 0.0, clip_min, x)
+            x = tf.where(perturbation > 0.0, clip_max, x)
+        else:
+            x = x + tf.constant(eps_step, dtype=ART_NUMPY_DTYPE) * perturbation
+
+            if self.estimator.clip_values is not None:
+                clip_min, clip_max = self.estimator.clip_values
+                x = tf.clip_by_value(x, clip_min, clip_max)
 
         return x
 

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
@@ -304,7 +304,7 @@ class ProjectedGradientDescentTensorFlowV2(ProjectedGradientDescentCommon):
         """
         import tensorflow as tf  # lgtm [py/repeated-import]
 
-        if eps_step == np.inf:
+        if isinstance(eps_step, (int, float)) and eps_step == np.inf:
             clip_min, clip_max = self.estimator.clip_values
             x = tf.where(perturbation < 0.0, clip_min, x)
             x = tf.where(perturbation > 0.0, clip_max, x)


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds support for `eps_step` larger than `eps` for all norms, `eps_step = np.inf` to enable stepping immediately towards the boundary of clip values in the direction of the gradient, and `eps=0` to zero any perturbation for debugging purposes.

Fixes #823

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
