### PR TITLE
899 updated MembershipInferenceBlackBox#infer to have CUDA support

### DIFF
--- a/art/utils.py
+++ b/art/utils.py
@@ -36,6 +36,7 @@ import numpy as np
 from scipy.special import gammainc
 import six
 from tqdm.auto import tqdm
+from torch import Tensor
 
 from art import config
 
@@ -1235,3 +1236,34 @@ def pad_sequence_input(x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         x_padded[i, : len(x_i)] = x_i
         x_mask[i, : len(x_i)] = 1
     return x_padded, x_mask
+
+
+# -------------------------------------------------------------------------------------------------------- CUDA SUPPORT
+
+
+def to_cuda(x: Tensor) -> Tensor:
+    """
+    Move the tensor from the CPU to the GPU if a GPU is available.
+
+    :param x: CPU Tensor to move to GPU if available.
+    :return: The CPU Tensor moved to a GPU Tensor.
+    """
+    from torch.cuda import is_available
+    use_cuda = is_available()
+    if use_cuda:
+        x = x.cuda()
+    return x
+
+
+def from_cuda(x: Tensor) -> Tensor:
+    """
+    Move the tensor from the GPU to the CPU if a GPU is available.
+
+    :param x: GPU Tensor to move to CPU if available.
+    :return: The GPU Tensor moved to a CPU Tensor.
+    """
+    from torch.cuda import is_available
+    use_cuda = is_available()
+    if use_cuda:
+        x = x.cpu()
+    return x


### PR DESCRIPTION
Signed-off-by: Evan Sakmar <sakmarev@ctc.com>

# Description

Added two helper methods to_cuda and from_cuda to assist in moving the tensors to and from CUDA.  Updated the logic to move those tensors when appropriate.

Fixes #899

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

I ran through each of these steps
- Ran through the notebooks/attack_membership_inference.ipynb notebook in a CUDA enable instance and compared it to the results of the notebook run on a CPU only instance.
- Ran  the membership inference tests on a CUDA enabled instance and CPU only instance and ensured that all tests passed.

**Test Configuration**:
- OS: Ubuntu 18.04
- CUDA: 10.1
- Python version: 3.6.9
- TensorFlow / Keras / PyTorch / MXNet version: TensorFlow 2.4, Keras 2.4.3 torch 1.6.0+cu92, MXNet 1.6.0

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
#- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
#- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
