### PR TITLE
Define dtype in StandardisationMeanStdPyTorch

### DIFF
--- a/art/preprocessing/standardisation_mean_std/standardisation_mean_std_pytorch.py
+++ b/art/preprocessing/standardisation_mean_std/standardisation_mean_std_pytorch.py
@@ -72,8 +72,8 @@ class StandardisationMeanStdPyTorch(PreprocessorPyTorch):
         """
         import torch  # lgtm [py/repeated-import]
 
-        mean = torch.tensor(self.mean, device=self._device)
-        std = torch.tensor(self.std, device=self._device)
+        mean = torch.tensor(self.mean, device=self._device, dtype=torch.float32)
+        std = torch.tensor(self.std, device=self._device, dtype=torch.float32)
 
         x_norm = x - mean
         x_norm = x_norm / std


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request defines dtype of `mean` and `std` in `StandardisationMeanStdPyTorch`.

Fixes #889

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
