### PR TITLE
Implement method to apply adversarial patch onto a real-world surface

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@
 - Kyushu University
 - Intel Corporation
 - University of Chicago
+- The MITRE Corporation

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch.py
@@ -31,9 +31,9 @@ import numpy as np
 
 from art.attacks.evasion.adversarial_patch.adversarial_patch_numpy import AdversarialPatchNumpy
 from art.attacks.evasion.adversarial_patch.adversarial_patch_tensorflow import AdversarialPatchTensorFlowV2
+from art.attacks.evasion.adversarial_patch.utils import insert_transformed_patch
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin
 from art.estimators.classification.classifier import ClassifierMixin
-
 from art.estimators.classification import TensorFlowV2Classifier
 from art.attacks.attack import EvasionAttack
 
@@ -170,51 +170,18 @@ class AdversarialPatch(EvasionAttack):
         """
         self._attack.reset_patch(initial_patch_value=initial_patch_value)
 
-    def insert_transformed_patch(patch, image, image_coords):
+    def insert_transformed_patch(self, x: np.ndarray, patch: np.ndarray, image_coords: np.ndarray):
         """
-        Insert patch to image based on given or selected coordinates
+        Insert patch to image based on given or selected coordinates.
 
-        attributes::
-            patch
-                patch as numpy array
-            image
-                image as numpy array
-            image_coords
-                image coordinates patch coordinates will be mapped to [numpy array]
-                going in clockwise direction, starting with upper left corner
-
-        returns::
-            image with patch inserted
+        :param x: The images to insert the patch.
+        :param patch: The patch to be transformed and inserted.
+        :param image_coords: The coordinates of the 4 corners of the transformed, inserted patch of shape
+            [[x1, y1], [x2, y2], [x3, y3], [x4, y4]] in pixel units going in clockwise direction, starting with upper
+            left corner.
+        :return: The input `x` with the patch inserted.
         """
-
-        rows = patch.shape[0]
-        cols = patch.shape[1]
-        if image_coords.shape[0] == 4:
-            patch_coords = np.array([[0, 0], [cols - 1, 0], [cols - 1, rows - 1], [0, rows - 1]])
-        else:
-            patch_coords = np.array([[0, 0], [cols - 1, 0], [cols - 1, (rows - 1) // 2], \
-                                     [cols - 1, rows - 1], [0, rows - 1], [0, (rows - 1) // 2]])
-
-        # calculate homography
-        h, status = cv2.findHomography(patch_coords, image_coords)
-
-        # warp patch to destination coordinates
-        im_out = cv2.warpPerspective(patch, h, (image.shape[1], image.shape[0]),
-                                     cv2.INTER_CUBIC)
-        cv2.imwrite('im_out.jpg', im_out)
-
-        # mask to aid with insertion
-        mask = np.ones(patch.shape)
-        mask_out = cv2.warpPerspective(mask, h, (image.shape[1], image.shape[0]),
-                                       cv2.INTER_CUBIC)
-        cv2.imwrite('mask_out.jpg', mask_out * 255)
-
-        # save image before adding shadows
-        im_neg_patch = np.copy(image)
-        im_neg_patch[mask_out != 0] = 0  # negative of the patch space
-        im_out = im_neg_patch.astype('float32') + im_out.astype('float32')
-
-        return im_out
+        return self._attack.insert_transformed_patch(x, patch, image_coords)
 
     def set_params(self, **kwargs) -> None:
         super().set_params(**kwargs)

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch.py
@@ -26,12 +26,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 from typing import Optional, Tuple, Union, TYPE_CHECKING
 
-import cv2
 import numpy as np
 
 from art.attacks.evasion.adversarial_patch.adversarial_patch_numpy import AdversarialPatchNumpy
 from art.attacks.evasion.adversarial_patch.adversarial_patch_tensorflow import AdversarialPatchTensorFlowV2
-from art.attacks.evasion.adversarial_patch.utils import insert_transformed_patch
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin
 from art.estimators.classification.classifier import ClassifierMixin
 from art.estimators.classification import TensorFlowV2Classifier

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch.py
@@ -172,7 +172,7 @@ class AdversarialPatch(EvasionAttack):
         """
         Insert patch to image based on given or selected coordinates.
 
-        :param x: The images to insert the patch.
+        :param x: The image to insert the patch.
         :param patch: The patch to be transformed and inserted.
         :param image_coords: The coordinates of the 4 corners of the transformed, inserted patch of shape
             [[x1, y1], [x2, y2], [x3, y3], [x4, y4]] in pixel units going in clockwise direction, starting with upper

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
@@ -585,7 +585,7 @@ class AdversarialPatchNumpy(EvasionAttack):
         """
         Insert patch to image based on given or selected coordinates.
 
-        :param x: The images to insert the patch.
+        :param x: The image to insert the patch.
         :param patch: The patch to be transformed and inserted.
         :param image_coords: The coordinates of the 4 corners of the transformed, inserted patch of shape
             [[x1, y1], [x2, y2], [x3, y3], [x4, y4]] in pixel units going in clockwise direction, starting with upper

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
@@ -33,6 +33,7 @@ from scipy.ndimage import rotate, shift, zoom
 from tqdm.auto import trange
 
 from art.attacks.attack import EvasionAttack
+from art.attacks.evasion.adversarial_patch.utils import insert_transformed_patch
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin
 from art.estimators.classification.classifier import ClassifierMixin
 from art.utils import check_and_transform_label_format
@@ -578,3 +579,17 @@ class AdversarialPatchNumpy(EvasionAttack):
             self.patch = initial_patch_value
         else:
             raise ValueError("Unexpected value for initial_patch_value.")
+
+    @staticmethod
+    def insert_transformed_patch(x: np.ndarray, patch: np.ndarray, image_coords: np.ndarray):
+        """
+        Insert patch to image based on given or selected coordinates.
+
+        :param x: The images to insert the patch.
+        :param patch: The patch to be transformed and inserted.
+        :param image_coords: The coordinates of the 4 corners of the transformed, inserted patch of shape
+            [[x1, y1], [x2, y2], [x3, y3], [x4, y4]] in pixel units going in clockwise direction, starting with upper
+            left corner.
+        :return: The input `x` with the patch inserted.
+        """
+        return insert_transformed_patch(x, patch, image_coords)

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
@@ -31,6 +31,7 @@ import numpy as np
 from tqdm.auto import trange
 
 from art.attacks.attack import EvasionAttack
+from art.attacks.evasion.adversarial_patch.utils import insert_transformed_patch
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin
 from art.estimators.classification.classifier import ClassifierMixin
 from art.utils import check_and_transform_label_format, is_probability
@@ -495,3 +496,17 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
             self._patch.assign(initial_patch_value)
         else:
             raise ValueError("Unexpected value for initial_patch_value.")
+
+    @staticmethod
+    def insert_transformed_patch(x: np.ndarray, patch: np.ndarray, image_coords: np.ndarray):
+        """
+        Insert patch to image based on given or selected coordinates.
+
+        :param x: The images to insert the patch.
+        :param patch: The patch to be transformed and inserted.
+        :param image_coords: The coordinates of the 4 corners of the transformed, inserted patch of shape
+            [[x1, y1], [x2, y2], [x3, y3], [x4, y4]] in pixel units going in clockwise direction, starting with upper
+            left corner.
+        :return: The input `x` with the patch inserted.
+        """
+        return insert_transformed_patch(x, patch, image_coords)

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
@@ -502,7 +502,7 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
         """
         Insert patch to image based on given or selected coordinates.
 
-        :param x: The images to insert the patch.
+        :param x: The image to insert the patch.
         :param patch: The patch to be transformed and inserted.
         :param image_coords: The coordinates of the 4 corners of the transformed, inserted patch of shape
             [[x1, y1], [x2, y2], [x3, y3], [x4, y4]] in pixel units going in clockwise direction, starting with upper

--- a/art/attacks/evasion/adversarial_patch/utils.py
+++ b/art/attacks/evasion/adversarial_patch/utils.py
@@ -1,0 +1,84 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2021
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import numpy as np
+
+
+def insert_transformed_patch(x: np.ndarray, patch: np.ndarray, image_coords: np.ndarray):
+    """
+    Insert patch to image based on given or selected coordinates.
+
+    :param x: A single image of shape HWC to insert the patch.
+    :param patch: The patch to be transformed and inserted.
+    :param image_coords: The coordinates of the 4 corners of the transformed, inserted patch of shape
+            [[x1, y1], [x2, y2], [x3, y3], [x4, y4]] in pixel units going in clockwise direction, starting with upper
+            left corner.
+    :return: The input `x` with the patch inserted.
+    """
+    import cv2
+
+    scaling = False
+
+    if np.max(x) <= 1.0:
+        scaling = True
+        x = (x * 255).astype(np.uint8)
+        patch = (patch * 255).astype(np.uint8)
+
+    rows = patch.shape[0]
+    cols = patch.shape[1]
+
+    if image_coords.shape[0] == 4:
+        patch_coords = np.array([[0, 0], [cols - 1, 0], [cols - 1, rows - 1], [0, rows - 1]])
+    else:
+        patch_coords = np.array(
+            [
+                [0, 0],
+                [cols - 1, 0],
+                [cols - 1, (rows - 1) // 2],
+                [cols - 1, rows - 1],
+                [0, rows - 1],
+                [0, (rows - 1) // 2],
+            ]
+        )
+
+    # calculate homography
+    h, status = cv2.findHomography(patch_coords, image_coords)
+
+    # warp patch to destination coordinates
+    x_out = cv2.warpPerspective(patch, h, (x.shape[1], x.shape[0]), cv2.INTER_CUBIC)
+    # cv2.imwrite("im_out.jpg", x_out)
+
+    # mask to aid with insertion
+    mask = np.ones(patch.shape)
+    mask_out = cv2.warpPerspective(mask, h, (x.shape[1], x.shape[0]), cv2.INTER_CUBIC)
+    # cv2.imwrite("mask_out.jpg", mask_out * 255)
+
+    # save image before adding shadows
+    x_neg_patch = np.copy(x)
+    x_neg_patch[mask_out != 0] = 0  # negative of the patch space
+
+    if x_neg_patch.shape[2] == 1:
+        x_out = np.expand_dims(x_out, axis=2)
+
+    x_out = x_neg_patch.astype("float32") + x_out.astype("float32")
+
+    if scaling:
+        x_out = x_out / 255
+
+    # cv2.imwrite("im_out_2.jpg", x_out)
+
+    return x_out

--- a/art/attacks/evasion/adversarial_patch/utils.py
+++ b/art/attacks/evasion/adversarial_patch/utils.py
@@ -60,12 +60,10 @@ def insert_transformed_patch(x: np.ndarray, patch: np.ndarray, image_coords: np.
 
     # warp patch to destination coordinates
     x_out = cv2.warpPerspective(patch, h, (x.shape[1], x.shape[0]), cv2.INTER_CUBIC)
-    # cv2.imwrite("im_out.jpg", x_out)
 
     # mask to aid with insertion
     mask = np.ones(patch.shape)
     mask_out = cv2.warpPerspective(mask, h, (x.shape[1], x.shape[0]), cv2.INTER_CUBIC)
-    # cv2.imwrite("mask_out.jpg", mask_out * 255)
 
     # save image before adding shadows
     x_neg_patch = np.copy(x)
@@ -78,7 +76,5 @@ def insert_transformed_patch(x: np.ndarray, patch: np.ndarray, image_coords: np.
 
     if scaling:
         x_out = x_out / 255
-
-    # cv2.imwrite("im_out_2.jpg", x_out)
 
     return x_out

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ ffmpeg-python==0.2.0
 cma==3.0.3
 pandas==1.1.4
 numba~=0.52.0
+opencv-python
 
 # frameworks
 h5py==2.10.0

--- a/tests/attacks/test_adversarial_patch.py
+++ b/tests/attacks/test_adversarial_patch.py
@@ -82,6 +82,45 @@ class TestAdversarialPatch(TestBase):
             self.assertAlmostEqual(patch_adv[14, 14, 0], 0.6292826, delta=0.05)
             self.assertAlmostEqual(float(np.sum(patch_adv)), 424.31439208984375, delta=1.0)
 
+        # insert_transformed_patch
+        x_out = attack_ap.insert_transformed_patch(
+            self.x_train_mnist[0], np.ones((14, 14, 1)), np.asarray([[2, 13], [2, 18], [12, 22], [8, 13]])
+        )
+        x_out_expexted = np.array(
+            [
+                0.0,
+                0.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                0.84313726,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.1764706,
+                0.7294118,
+                0.99215686,
+                0.99215686,
+                0.5882353,
+                0.10588235,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ],
+            dtype=np.float32,
+        )
+        np.testing.assert_almost_equal(x_out[15, :, 0], x_out_expexted, decimal=3)
+
         if sess is not None:
             sess.close()
 
@@ -111,6 +150,45 @@ class TestAdversarialPatch(TestBase):
         self.assertAlmostEqual(patch_adv[14, 14, 0], 0.0, delta=0.05)
         self.assertAlmostEqual(float(np.sum(patch_adv)), 377.415771484375, delta=1.0)
 
+        # insert_transformed_patch
+        x_out = attack_ap.insert_transformed_patch(
+            self.x_train_mnist[0], np.ones((14, 14, 1)), np.asarray([[2, 13], [2, 18], [12, 22], [8, 13]])
+        )
+        x_out_expexted = np.array(
+            [
+                0.0,
+                0.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                0.84313726,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.1764706,
+                0.7294118,
+                0.99215686,
+                0.99215686,
+                0.5882353,
+                0.10588235,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ],
+            dtype=np.float32,
+        )
+        np.testing.assert_almost_equal(x_out[15, :, 0], x_out_expexted, decimal=3)
+
     @unittest.skipIf(
         int(keras.__version__.split(".")[0]) == 2 and int(keras.__version__.split(".")[1]) < 3,
         reason="Skip unittests if not Keras>=2.3.",
@@ -132,6 +210,45 @@ class TestAdversarialPatch(TestBase):
         self.assertAlmostEqual(patch_adv[8, 8, 0], 0.67151666, delta=0.05)
         self.assertAlmostEqual(patch_adv[14, 14, 0], 0.6292826, delta=0.05)
         self.assertAlmostEqual(float(np.sum(patch_adv)), 424.31439208984375, delta=1.0)
+
+        # insert_transformed_patch
+        x_out = attack_ap.insert_transformed_patch(
+            self.x_train_mnist[0], np.ones((14, 14, 1)), np.asarray([[2, 13], [2, 18], [12, 22], [8, 13]])
+        )
+        x_out_expexted = np.array(
+            [
+                0.0,
+                0.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                0.84313726,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.1764706,
+                0.7294118,
+                0.99215686,
+                0.99215686,
+                0.5882353,
+                0.10588235,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ],
+            dtype=np.float32,
+        )
+        np.testing.assert_almost_equal(x_out[15, :, 0], x_out_expexted, decimal=3)
 
     def test_4_pytorch(self):
         """


### PR DESCRIPTION
# Description

This pull request adds a method to apply the patch to coordinates after perspective transformation. These coordinates can be the coordinates of a real-world, quadratic surface in the targeted image.

Thank you to @yusong-tan for sharing the code!

Fixes #853 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
