### PR TITLE
Check for NaN in loss gradient of PGD attacks and replace with 0.0

### DIFF
--- a/art/attacks/evasion/fast_gradient.py
+++ b/art/attacks/evasion/fast_gradient.py
@@ -344,7 +344,7 @@ class FastGradientMethod(EvasionAttack):
         # Check for NaN before normalisation an replace with 0
         if np.isnan(grad).any():
             logger.warning("Elements of the loss gradient are NaN and have been replaced with 0.0.")
-            grad = np.where(np.isnan(grad), np.zeros_like(grad), grad)
+            grad = np.where(np.isnan(grad), 0.0, grad)
 
         # Apply mask
         if mask is not None:
@@ -352,6 +352,9 @@ class FastGradientMethod(EvasionAttack):
 
         # Apply norm bound
         def _apply_norm(grad, object_type=False):
+            if np.isinf(grad).any():
+                logger.info("The loss gradient array contains at least one positive or negative infinity.")
+
             if self.norm in [np.inf, "inf"]:
                 grad = np.sign(grad)
             elif self.norm == 1:

--- a/art/attacks/evasion/fast_gradient.py
+++ b/art/attacks/evasion/fast_gradient.py
@@ -341,6 +341,11 @@ class FastGradientMethod(EvasionAttack):
         # Get gradient wrt loss; invert it if attack is targeted
         grad = self.estimator.loss_gradient(batch, batch_labels) * (1 - 2 * int(self.targeted))
 
+        # Check for NaN before normalisation an replace with 0
+        if np.is_nan(grad).any():
+            logger.warning("Elements of the loss gradient are NaN and have been replaced with 0.0.")
+            grad = np.where(np.is_nan(grad), np.zeros_like(grad), grad)
+
         # Apply mask
         if mask is not None:
             grad = np.where(mask == 0.0, 0.0, grad)

--- a/art/attacks/evasion/fast_gradient.py
+++ b/art/attacks/evasion/fast_gradient.py
@@ -342,9 +342,9 @@ class FastGradientMethod(EvasionAttack):
         grad = self.estimator.loss_gradient(batch, batch_labels) * (1 - 2 * int(self.targeted))
 
         # Check for NaN before normalisation an replace with 0
-        if np.is_nan(grad).any():
+        if np.isnan(grad).any():
             logger.warning("Elements of the loss gradient are NaN and have been replaced with 0.0.")
-            grad = np.where(np.is_nan(grad), np.zeros_like(grad), grad)
+            grad = np.where(np.isnan(grad), np.zeros_like(grad), grad)
 
         # Apply mask
         if mask is not None:

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
@@ -278,6 +278,11 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
         # Get gradient wrt loss; invert it if attack is targeted
         grad = self.estimator.loss_gradient(x=x, y=y) * (1 - 2 * int(self.targeted))
 
+        # Check for nan before normalisation an replace with 0
+        if torch.any(grad.is_nan()):
+            logger.warning("Elements of the loss gradient are NaN and have been replaced with 0.0.")
+            grad[grad.isnan()] = 0.0
+
         # Apply mask
         if mask is not None:
             grad = torch.where(mask == 0.0, torch.tensor(0.0), grad)

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_pytorch.py
@@ -279,7 +279,7 @@ class ProjectedGradientDescentPyTorch(ProjectedGradientDescentCommon):
         grad = self.estimator.loss_gradient(x=x, y=y) * (1 - 2 * int(self.targeted))
 
         # Check for nan before normalisation an replace with 0
-        if torch.any(grad.is_nan()):
+        if torch.any(grad.isnan()):
             logger.warning("Elements of the loss gradient are NaN and have been replaced with 0.0.")
             grad[grad.isnan()] = 0.0
 

--- a/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
+++ b/art/attacks/evasion/projected_gradient_descent/projected_gradient_descent_tensorflow_v2.py
@@ -269,6 +269,11 @@ class ProjectedGradientDescentTensorFlowV2(ProjectedGradientDescentCommon):
             1 - 2 * int(self.targeted), dtype=ART_NUMPY_DTYPE
         )
 
+        # Check for NaN before normalisation an replace with 0
+        if tf.reduce_any(tf.math.is_nan(grad)):
+            logger.warning("Elements of the loss gradient are NaN and have been replaced with 0.0.")
+            grad = tf.where(tf.math.is_nan(grad), tf.zeros_like(grad), grad)
+
         # Apply mask
         if mask is not None:
             grad = tf.where(mask == 0.0, 0.0, grad)


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request check for elements with NaN in the loss gradient of all PGD attacks and replaces them with 0.0. A warning is logged if an element with NaN is detected.

Fixes #824

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
