### PR TITLE
Fixed loss function doesn't work on GPU

### DIFF
--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -505,7 +505,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         loss = self._loss(model_outputs[-1], labels_t)
         self._loss.reduction = prev_reduction
 
-        return loss.detach().numpy()
+        return loss.cpu().detach().numpy()
 
     def loss_gradient(
         self, x: Union[np.ndarray, "torch.Tensor"], y: Union[np.ndarray, "torch.Tensor"], **kwargs


### PR DESCRIPTION
# Description
When attacking with APGD. The loss function reports error:
"TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first."
Move loss to CPU to fix it.

Fixes # (issue)

from loss.detach().numpy() to loss.cpu().detahc().numpy()

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS: Ubuntu.18.04
- Python version: 3.6.9
- ART version or commit number: 1.5.1
- PyTorch: 1.7.0+cu110
- 

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
