### PR TITLE
Extend Image Trigger Functionality

### DIFF
--- a/art/attacks/poisoning/clean_label_backdoor_attack.py
+++ b/art/attacks/poisoning/clean_label_backdoor_attack.py
@@ -130,7 +130,7 @@ class PoisoningAttackCleanLabelBackdoor(PoisoningAttackBlackBox):
         if any(no_change_detected):
             logger.warning("Perturbed input is the same as original data after PGD. Check params.")
             idx_no_change = np.arange(len(no_change_detected))[no_change_detected]
-            logger.warning(f"Indices without change: {idx_no_change}")
+            logger.warning(f"{len(idx_no_change)} indices without change: {idx_no_change}")
 
         # Add backdoor and poison with the same label
         poisoned_input, _ = self.backdoor.poison(perturbed_input, self.target, broadcast=True)

--- a/art/attacks/poisoning/clean_label_backdoor_attack.py
+++ b/art/attacks/poisoning/clean_label_backdoor_attack.py
@@ -123,7 +123,6 @@ class PoisoningAttackCleanLabelBackdoor(PoisoningAttackBlackBox):
 
         # Run untargeted PGD on selected points, making it hard to classify correctly
         perturbed_input = self.attack.generate(data[selected_indices])
-        logger.warning(f"perturbed input shape: {perturbed_input.shape}")
         no_change_detected = np.array([np.all(data[selected_indices][poison_idx] == perturbed_input[poison_idx])
                                        for poison_idx in range(len(perturbed_input))])
 

--- a/art/attacks/poisoning/clean_label_backdoor_attack.py
+++ b/art/attacks/poisoning/clean_label_backdoor_attack.py
@@ -123,9 +123,14 @@ class PoisoningAttackCleanLabelBackdoor(PoisoningAttackBlackBox):
 
         # Run untargeted PGD on selected points, making it hard to classify correctly
         perturbed_input = self.attack.generate(data[selected_indices])
+        logger.warning(f"perturbed input shape: {perturbed_input.shape}")
+        no_change_detected = np.array([np.all(data[selected_indices][poison_idx] == perturbed_input[poison_idx])
+                                       for poison_idx in range(len(perturbed_input))])
 
-        if np.all(data[selected_indices] == perturbed_input, axis=1):
+        if any(no_change_detected):
             logger.warning("Perturbed input is the same as original data after PGD. Check params.")
+            idx_no_change = np.arange(len(no_change_detected))[no_change_detected]
+            logger.warning(f"Indices without change: {idx_no_change}")
 
         # Add backdoor and poison with the same label
         poisoned_input, _ = self.backdoor.poison(perturbed_input, self.target, broadcast=True)

--- a/art/attacks/poisoning/clean_label_backdoor_attack.py
+++ b/art/attacks/poisoning/clean_label_backdoor_attack.py
@@ -124,6 +124,9 @@ class PoisoningAttackCleanLabelBackdoor(PoisoningAttackBlackBox):
         # Run untargeted PGD on selected points, making it hard to classify correctly
         perturbed_input = self.attack.generate(data[selected_indices])
 
+        if np.all(data[selected_indices] == perturbed_input, axis=1):
+            logger.warning("Perturbed input is the same as original data after PGD. Check params.")
+
         # Add backdoor and poison with the same label
         poisoned_input, _ = self.backdoor.poison(perturbed_input, self.target, broadcast=True)
         data[selected_indices] = poisoned_input

--- a/art/attacks/poisoning/perturbations/image_perturbations.py
+++ b/art/attacks/poisoning/perturbations/image_perturbations.py
@@ -121,7 +121,11 @@ def insert_image(
     if n_dim != 3:
         raise ValueError("Invalid array shape " + str(x.shape))
 
-    width, height, num_channels = x.shape
+    if channels_first:
+        num_channels, width, height = x.shape
+    else:
+        width, height, num_channels = x.shape
+
     no_color = num_channels == 1
     orig_img = Image.new('RGBA', (width, height), 0)
     backdoored_img = Image.new('RGBA', (width, height), 0)

--- a/art/attacks/poisoning/perturbations/image_perturbations.py
+++ b/art/attacks/poisoning/perturbations/image_perturbations.py
@@ -86,48 +86,75 @@ def add_pattern_bd(x: np.ndarray, distance: int = 2, pixel_value: int = 1) -> np
 
 
 def insert_image(
-    x: np.ndarray,
-    backdoor_path: str = "../utils/data/backdoors/alert.png",
-    random: bool = True,
-    x_shift: int = 0,
-    y_shift: int = 0,
-    size: Optional[Tuple[int, int]] = None,
-    mode: str = "L",
+        x: np.ndarray,
+        backdoor_path: str = "../utils/data/backdoors/alert.png",
+        channels_first: bool = False,
+        random: bool = True,
+        x_shift: int = 0,
+        y_shift: int = 0,
+        size: Optional[Tuple[int, int]] = None,
+        mode: str = "L",
+        blend=0.6
 ) -> np.ndarray:
     """
     Augments a matrix by setting a checkboard-like pattern of values some `distance` away from the bottom-right
     edge to 1. Works for single images or a batch of images.
 
-    :param x: N X W X H matrix or W X H matrix.
-    :param backdoor_path: The path to the image to insert as a backdoor.
+    :param x: N x W x H x C or N x C x W x H or N x W x H x C matrix or W x H x C matrix.
+    :param backdoor_path: The path to the image to insert as a trigger.
+    :param channels_first: Whether the channels axis is in the first or last dimension
     :param random: Whether or not the image should be randomly placed somewhere on the image.
-    :param x_shift: Number of pixels from the left to shift the backdoor (when not using random placement).
-    :param y_shift: Number of pixels from the right to shift the backdoor (when not using random placement).
-    :param size: The size the backdoor image should be (width, height). Default `None` if no resizing necessary.
+    :param x_shift: Number of pixels from the left to shift the trigger (when not using random placement).
+    :param y_shift: Number of pixels from the right to shift the trigger (when not using random placement).
+    :param size: The size the trigger image should be (width, height). Default `None` if no resizing necessary.
     :param mode: The mode the image should be read in. See PIL documentation
                  (https://pillow.readthedocs.io/en/stable/handbook/concepts.html#concept-modes).
+    :param blend: The blending factor
     :return: Backdoored image.
     """
-    if len(x.shape) == 3:
-        return np.array([insert_image(single_img, backdoor_path, random, x_shift, y_shift, size) for single_img in x])
+    n_dim = len(x.shape)
+    if n_dim == 4:
+        return np.array(
+            [insert_image(single_img, backdoor_path, channels_first, random, x_shift, y_shift, size, mode, blend)
+             for single_img in x])
 
-    if len(x.shape) != 2:
+    if n_dim != 3:
         raise ValueError("Invalid array shape " + str(x.shape))
 
-    backdoor = Image.open(backdoor_path)
-    backdoored_input = Image.fromarray(np.copy(x), mode=mode)
+    width, height, num_channels = x.shape
+    no_color = num_channels == 1
+    orig_img = Image.new('RGBA', (width, height), 0)
+    backdoored_img = Image.new('RGBA', (width, height), 0)
 
+    if no_color:
+        backdoored_input = Image.fromarray(np.copy(x).astype('uint8').squeeze(axis=2), mode=mode)
+    else:
+        backdoored_input = Image.fromarray(np.copy(x).astype('uint8'), mode=mode)
+
+    orig_img.paste(backdoored_input)
+
+    trigger = Image.open(backdoor_path).convert('RGBA')
     if size:
-        backdoor = backdoor.resize(size).convert(mode=mode)
+        trigger = trigger.resize(size)
 
-    backdoor_width, backdoor_height = backdoor.size
-    orig_width, orig_height = backdoored_input.size
+    backdoor_width, backdoor_height = trigger.size
 
-    if backdoor_width > orig_width or backdoor_height > orig_height:
+    if backdoor_width > width or backdoor_height > height:
         raise ValueError("Backdoor does not fit inside original image")
 
     if random:
-        x_shift = np.random.randint(orig_width - backdoor_width)
-        y_shift = np.random.randint(orig_height - backdoor_height)
-    backdoored_input.paste(backdoor, box=(x_shift, y_shift))
-    return np.array(backdoored_input)
+        x_shift = np.random.randint(width - backdoor_width)
+        y_shift = np.random.randint(height - backdoor_height)
+
+    backdoored_img.paste(trigger, (x_shift, y_shift), mask=trigger)
+    composite = Image.alpha_composite(orig_img, backdoored_img)
+    backdoored_img = Image.blend(backdoored_img, composite, blend)
+
+    backdoored_img = backdoored_img.convert(mode)
+
+    res = np.array(backdoored_img)
+
+    if no_color:
+        res = np.expand_dims(res, 2)
+
+    return res

--- a/art/attacks/poisoning/perturbations/image_perturbations.py
+++ b/art/attacks/poisoning/perturbations/image_perturbations.py
@@ -100,7 +100,7 @@ def insert_image(
     Augments a matrix by setting a checkboard-like pattern of values some `distance` away from the bottom-right
     edge to 1. Works for single images or a batch of images.
 
-    :param x: N x W x H x C or N x C x W x H or N x W x H x C matrix or W x H x C matrix.
+    :param x: N x W x H x C or N x C x W x H or N x W x H x C matrix or W x H x C matrix. X is in range [0,1]
     :param backdoor_path: The path to the image to insert as a trigger.
     :param channels_first: Whether the channels axis is in the first or last dimension
     :param random: Whether or not the image should be randomly placed somewhere on the image.
@@ -131,9 +131,9 @@ def insert_image(
     backdoored_img = Image.new('RGBA', (width, height), 0)
 
     if no_color:
-        backdoored_input = Image.fromarray(np.copy(x).astype('uint8').squeeze(axis=2), mode=mode)
+        backdoored_input = Image.fromarray(np.copy(x * 255).astype('uint8').squeeze(axis=2), mode=mode)
     else:
-        backdoored_input = Image.fromarray(np.copy(x).astype('uint8'), mode=mode)
+        backdoored_input = Image.fromarray(np.copy(x * 255).astype('uint8'), mode=mode)
 
     orig_img.paste(backdoored_input)
 
@@ -156,7 +156,7 @@ def insert_image(
 
     backdoored_img = backdoored_img.convert(mode)
 
-    res = np.array(backdoored_img)
+    res = np.array(backdoored_img) / 255.0
 
     if no_color:
         res = np.expand_dims(res, 2)

--- a/art/attacks/poisoning/perturbations/image_perturbations.py
+++ b/art/attacks/poisoning/perturbations/image_perturbations.py
@@ -94,7 +94,7 @@ def insert_image(
         y_shift: int = 0,
         size: Optional[Tuple[int, int]] = None,
         mode: str = "L",
-        blend=0.6
+        blend=0.8,
 ) -> np.ndarray:
     """
     Augments a matrix by setting a checkboard-like pattern of values some `distance` away from the bottom-right

--- a/art/attacks/poisoning/perturbations/image_perturbations.py
+++ b/art/attacks/poisoning/perturbations/image_perturbations.py
@@ -121,19 +121,20 @@ def insert_image(
     if n_dim != 3:
         raise ValueError("Invalid array shape " + str(x.shape))
 
+    data = np.copy(x)
     if channels_first:
-        num_channels, width, height = x.shape
-    else:
-        width, height, num_channels = x.shape
+        data = data.transpose([2, 0, 1])
+
+    width, height, num_channels = x.shape
 
     no_color = num_channels == 1
     orig_img = Image.new('RGBA', (width, height), 0)
     backdoored_img = Image.new('RGBA', (width, height), 0)
 
     if no_color:
-        backdoored_input = Image.fromarray(np.copy(x * 255).astype('uint8').squeeze(axis=2), mode=mode)
+        backdoored_input = Image.fromarray((data * 255).astype('uint8').squeeze(axis=2), mode=mode)
     else:
-        backdoored_input = Image.fromarray(np.copy(x * 255).astype('uint8'), mode=mode)
+        backdoored_input = Image.fromarray((data * 255).astype('uint8'), mode=mode)
 
     orig_img.paste(backdoored_input)
 
@@ -160,5 +161,8 @@ def insert_image(
 
     if no_color:
         res = np.expand_dims(res, 2)
+
+    if channels_first:
+        res = res.transpose([2, 0, 1])
 
     return res

--- a/art/attacks/poisoning/perturbations/image_perturbations.py
+++ b/art/attacks/poisoning/perturbations/image_perturbations.py
@@ -153,7 +153,7 @@ def insert_image(
 
     backdoored_img.paste(trigger, (x_shift, y_shift), mask=trigger)
     composite = Image.alpha_composite(orig_img, backdoored_img)
-    backdoored_img = Image.blend(backdoored_img, composite, blend)
+    backdoored_img = Image.blend(orig_img, composite, blend)
 
     backdoored_img = backdoored_img.convert(mode)
 

--- a/notebooks/poisoning_attack_backdoor_image.ipynb
+++ b/notebooks/poisoning_attack_backdoor_image.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Creating Image Trigger Poison Samples with ART\n",
+    "\n",
+    "This notebook shows how to create image triggers in ART with RBG and grayscale images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import os, sys\n",
+    "%matplotlib inline\n",
+    "\n",
+    "module_path = os.path.abspath(os.path.join('..'))\n",
+    "if module_path not in sys.path:\n",
+    "    sys.path.append(module_path)\n",
+    "\n",
+    "from art.estimators.classification import KerasClassifier\n",
+    "from art.attacks.poisoning import PoisoningAttackBackdoor\n",
+    "from art.attacks.poisoning.perturbations import add_pattern_bd, add_single_bd, insert_image\n",
+    "from art.utils import load_mnist, preprocess, load_cifar10\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(x_raw, y_raw), (x_raw_test, y_raw_test), min_, max_ = load_mnist()\n",
+    "\n",
+    "# Random Selection:\n",
+    "n_train = np.shape(x_raw)[0]\n",
+    "num_selection = 7500\n",
+    "random_selection_indices = np.random.choice(n_train, num_selection)\n",
+    "x_raw = x_raw[random_selection_indices]\n",
+    "y_raw = y_raw[random_selection_indices]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "idx = 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Note the shape of `x_raw`, black and white images must still have a color channel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x_raw shape: (7500, 28, 28, 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"x_raw shape: {x_raw.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7ff4715ed6a0>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAM20lEQVR4nO3db4xc9XXG8efBrNeJsYNdY+MaN6TUUYqq1qQrU9VVRYQSEVeV4UUqrDQyFa1TNaikjapS+gJLfeNGTVAkoihLsWIiCopEEG6KEoyVCKVKHdbI9Z+6qSl1ieON16lT2dBgr3dPX+wl2pid3ywzd+YOPt+PtJqZe+bOPbrw+N6Z39z5OSIE4PJ3RdMNAOgPwg4kQdiBJAg7kARhB5K4sp8bW+jhWKTF/dwkkMrrek0X4rznqnUVdtu3SfqcpAWS/j4idpSev0iLdbNv7WaTAAr2xd6WtY5P420vkPR5SR+WdKOkLbZv7PT1APRWN+/ZN0h6KSJejogLkp6QtLmetgDUrZuwr5H0/VmPT1TLfobtbbbHbI9N6nwXmwPQjW7CPteHAG/67m1EjEbESESMDGm4i80B6EY3YT8hae2sx9dJOtldOwB6pZuwvyBpne332F4o6U5Ju+tpC0DdOh56i4iLtu+R9A3NDL3tjIgjtXUGoFZdjbNHxDOSnqmpFwA9xNdlgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0l0NWWz7eOSzkmaknQxIkbqaApA/boKe+UDEfGjGl4HQA9xGg8k0W3YQ9Kztvfb3jbXE2xvsz1me2xS57vcHIBOdXsavzEiTtpeKWmP7X+PiOdnPyEiRiWNStJSL48utwegQ10d2SPiZHU7IekpSRvqaApA/ToOu+3Ftpe8cV/ShyQdrqsxAPXq5jR+laSnbL/xOv8QEV+vpSsAtes47BHxsqRfq7EXAD3E0BuQBGEHkiDsQBKEHUiCsANJ1HEhTHqvbP/NYv1rf/DpYv2GoavKr3/x1WL9g1/+i5a1X3rov4rrxoULxfrU/5wp1q9YsqRYnz53rlhH/3BkB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkGGevwesrLxbrv3DlO4r1yZgq1lcvKK9/+K6HWhfvKq6q3a8tK9b/av8dxfrvvvdQsf7Ukfe3rL3vb18rrjt15HvFOt4ajuxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kIQj+jdJy1Ivj5t9a9+21y8//qd1xfo/r3+iWJ/WdLH+ndeHi/WNiyaL9UF1auonxfpH/+TPi/VFX/tune1cFvbFXp2NM56rxpEdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5LgevYaXPXg0mJ945/dWaz/+MiKYv36f3y9WB/+mx8W6yXrrz5RrD9wzYGOX7udVW2u0z+3dkGxvqjOZhJoe2S3vdP2hO3Ds5Ytt73H9rHqtvwLCAAaN5/T+C9Juu2SZfdJ2hsR6yTtrR4DGGBtwx4Rz0u6dA6gzZJ2Vfd3Sbq95r4A1KzTD+hWRcS4JFW3K1s90fY222O2xyZ1vsPNAehWzz+Nj4jRiBiJiJEhlS/oANA7nYb9lO3VklTdTtTXEoBe6DTsuyVtre5vlfR0Pe0A6JW24+y2H5d0i6QVtk9IekDSDklfsX23pFckfaSXTQ66oef2F+vLniuvv0zHutr+5C2dr/viNdcW65ve94fF+o5Hv1is/+rC8lg5+qdt2CNiS4vS5fcrFMBljK/LAkkQdiAJwg4kQdiBJAg7kASXuCY3dfp0se73rinWr77iQpstlC9jRf9wZAeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJBhnR1FcMefsvz/F0eLtg/9WQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AE4+womvj18vXo113J9epvFxzZgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4k0TbstnfanrB9eNay7bZ/YPtA9bept20C6NZ8juxfknTbHMsfjIj11d8z9bYFoG5twx4Rz0s604deAPRQN+/Z77F9sDrNX9bqSba32R6zPTap811sDkA3Og37FyTdIGm9pHFJn2n1xIgYjYiRiBgZ0nCHmwPQrY7CHhGnImIqIqYlPSxpQ71tAahbR2G3vXrWwzskHW71XACDoe317LYfl3SLpBW2T0h6QNItttdLCknHJX28hz2iQf/389Gz197f5iOca587VaxP1dhLBm3DHhFb5lj8SA96AdBDfIMOSIKwA0kQdiAJwg4kQdiBJPgpaRT96e/07hqnH069q1ifOvZyz7adEUd2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCcXYUff7J8g8H//HdD3X82h94x+lifcdHf79Yf9dj/9LxtjPiyA4kQdiBJAg7kARhB5Ig7EAShB1IgrADSTDOjqLhM+7Za7/TC4v1C0t7t+2MOLIDSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKMs6MxGw/cWaxf88Xv9qmTHNoe2W2vtf1N20dtH7F9b7V8ue09to9Vt8t63y6ATs3nNP6ipE9FxC9L+g1Jn7B9o6T7JO2NiHWS9laPAQyotmGPiPGIeLG6f07SUUlrJG2WtKt62i5Jt/eqSQDde0sf0Nm+XtJNkvZJWhUR49LMPwiSVrZYZ5vtMdtjkzrfXbcAOjbvsNu+StKTkj4ZEWfnu15EjEbESESMDGm4kx4B1GBeYbc9pJmgPxYRX60Wn7K9uqqvljTRmxYB1KHt0JttS3pE0tGI+Oys0m5JWyXtqG6f7kmHuGz979l3FuvLpqf61EkO8xln3yjpY5IO2T5QLbtfMyH/iu27Jb0i6SO9aRFAHdqGPSK+LanVrwjcWm87AHqFr8sCSRB2IAnCDiRB2IEkCDuQBJe4oqcmo/VY+ZJvlcfZUS+O7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBOPs6KlpTbesXfmTPjYCjuxAFoQdSIKwA0kQdiAJwg4kQdiBJAg7kATj7OipYQ+1rL16XasfLZ5xdd3NJMeRHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSmM/87GslPSrpWknTkkYj4nO2t0v6I0mnq6feHxHP9KpRvD3de3Jjy9q7Hz5WXJfZ2es1ny/VXJT0qYh40fYSSftt76lqD0bE3/WuPQB1mc/87OOSxqv752wflbSm140BqNdbes9u+3pJN0naVy26x/ZB2zttL2uxzjbbY7bHJnW+q2YBdG7eYbd9laQnJX0yIs5K+oKkGySt18yR/zNzrRcRoxExEhEjQxquoWUAnZhX2G0PaSboj0XEVyUpIk5FxFRETEt6WNKG3rUJoFttw27bkh6RdDQiPjtr+epZT7tD0uH62wNQl/l8Gr9R0sckHbJ9oFp2v6QtttdLCknHJX28Jx2iUSsOlj9nGZ8q/x70s9+6qWXthtPf6agndGY+n8Z/W9JcFx4zpg68jfANOiAJwg4kQdiBJAg7kARhB5Ig7EASjoi+bWypl8fNvrVv2wOy2Rd7dTbOzPkb3RzZgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiCJvo6z2z4t6b9nLVoh6Ud9a+CtGdTeBrUvid46VWdv746Ia+Yq9DXsb9q4PRYRI401UDCovQ1qXxK9dapfvXEaDyRB2IEkmg77aMPbLxnU3ga1L4neOtWX3hp9zw6gf5o+sgPoE8IOJNFI2G3fZvt7tl+yfV8TPbRi+7jtQ7YP2B5ruJedtidsH561bLntPbaPVbdzzrHXUG/bbf+g2ncHbG9qqLe1tr9p+6jtI7bvrZY3uu8KffVlv/X9PbvtBZL+Q9IHJZ2Q9IKkLRHxb31tpAXbxyWNRETjX8Cw/duSXpX0aET8SrXs05LORMSO6h/KZRHxlwPS23ZJrzY9jXc1W9Hq2dOMS7pd0l1qcN8V+vo99WG/NXFk3yDppYh4OSIuSHpC0uYG+hh4EfG8pDOXLN4saVd1f5dm/mfpuxa9DYSIGI+IF6v75yS9Mc14o/uu0FdfNBH2NZK+P+vxCQ3WfO8h6Vnb+21va7qZOayKiHFp5n8eSSsb7udSbafx7qdLphkfmH3XyfTn3Woi7HP9PtYgjf9tjIj3S/qwpE9Up6uYn3lN490vc0wzPhA6nf68W02E/YSktbMeXyfpZAN9zCkiTla3E5Ke0uBNRX3qjRl0q9uJhvv5qUGaxnuuacY1APuuyenPmwj7C5LW2X6P7YWS7pS0u4E+3sT24uqDE9leLOlDGrypqHdL2lrd3yrp6QZ7+RmDMo13q2nG1fC+a3z684jo+5+kTZr5RP4/Jf11Ez206OsXJf1r9Xek6d4kPa6Z07pJzZwR3S3p5yTtlXSsul0+QL19WdIhSQc1E6zVDfX2W5p5a3hQ0oHqb1PT+67QV1/2G1+XBZLgG3RAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kMT/A0HY0pKcpkanAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(x_raw[idx].squeeze())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7ff471611c50>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAMwElEQVR4nO3df4wcdRnH8c/HclzhaLWVUi5tBUQ0EBOrXoqxxmCIBolJ8Q8NjZqqxKqBqPFHJPgHJP6DP8CYYIwnNBaDqAkiNSFqvRCJiVaupEKxahErlp49TDEtKu31+vjHDXqW3dljZ3Zn8Xm/ksvuzrO782TTT2d2vjP7dUQIwP+/FzXdAID+IOxAEoQdSIKwA0kQdiCJU/q5slM9HIs10s9VAqk8o3/oWBx1q1qlsNu+TNJXJS2SdGtE3Fj2/MUa0cW+tMoqAZTYERNta13vxtteJOlrkt4u6SJJG21f1O37AeitKt/Z10l6NCIei4hjkr4raUM9bQGoW5Wwr5L0l3mP9xfL/oftzbYnbU/O6GiF1QGookrYWx0EeM65txExHhFjETE2pOEKqwNQRZWw75e0Zt7j1ZIOVGsHQK9UCfsDki6wfZ7tUyVdKWlbPW0BqFvXQ28Rcdz2NZJ+ormhty0R8UhtnQGoVaVx9oi4V9K9NfUCoIc4XRZIgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQRKUpm23vk3RE0qyk4xExVkdTAOpXKeyFt0TE32p4HwA9xG48kETVsIekn9reaXtzqyfY3mx70vbkjI5WXB2AblXdjV8fEQdsnyVpu+3fRcT9858QEeOSxiVpqZdHxfUB6FKlLXtEHChupyXdLWldHU0BqF/XYbc9YnvJs/clvU3S7roaA1CvKrvxKyXdbfvZ9/lORPy4lq4A1K7rsEfEY5JeU2MvAHqIoTcgCcIOJEHYgSQIO5AEYQeSqONCmPQev/6NpfV7Pvil0vorh0bK3//406X1t97+mba1V9zyWOlr4+ix0vrsU0+V1j083OH9OUV6ULBlB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkGGevwTMrj5fWzztlcWl9JmZL66OLTiut7/7ALe2LHyh9qS688+rS+vmf/lVpfeqjry+tj0ydaFtb8r3y90a92LIDSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKMs9dgxTnl13x3ckLtx6Il6ZfPlF8zvn7xTNvazg6Xk7/i2snSeqcpfGaWlNf/vqT99qTDS1EztuxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kATj7DVYcvPS0vr6T15ZWn9q95ml9XN/9K/S+tDnp9vW/nHT6tLXLj7+69J6J6cd7DQSj0HRcctue4vtadu75y1bbnu77b3F7bLetgmgqoXsxn9L0mUnLbtW0kREXCBpongMYIB1DHtE3C/p0EmLN0jaWtzfKumKmvsCULNuD9CtjIgpSSpuz2r3RNubbU/anpwR834BTen50fiIGI+IsYgYG1L5BR0AeqfbsB+0PSpJxW37w8EABkK3Yd8maVNxf5Oke+ppB0CvOKJ8nNT2nZIukXSmpIOSrpf0Q0nfl/QySY9LeldEnHwQ7zmWenlc7Esrtow6LVpafo5AnLeqtH7kC+XHYc4eOdy2tnhR+e/t77vpVaX1kbt2lNYz2hETOhyH3KrW8aSaiNjYpkRqgRcQTpcFkiDsQBKEHUiCsANJEHYgCS5xTW72cPuhMUmKM15eWt9y4a2l9U7TVZe5eMWFpfWRrt85J7bsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AE4+woFS0vlvyvoY6TOmNQsGUHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQYZ0ep6bHTS+urTzmtT52gKrbsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeS6Bh221tsT9vePW/ZDbafsL2r+Lu8t20CqGohW/ZvSbqsxfKvRMTa4u/eetsCULeOYY+I+yUd6kMvAHqoynf2a2w/VOzmL2v3JNubbU/anpzR0QqrA1BFt2H/uqTzJa2VNCXppnZPjIjxiBiLiLEhDXe5OgBVdRX2iDgYEbMRcULSNyWtq7ctAHXrKuy2R+c9fKek3e2eC2AwdLye3fadki6RdKbt/ZKul3SJ7bWSQtI+SR/uYY9o0D9He/e78Ds7HMI5+2d/La3P1thLBh3DHhEbWyy+rQe9AOghzqADkiDsQBKEHUiCsANJEHYgCX5KGqU+9o7eXeP019kXl9ZnH/1Tz9adEVt2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCcXaU+tpd5T8c/JGrbun6vd9y2pOl9Rvf897S+ovv+FXX686ILTuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJME4O0oNH3LP3vt0n1paP7akd+vOiC07kARhB5Ig7EAShB1IgrADSRB2IAnCDiTBODsas37XlaX1Fd/gevU6ddyy215j+z7be2w/YvvjxfLltrfb3lvcLut9uwC6tZDd+OOSPhURF0p6g6SrbV8k6VpJExFxgaSJ4jGAAdUx7BExFREPFvePSNojaZWkDZK2Fk/bKumKXjUJoLrndYDO9rmSXitph6SVETElzf2HIOmsNq/ZbHvS9uSMjlbrFkDXFhx222dIukvSJyLi8EJfFxHjETEWEWNDGu6mRwA1WFDYbQ9pLuh3RMQPisUHbY8W9VFJ071pEUAdOg692bak2yTtiYib55W2Sdok6cbi9p6edIj/W38/fHppfVlEnzrJYSHj7OslvU/Sw7Z3Fcuu01zIv2/7KkmPS3pXb1oEUIeOYY+IX0hq9ysCl9bbDoBe4XRZIAnCDiRB2IEkCDuQBGEHkuASV/TU0ZhpW1tyX/k4O+rFlh1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkmCcHY055V9Nd5ALW3YgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIJxdvTUsIfa1p5e3e5Hi+e8pO5mkmPLDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJLGR+9jWSbpd0tqQTksYj4qu2b5D0IUlPFk+9LiLu7VWjeGG65ok3ta2dc+ve0tfO1t1Mcgs5qea4pE9FxIO2l0jaaXt7UftKRHy5d+0BqMtC5mefkjRV3D9ie4+kVb1uDEC9ntd3dtvnSnqtpB3FomtsP2R7i+1lbV6z2fak7ckZHa3ULIDuLTjsts+QdJekT0TEYUlfl3S+pLWa2/Lf1Op1ETEeEWMRMTak4RpaBtCNBYXd9pDmgn5HRPxAkiLiYETMRsQJSd+UtK53bQKoqmPYbVvSbZL2RMTN85aPznvaOyXtrr89AHVZyNH49ZLeJ+lh27uKZddJ2mh7raSQtE/Sh3vSIRq14jfPlNanZst/D3ri52vb1s5/8pdd9YTuLORo/C8ktbrwmDF14AWEM+iAJAg7kARhB5Ig7EAShB1IgrADSTgi+raypV4eF/vSvq0PyGZHTOhwHGr5G91s2YEkCDuQBGEHkiDsQBKEHUiCsANJEHYgib6Os9t+UtKf5y06U9Lf+tbA8zOovQ1qXxK9davO3s6JiBWtCn0N+3NWbk9GxFhjDZQY1N4GtS+J3rrVr97YjQeSIOxAEk2Hfbzh9ZcZ1N4GtS+J3rrVl94a/c4OoH+a3rID6BPCDiTRSNhtX2b797YftX1tEz20Y3uf7Ydt77I92XAvW2xP2949b9ly29tt7y1uW86x11BvN9h+ovjsdtm+vKHe1ti+z/Ye24/Y/nixvNHPrqSvvnxuff/ObnuRpD9Iequk/ZIekLQxIn7b10basL1P0lhENH4Chu03S3pa0u0R8epi2RclHYqIG4v/KJdFxGcHpLcbJD3d9DTexWxFo/OnGZd0haT3q8HPrqSvd6sPn1sTW/Z1kh6NiMci4pik70ra0EAfAy8i7pd06KTFGyRtLe5v1dw/lr5r09tAiIipiHiwuH9E0rPTjDf62ZX01RdNhH2VpL/Me7xfgzXfe0j6qe2dtjc33UwLKyNiSpr7xyPprIb7OVnHabz76aRpxgfms+tm+vOqmgh7q9/HGqTxv/UR8TpJb5d0dbG7ioVZ0DTe/dJimvGB0O3051U1Efb9ktbMe7xa0oEG+mgpIg4Ut9OS7tbgTUV98NkZdIvb6Yb7+Y9Bmsa71TTjGoDPrsnpz5sI+wOSLrB9nu1TJV0paVsDfTyH7ZHiwIlsj0h6mwZvKuptkjYV9zdJuqfBXv7HoEzj3W6acTX82TU+/XlE9P1P0uWaOyL/R0mfa6KHNn29XNJvir9Hmu5N0p2a262b0dwe0VWSXippQtLe4nb5APX2bUkPS3pIc8Eabai3N2nuq+FDknYVf5c3/dmV9NWXz43TZYEkOIMOSIKwA0kQdiAJwg4kQdiBJAg7kARhB5L4N12M1PbY8RexAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "backdoor_attack = PoisoningAttackBackdoor(lambda x: insert_image(x, \n",
+    "                                                                 backdoor_path='../utils/data/backdoors/alert.png',\n",
+    "                                                                 size=(10,10),\n",
+    "                                                                 mode='L',\n",
+    "                                                                ))\n",
+    "poisoned_x, poisoned_y = backdoor_attack.poison(x_raw[:20], y_raw[:20])\n",
+    "plt.imshow(poisoned_x[idx].squeeze())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(x_raw, y_raw), (x_raw_test, y_raw_test), min_, max_ = load_cifar10()\n",
+    "\n",
+    "# Random Selection:\n",
+    "n_train = np.shape(x_raw)[0]\n",
+    "num_selection = 1\n",
+    "random_selection_indices = np.random.choice(n_train, num_selection)\n",
+    "x_raw = x_raw[random_selection_indices]\n",
+    "y_raw = y_raw[random_selection_indices]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x_raw shape: (1, 32, 32, 3)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7ff4717af1d0>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD5CAYAAADhukOtAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAddklEQVR4nO2daaxd13Xf/+vOb36P82iSkmVLqixLKiModWC4jhvIThDZQBPYQAN9MMygiIEaSA0ILlC7QD84RW3DHwoXdC1EKVwP8VCrgZtEEGLIaVLJlC1rogZKpkiKFB+HR/JNd179cK8KStn/9Z7ecB+j/f8BBO/b6+5z9tnnrHPu3f+71jJ3hxDi7U9howcghBgMcnYhMkHOLkQmyNmFyAQ5uxCZIGcXIhNKq+lsZncD+CqAIoD/5u5fjN5fLphXCpa0RXcd0gWk+fXBUVO9G+0r2KqnOw6V+TSWa0PU1u10qG1kYoLaikM1amu2Wsl27/LjqlQqfF/FIrXV63Vq63r62KLpXSmdNp9Hb6bng51LACgFxxwJ1eVKldpqtWHekUxKJIu3u+ljnp6expUrV5IbXLGzm1kRwH8B8C8AnALwMzN70N2fZX0qBcMt4+kLq1rgkz9STA+zVOCTYUV++3hhjppQqZS5sZm+uG/duZl22X7TrdS2OHuJ2n79w79NbeM330BtJ89NJ9tb8/wCfseed1DbxOQ4tR197nlqqzfTk1zi/oDYlThXzvN5XDxxNj2OxgLtMzk5Rm1e4PO4fc8Barvh5juorVBIX3PNDrlRATg/N5Ns/+xnP8v3Qy1LcyeAY+7+srs3AXwbwD2r2J4QYh1ZjbPvBnDyqr9P9duEENcgq/nOnvpe8A8+h5nZIQCHAKCi5UAhNozVuN8pAHuv+nsPgNNvfpO7H3b3g+5+sLQeqzNCiGWxGmf/GYAbzOyAmVUAfBzAg2szLCHEWrPij/Hu3jazTwP4K/Skt/vd/ZmoT8GAWjH9dDemrwEokwXQCl8YDbdXWuEtjn0wMQtUgcBWKgcr/4Hs0mm3eTc00+1Fvr2mc3mi41w6HBrjl0+xnT62SG5sN7mtC67WlAPps1lNqz+LLT4f4yV+zJVgHi14dnbafPwFonx6cO20nUisgaKxKp3d3X8M4Mer2YYQYjBoyUyITJCzC5EJcnYhMkHOLkQmyNmFyIRVrca/VQoGDBO1qRlEolXLaTmhGkhv3UB6qwW2VhRLZ+l7Y/hboW4ghQTRVYWg3+6tW6lt5760LYrmq5V44EfReOTKrp0j1NZsEQkwkN5CgnPdrC9S26N/9X+T7b+6cp72KQ/x4xqp8PMyPMTnqkIkQAAoEumwFGjEu0a2JNsjGVJPdiEyQc4uRCbI2YXIBDm7EJkgZxciEwa+Gl8jK+vtIDCBZYqKVuM7wQp5JVjl7Hi0Gk9sUQmtbhAAEazGWxDQsGl8E7UNbU7nOosCMbzNV5GLQRqmYjkIyLEVrroTWk2+r1fOnaK2UiW9sr517DLtM1HjAUrVYFW9WuXzGCovhfT1WAgCpcrEFp0vPdmFyAQ5uxCZIGcXIhPk7EJkgpxdiEyQswuRCQOX3oaqaflqMSpPxKS3YPSR8FMhefAAoNnmti67NwZqXZeU6QGAUhC00A7yzBWMl3+qltNloxbbPFhkcTHK18efB8NBeZdSKS0dNtsN2seDs1av8/k4c/ICtTUW0rnaahO80o2X+HkpBfJascLPSxDnhS4JemovBPn6yFx1Olyy1ZNdiEyQswuRCXJ2ITJBzi5EJsjZhcgEObsQmbAq6c3MjgOYRU/parv7wfj9QLWalgZKzaD8UyVtqwT5wDqB1lEp83tcIdDsnEUUGd+ZOd9gscgjqCzI1Vbu8PGPIp1PrlLmedW8GpR/CnLhWZNHWC3MXEnvy/glVy5z6WqsxKWym999C7VNDKWlyIWFBdqn2ZrntmY6tx4AFKvpiMNevzq1Fdhxl/j2uixpYxC1uRY6+z93d569TwhxTaCP8UJkwmqd3QH8tZk9bmaH1mJAQoj1YbUf49/n7qfNbBuAh8zsOXd/5Oo39G8ChwBgJKhQLIRYX1b1ZHf30/3/pwH8EMCdifccdveD7n6Q1WYXQqw/K3Z2Mxsxs7HXXwP4LQBPr9XAhBBry2o+xm8H8EPrJWEsAfgf7v6XUQczoFJOP92LBS5fVUiSShZBBwCtIONkNUg4WQgSPXZJwkmLYpq6PFqrGJRkiqLl6vVZart85Uyy3YPjKgfRa1jgUWpH/vJ/UduZU68m2w+85y7aZ2zTDmprB5JXZYhLmNs2p8sk+SZ+zmojXPJq1Pk4Zi/PUFtzkc9jmQxlqBaUjKqkrw8rBOXGqGUJ3P1lAO9daX8hxGCR9CZEJsjZhcgEObsQmSBnFyIT5OxCZMJAE06aASzHYqEQROsQuS4ohQUL6sBVSkGNtUIglRFVoxtknIyi3myF0tt8ELHVOJeOrvIuj2wrF9ORcgDw3E+4mvp3D36L2oZGJ5Pt1UBOKo9so7b5y7w22653vpPatu3Zn2yvDA3RPvUFPldbt+2itlaDy3KtOj9nNKlnh8t15unzHMnAerILkQlydiEyQc4uRCbI2YXIBDm7EJkw8NX4Ill1DxbjUSSjLAWBMEFcDWpkdX+pcbil741BmjYULCjHU+T3Wm/z1XhvpUsaAUCL1cpq8QN79qffp7bH//f3qO3KFb763PH0sf3i8cdpn8t1rpKMFfgxX5w+QW2F4c3J9nfeysM6rnvXjdQ2c/EctU1uSisQADA3y4+t00rPY7UUKFTVdN66SNXSk12ITJCzC5EJcnYhMkHOLkQmyNmFyAQ5uxCZMFDpDTA4kQaixLMFYmQBMq/vi1ELAmjKQXCKE5t7IK9FgQmhzselt25QbqpD6lctzEzTPscefYjaFhe4vFYu86CW+fl0MMm5M0/RPp3KFLVNXreP2jyo9fXKy8eS7adOPE/7bPlXn6K22QVeGmrnnndQ28hougwVAMzOXEy216r8Qh0aZrkco/yKQogskLMLkQlydiEyQc4uRCbI2YXIBDm7EJmwpPRmZvcD+B0A0+5+S79tE4DvANgP4DiA33d3XvumT73lePG1tEzVqAdS2Uy6z8Qov1fVgoi4SLIrBLnrSiwHXRT1FkUhkSg6AOgEkW3e4Tskqckwf+EK7VMc2kRttTGeO61V52PsNNJy2O5xLieN7dpObZWdXNYa372f2n73g+9Ktp89+RLt89SRv6e24dERapuY5NIhi1IDAJDIyG6by55tcg24ry4H3Z8CuPtNbfcBeNjdbwDwcP9vIcQ1zJLO3q+3/mbV/x4AD/RfPwDgo2s8LiHEGrPS7+zb3f0MAPT/5zmAhRDXBOv+c1kzOwTgEADUot/ECiHWlZU+2c+a2U4A6P9Pf3jt7ofd/aC7H6wEi19CiPVlpc7+IIB7+6/vBfCjtRmOEGK9WI709i0AHwCwxcxOAfg8gC8C+K6ZfRLACQC/t5ydLbaAJ19L2yrGo7zmmumP/yPDXII6sJOPI6j+hGKgvXkhvb9OENlmkRQSRCgVq6N8m1bl/brpU1roBJLXJF9yqc+epbZ5DxJOkspF9QYvafTaM89Q27HHnqO26268idp2bU8ngbz91z9A+zz6f35CbQ4uNzaagRTZDjKgkst4scl9okNqkXWD3Szp7O7+CWL6zaX6CiGuHfQLOiEyQc4uRCbI2YXIBDm7EJkgZxciEwZc681QJr+im2txGa3USPd5/iTfV/RrPWNaB4BiUH+tS3SNdhD2NjSerjUGALtv4PXGJjdvpbaZU8epbf5CelLOv/IE7bNwgUeAoblITVGixzZ5jlxp8/ltGb8cd23mUWMTQYTjLx77abK9WOXy5fZ911NbvZFOpAkAlRE+Rg+ShFoxLYu68Qi7RjO9PSc19gA92YXIBjm7EJkgZxciE+TsQmSCnF2ITJCzC5EJA5XeSsUCtoyPJ23zF3i+SqIy4OI8l7xeepVLHVsmuVRTDqQ3Ztl940Ha5/rb/xm1Vcs8wm72DI/yeu3CGWpbvPRqsr1VP0f71Bd5JNpCvU1tjUU+x9NzadsLl/n2hir8vLxjS/q6AYDxLTxqb98tdyXbt+1PJ6IEgLPRtdjk40eNy3LdQAou1dLH1nVeS69Jkn2GyU+5SQjxdkLOLkQmyNmFyAQ5uxCZIGcXIhMGuhpfKVewd1e6jM+FWb6S2WilV4ubXX6vusirFiGIgYAHy5kHrj+QbL/z9nfTPu3Lv6K2mXMnqG1+lq8Iz1+e5ftrpANXLMidVqoEufBKwfOgyNWE4eF0v6kgF9uFOrednuer4HtHtlDbLf80rYbs2beP9qn7i9RWHAqSvBWDQJhgZd1I3sMoKItdpRZka9eTXYhMkLMLkQlydiEyQc4uRCbI2YXIBDm7EJmwnPJP9wP4HQDT7n5Lv+0LAD4F4PXois+5+4+X2la5UsWuPWnp7fT0adrvlXPpupGtIJdcFBBQ51V1sHvvHmq75eb02O3ys7TPpZkgAGV+ntoW5urUNncpKDPUSR94scQ1maFIXSsFl0iJy0lTo+n8aZt2TdA+9VYQLDKaLuMEAFumeJBMYzEt6S7Mcfly/iKXPV89zuXSk87lwVKJl98yS0tv5TKf30IhPVf1Ba45L+fJ/qcA7k60f8Xdb+v/W9LRhRAby5LO7u6PALg4gLEIIdaR1Xxn/7SZPWlm95vZ1JqNSAixLqzU2b8G4HoAtwE4A+BL7I1mdsjMjpjZkcWgXK8QYn1ZkbO7+1l377h7F8DXAdwZvPewux9094ND0Y/ShRDryoqc3cx2XvXnxwA8vTbDEUKsF8uR3r4F4AMAtpjZKQCfB/ABM7sNveCb4wD+cDk7MwOKJO/azqDc0bmZS8n2rvMIJFKpCQCwadt2avu1gzdRW83T8uCVC1yOWZzlEtr8PJfQGnWuHbLSPwDgSEsyXuDbqze4zYMoKu9yY6U6nGwvj3HpbWqYy2v1Jv8K2Jk9S21zl9My2rEFXtbqlRefp7bzZ9I5/gCg2eDnOoqmdHIdd7tcI+600zJfJCku6ezu/olE8zeW6ieEuLbQL+iEyAQ5uxCZIGcXIhPk7EJkgpxdiEwYaMLJbqeDxbkrSdtwmQ9lopb+Mc7lRS6fbNnBSwK99z37qW24kI6wA4DZ82mJbX6ORxrNL3B5bSEoX1XnKg6CnI3oEIknigKMshS2A3mzHWzTGunjLo3wToUggeX4OJfsJgIp9fhzz6Tbn+c/DXHnYzTjz8du0M+DfkbmP9oX6HkJ5pdvTQjxdkLOLkQmyNmFyAQ5uxCZIGcXIhPk7EJkwkClt3arhYuvpSPH2oGMViWSzNhIOrIKAP7JjVyO2TbGs2zNX3qN2pok8mohkNcaQURZi3dDi+cuRKvD79GNZjpSqlbm8poHNcW6xi8RKwdJFIvpfqWgdtzUFl6z7cCN76W26bM86u2xv/hOsv3yeZ7glNVeA4BCIFNG0iGCOS4QiS3al5OEk+366hJOCiHeBsjZhcgEObsQmSBnFyIT5OxCZMJAV+Nb7RbOTqdXTrtB0ji2ML1v9ybaZ8dmvr1Gg5f3aQTprhcWm8n2+iJfcV+c4yuq9Sa3NYIV93pga3v6lAbpzFALImuqwzwjcJRPbnTzjmT7ll37aJ/9N90ajIOXeHrx8f9JbedfTQcvRbn14OnzDAAFkuMPAMyCQJhgdyxKKXoSM1uX5KZbantCiLcRcnYhMkHOLkQmyNmFyAQ5uxCZIGcXIhOWU/5pL4A/A7ADQBfAYXf/qpltAvAdAPvRKwH1++7ONS30FIZ5IgE12lwbGh0fSbbv3j5K+1QKQbmgNo9Aabe4DNVspiWSZoP3qTf4/bTV5oETbeOSV8d4v+pEeq4mpnhppVqRz0ezPk9twxM8cGX39ekyWhObeYDSlu07qe3YsZep7alnnqW22bn0dVAIHnOFQAYukgAUALAgX1856Fcupm1DQZ8qsa1ErruaNoA/dvebANwF4I/M7GYA9wF42N1vAPBw/28hxDXKks7u7mfc/ef917MAjgLYDeAeAA/03/YAgI+u1yCFEKvnLX1nN7P9AG4H8CiA7e5+BujdEADw3M1CiA1n2T+XNbNRAN8H8Bl3v8JyXSf6HQJwCADK0RclIcS6sizvM7Myeo7+TXf/Qb/5rJnt7Nt3AkhWV3D3w+5+0N0PluTsQmwYS3qf9R7h3wBw1N2/fJXpQQD39l/fC+BHaz88IcRasZyP8e8D8AcAnjKzJ/ptnwPwRQDfNbNPAjgB4PeW2pABKHbS8tVUtUb7TVUqyfZCk0cnNRtcyiuUuY2VTwIAJ6FSXXAprBNESXUK6eMCAJR5fr1KeYjaJrem5bDrbrqF9tm0eYrafvHwD6ltKpDzbrz19mT72CSX6xYWuMz3y79/hNpOv8Zz0LEySZ1AJmPneSkqQbfJSlT+KX3NtYNYuSKxRaWrlnR2d/9bgF6xv7lUfyHEtYG+RAuRCXJ2ITJBzi5EJsjZhcgEObsQmTDQhJPujm4nHYU0UuCRV8WFdEmbufO8/NDsFI8a82EuTyws8oR98/NpWxi9FshrhRGesLE8upnaWoHUd2k2LV/NXLhA+4xNjFFbZYTbJqd4ws/N23en9zXJZb5uUMZpoc6jGKOIsgopyeRt/pyLk0Ny2XaEX46YrHCpr0bGHx0XI/plq57sQmSCnF2ITJCzC5EJcnYhMkHOLkQmyNmFyISBSm8jNcMdN6b1iR1bIskgfU+yQCSxoF5XO5DKCgW+zQ5RT1rg8lqzyG2NoMba5SCS68LMZWprN9IS5rFfvUL77Nq7l9qmprg8eHGG5xetz11Kto+OcSlvdIhfjh/6yIep7fJrZ6jthaNPJdtbnUCuA5fXakFoW8H4szOKwiyShJPRo5hdpVHUm57sQmSCnF2ITJCzC5EJcnYhMkHOLkQmDHQ1vt1xXLyYXiVnJXAAYMeOdFDL1GQQZELyegHA/Bxfqb90ha+Qz5BAmFqJb2+yzI/r1BXe76WTfMX9chAUUiDzaJf5cU1f4vvau30rtZ09xoOXFhbSx/Zr7/8Q7TNzkQfrzFxMr+4DwLvecyu1jW1OB+ucOPUq7TN/6gS1dZs8T17d+bOzweOrMI/0uYlKTbE9BQKPnuxC5IKcXYhMkLMLkQlydiEyQc4uRCbI2YXIBIt+OA8AZrYXwJ8B2AGgC+Cwu3/VzL4A4FMAzvXf+jl3/3G0rWqh4Ltr6UCYqSB/10gtHbhSG+LSxNgoD3YZCoIZzs4EpaGIabzK75mXuEqGSw3erxKUqBop8XO2OJ/WXhabUVkrPo6hMldnh8pc+hwbTQe8jE/y3HpDY9w2PMbz3Y1u5v3GJtIlqqpD/IKbu3Se2k688By1Pf/is3ybMxepbYjIxJFnMtvT8w3MdbrJC3w5OnsbwB+7+8/NbAzA42b2UN/2FXf/z8vYhhBig1lOrbczAM70X8+a2VEA6dShQohrlrf0nd3M9gO4HcCj/aZPm9mTZna/mfEcwUKIDWfZzm5mowC+D+Az7n4FwNcAXA/gNvSe/F8i/Q6Z2REzO9KJM3ILIdaRZTm7mZXRc/RvuvsPAMDdz7p7x927AL4O4M5UX3c/7O4H3f1gMahVLoRYX5Z0duuVmPgGgKPu/uWr2nde9baPAXh67YcnhFgrliO9/QaAnwJ4Cvj/4TmfA/AJ9D7CO4DjAP6wv5hHKRcKvrmSXhOsBfm72BijHHSl4FNEJYiwI9WCAABjQ2ljpczHPt/iEtpEIB2+ex9fO902GZR/upAOrzp+ikfYnZzh42h0AnkwiMoqE1muVuFlucZH0zIZAIxNbqG2alCiqkakt807ttM+ExPj1FYu8vk4FUTLPfazv6O26VfT/QpBqakCub6P1RtYXKn05u5/CyS3HGrqQohrC/2CTohMkLMLkQlydiEyQc4uRCbI2YXIhCWlt7WkVDCfKKUFgCAvI3pS/z8kulMFChrI5pY0sv0NBVJeLTiwWimwBZF5wzV+5GUSETc7y2Wc12b5NdBsR9Ibt5VK6TNQLfFos6HqMLXVqkPUVq5xOa/dTUuRrRZPlmldnrWxGkQBToxzyY7PPvDcqVPJ9ouXeZJNdsmdrjfQ6KalNz3ZhcgEObsQmSBnFyIT5OxCZIKcXYhMkLMLkQkDrfXmALjgwQnyKwb74tJVZLNAimRRdu1uUFcuqPGVji/qUQyiAEukNhjAo/YiibUe1AdrBTJUdGg1Fi0X1ODzFo/Mq3f43nyO16prk36dYHuR/BpJuufOTVPbeI1Lh5vJnFgliAQl19zZQFbWk12ITJCzC5EJcnYhMkHOLkQmyNmFyAQ5uxCZMFDpDc4loEgOC5QhThTZFkhlUUSckY160KcTyIbRndaDo+5GB9dO2yKZrB3IcpHqGZTno1PcDfbVCCLRuoEEGMmKtJfz7RWCiyCKXmsHCTi9Uae2YZLEshzIr61wJGn0ZBciE+TsQmSCnF2ITJCzC5EJcnYhMmHJ1XgzqwF4BEC1//7vufvnzewAgG8D2ATg5wD+wN15JEMftgYaLJDTFfJopXjFd7Fgo3TVPRr7ioexshVhFqzTilasg+CUySBnXHR0bJutoKRRMIxwxT1SQ2ivlazgIy45Vgg6WrD6b56+WruBU7Dgq9X6RAPAB939vejVdrvbzO4C8CcAvuLuNwCYAfDJZWxLCLFBLOns3mOu/2e5/88BfBDA9/rtDwD46LqMUAixJiy3PnvRzJ4AMA3gIQAvAbjk7q//VuMUgN3rM0QhxFqwLGd394673wZgD4A7AdyUeluqr5kdMrMjZnZkcBnqhRBv5i2tY7n7JQA/AXAXgEkze32Bbw+A06TPYXc/6O4HV7pYJYRYPUs6u5ltNbPJ/ushAB8CcBTA3wD4l/233QvgR+s1SCHE6llOIMxOAA+YWRG9m8N33f0vzOxZAN82s/8I4BcAvrHUhhw8iCPKTcdEiygfWCStFML8dCtJeBdGz1BCiSeSoaKxkI5Rla+RIr8MRipceptv8rPWJvuLAnyKKzwvkWzLCD9lriAP4VJbjXo1yQE0guCfDgsoC3a0pLO7+5MAbk+0v4ze93chxD8C9As6ITJBzi5EJsjZhcgEObsQmSBnFyITLIomWvOdmZ0D8Er/zy0Azg9s5xyN441oHG/kH9s49rn71pRhoM7+hh2bHXH3gxuyc41D48hwHPoYL0QmyNmFyISNdPbDG7jvq9E43ojG8UbeNuPYsO/sQojBoo/xQmTChji7md1tZs+b2TEzu28jxtAfx3Eze8rMnjCzIwPc7/1mNm1mT1/VtsnMHjKzF/v/T23QOL5gZq/25+QJM/vIAMax18z+xsyOmtkzZvZv+u0DnZNgHAOdEzOrmdljZvbL/jj+Q7/9gJk92p+P75hZ5S1t2N0H+g+9yNSXAFwHoALglwBuHvQ4+mM5DmDLBuz3/QDuAPD0VW3/CcB9/df3AfiTDRrHFwD82wHPx04Ad/RfjwF4AcDNg56TYBwDnRP0YmVH+6/LAB5FL2HMdwF8vN/+XwH867ey3Y14st8J4Ji7v+y91NPfBnDPBoxjw3D3RwBcfFPzPegl7gQGlMCTjGPguPsZd/95//UseslRdmPAcxKMY6B4jzVP8roRzr4bwMmr/t7IZJUO4K/N7HEzO7RBY3id7e5+BuhddAC2beBYPm1mT/Y/5q/714mrMbP96OVPeBQbOCdvGgcw4DlZjySvG+HsqXQeGyUJvM/d7wDwYQB/ZGbv36BxXEt8DcD16NUIOAPgS4PasZmNAvg+gM+4+5VB7XcZ4xj4nPgqkrwyNsLZTwHYe9XfNFnleuPup/v/TwP4ITY2885ZM9sJAP3/pzdiEO5+tn+hdQF8HQOaEzMro+dg33T3H/SbBz4nqXFs1Jz09/2Wk7wyNsLZfwbghv7KYgXAxwE8OOhBmNmImY29/hrAbwF4Ou61rjyIXuJOYAMTeL7uXH0+hgHMiZkZejkMj7r7l68yDXRO2DgGPSfrluR1UCuMb1pt/Ah6K50vAfh3GzSG69BTAn4J4JlBjgPAt9D7ONhC75POJwFsBvAwgBf7/2/aoHH8dwBPAXgSPWfbOYBx/AZ6H0mfBPBE/99HBj0nwTgGOicAbkUvieuT6N1Y/v1V1+xjAI4B+HMA1beyXf2CTohM0C/ohMgEObsQmSBnFyIT5OxCZIKcXYhMkLMLkQlydiEyQc4uRCb8P9eMsax+Xw+2AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(f\"x_raw shape: {x_raw.shape}\")\n",
+    "plt.imshow(x_raw[idx])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ART method `insert_image` has different parameters that can affect image trigger generation.\n",
+    "\n",
+    "If `random=True`, the image will in a different random location for each sample. If `random=False`, the placement of each trigger depends on the values of `x_shift` and `y_shift`. \n",
+    "\n",
+    "You may also set `channels_first=True` if working with images of shape `(N, C, W, H)` instead of `(N, W, H, C)`\n",
+    "\n",
+    "The mode affects how Pillow processes the image. This is usually `RGB` for color images or `L` for 8-bit black and white images. More information [here](https://pillow.readthedocs.io/en/stable/handbook/concepts.html#concept-modes).\n",
+    "\n",
+    "The `blend` parameter affects how much the two images should blend into each other. The default blend is 0.8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def poison_func(x):\n",
+    "    return insert_image(x, backdoor_path='../utils/data/backdoors/alert.png',\n",
+    "                        size=(10,10), mode='RGB', blend=0.8, random=True)\n",
+    "backdoor_attack = PoisoningAttackBackdoor(poison_func)\n",
+    "poisoned_x, poisoned_y = backdoor_attack.poison(x_raw[:20], y_raw[:20])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7ff490883400>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD5CAYAAADhukOtAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAczUlEQVR4nO2da4xdV3XH/+s+5+kZ2+NX7AQ7icurlEBHKQJEKX0oRZUCUlvBB5QPCFcVSEVqP0RUKlTqB1oVUD5UVKZEpBXl0QIiqqIWmrak9JGSQOI4MRQn2LGJ7YntGc/rvu/qh3vTOun+rxnP447J/v8ky3f2uvucffY965x79/+stczdIYR4+VPY6gEIIQaDnF2ITJCzC5EJcnYhMkHOLkQmyNmFyITSejqb2R0A7gFQBPAX7v7xcGdmXi4Y2RaXAAsgfcLBcVOzG3SzoCORKaulIu1SqlT55rodahseG6e2QrVCba1Om+yLH1e5xE+DYpEfW6PZoDZ3Msnhh7Y2um3+gXo7PR/o8j7RMUcUy2Vqq1SHqM3IpESyeIfM7+XLl7G0tJTc4Jqd3cyKAP4MwC8DOAvgO2Z2v7s/xfqUC4ZbRtO7LBf4gQ0X0pNfDPpYgX9pebZGTeGJj3b65L51aoJ22XnwMLU1lheo7XVvfiu1jd58E7VdmL2cbG/X+Am8d89eahsbH6W2H506TW3N1nKyvcj9AcDanvlYmluktsb5S+lxtOq0z3hwzG78vNqx5wZqu+nQq6itUEifc+zCDQBztfS5c8899/D9UMvK3A7gpLs/4+5NAF8EcOc6tieE2ETW4+z7AZy56u+z/TYhxHXIen6zp34X/L/vYWZ2BMARAChvwu81IcTqWM+d/SyAG6/6+wCA5176Jnc/6u7T7j5djBa/hBCbynqc/TsADpvZITOrAHgPgPs3ZlhCiI1mzV/j3b1tZh8C8A/oSW/3uvuTUR8zoFK8dumNKVvl4FIVLJqCDGHNRJuLjqsYrfwHdDtcsnMQ6a3Yon1anl45B4Cuc+lwaISv8Bc76WPrdrjk1Wnz4+oGK/WlQPpsVdLL/402395okR9zpBpZcO/sdgJpmXTz4MTqOPmcA7luXTq7uz8A4IH1bEMIMRj0BJ0QmSBnFyIT5OxCZIKcXYhMkLMLkQnrWo2/VgoGDJE9toJItEopLSdE0puT6DoAqAQ2HnoAqueFzwoFsR1FEuADAIUu77h7+3Zqm9qXtkVX9UqJB34UwCNXdk0NU1urnZb6PJDeQoJAtFaDB7Uc/8/jyfbnluZon1KVH9dwmX8uQ0E0YolIgACXYIeL/FObGp5M7yeQIXVnFyIT5OxCZIKcXYhMkLMLkQlydiEyYaCr8QagSlbWgww8KJNRVoJLVZByDeVglbMbRR+wZfeohFaQ66wQjMOCZfxto9uorTqRznUWBaB4h68iF4KIomIpCMixNa66E9otvq9zsxeorVhKz8f2EX7qj1W4rRLZghx0pSBNGst7WCgFq/tkBb8Q7Ed3diEyQc4uRCbI2YXIBDm7EJkgZxciE+TsQmTCwANhqiSfdD0I/GCp2ipBcAQXauIAmlaHS2/Oss0Fal03KjMUBC20gzxzBeOSTKU0lmxvdHippkadH0AxkHKiMknFYvrzbHWatA/A56rZ5NrsxQtXqK1VT/erjAVVX4LPpVgJZMoyz10XCpFEum3W+TnQIVsMTjfd2YXIBTm7EJkgZxciE+TsQmSCnF2ITJCzC5EJ65LezOwUgAX0lK62u0+H7y8A5UpaZii1uPxTKqVtpSAfWFClB+VSEBkUSBddljMuiPCyQAQsFvn0WyC9lTp8/MMYSbaXSzyvmld4+adOIIlam0tU9YWl9L6M9ymVuHQ1UuRS2c2vuIXaxqppKbJe53nrWu0at7V4Ga1iJR1h1+vHJUca3Vbk2+u2yTkXRG1uhM7+C+5+cQO2I4TYRPQ1XohMWK+zO4BvmNmjZnZkIwYkhNgc1vs1/i3u/pyZ7QbwTTP7vrs/dPUb+heBIwAwPNCHc4UQV7OuO7u7P9f/fwbA1wDcnnjPUXefdvdpVptdCLH5rNnZzWzUzMZfeA3gVwCky28IIbac9Xyx3gPga/1keSUAf+3ufx91MABlIqMVAs2rTJJUDlWCMk5B9FoovTW51MRGGCWHRDeKXgsi7JzPR6PJpbLFpWsXRkpFnigRgdT01H88RG0XL8wk22+49XW0z+jETmrrtHjUW6nKT+MdE+kySb6Nz29lOJDQgui7pcV53q/BpTdyemOoyj+XQjl9XlmgOa/Z2d39GQCvX2t/IcRgkfQmRCbI2YXIBDm7EJkgZxciE+TsQmTCYGu9GcBy+RUKQdJDFvUWjT64jEW13lAIotSIqhElE7RAQrMgU2WUqLIWRWzNphNLepdHcpWK6Ug5ADj16L9T2+Pf+gdqGxoZT7ZXAjlp7uIOaqstLlLbrgM3Utv2PfuS7eUqj7Br1vlcbd+xi9raTS5Ttpv8MysxCTZIzmkFZgtqC1KLEOJlhZxdiEyQswuRCXJ2ITJBzi5EJgw8wrxIVt2j4FeWqq1ISkkBgAWxKVWyug/EV7+upa2kek9vHMFALFAFPMhBhzYPxmiXyWTxLnjmO/9EbSf+7R+pbWmJb7Tr6WP7/okTtM9ik+enGzW+ryuXz1NbYWgi2X7j4Z+iffbfdJDa5q/MUtv4RFqBAIDlJf5Zd9vpVfxyEBLOylBFwVW6swuRCXJ2ITJBzi5EJsjZhcgEObsQmSBnFyITBiu9GeBEGogSzxqR64LqSSgGYl4l6EeDEgC0iC2S3gpRYEKkNwYBNN2g3FTX0pJdfZ5LRmeO/ye1NepB7rcgEqlWT+fJm714kvbplrdR2/j+dEBLryOfj3M/PpNsnzl/mvaZfOe7qW0pCJKZ2r2X2oZH0mWoAGBp/kqyvRqcqNUh4hOFIL8itQghXlbI2YXIBDm7EJkgZxciE+TsQmSCnF2ITFhRejOzewH8GoAZd//pftsOAF8CcBDAKQC/6e5c2+nTbAPPXkrrVK1mIJXNp/uMjfBrVTWIiGM57QCgwAOv1paDLtDXCiSKDgC6QWSbd7jW5yQ1We3KEu1TrKYjwwCgOspzp7UbQdRbKz3G3WP8lBuZ4jnoylNc1hrdzWW5n59+RbL90oWztM/Jp45R29DIMLWNjfGotxKJUgNAQz67HZ7TrtNNz29UNmw1d/bPAbjjJW13A3jQ3Q8DeLD/txDiOmZFZ+/XW7/8kuY7AdzXf30fgHdt8LiEEBvMWn+z73H3cwDQ/3/3xg1JCLEZbPrjsmZ2BMARAKgEv4eFEJvLWu/sF8xsHwD0/08X4wbg7kfdfdrdp8vhw+BCiM1krc5+P4C7+q/vAvD1jRmOEGKzWI309gUAbwcwZWZnAXwUwMcBfNnM3g/gWQC/sZqdNdrADy+lbWUSrQUAy630N4LhIS5B3TDFxxFWfwrksGIhvb8ugqSSUfmnKEKpwiUeMy7jFLrp30rWCSSv8e3U1lgmHxiAunPpjalGzSYvaXTpmWeo7cyTp6ht/8FD1LZrR1oOe+XP/Cztc/zxR6nNg8ydrUAu7bSD0EhiarSC6EZ2Lga7WdHZ3f29xPSLK/UVQlw/6Ak6ITJBzi5EJsjZhcgEObsQmSBnFyITBl7rrUQerKkF0kSRRMSdvsD3Ez2tZ4FUVgh0uS6R0TpBwsPq6CS17b7xMLWNT3I5bH7mOWqrz6UnZe78f/M+V3gEGFoNavLguDsklGuxwz+YtnHbrokqtY1V+MNa33/ye8n2QhCFtnPvAWprtNKJNAGgPMTH6EGSUCOZU92GaJ8miSp0UmMP0J1diGyQswuRCXJ2ITJBzi5EJsjZhcgEObsQmTBQ6a1ULGBydDRpO39lnvZjqtwVXnYLZ2e4vDY5zqUaJg0CQKGUvjbuOvhTtM+BV76e2ipkewCwdPEUtV2cu0htjcV0aoF2Y472aTZ4JFq9waMRm3UuJ11eTs//s4t8e1GS0L2T6fMGAEYneaLKfbe8Ltm+44abaJ9LcwvU1m7z8aPKZTkPihkWLX1sXS/zcbTSEXZx3UEhRBbI2YXIBDm7EJkgZxciE+TsQmTCYFfjS2Xs3ZUu43Nlma9kttrphGat4KH/eV61CFElniiJ1w0Hbki2v/aVB2mfzuKPqe3S7Hlqqy3zFeHaIi/l1GmmA1csyJ1WLAd59wLFIErmNzSUtm3r8BX8uSaf++drfBV8zzAPNrrl1Wk1ZM8+Xk6q4WeorTgUFPsq8BPLnbtageQiLAY5ChlR/mbd2YXIBDm7EJkgZxciE+TsQmSCnF2ITJCzC5EJqyn/dC+AXwMw4+4/3W/7GIAPAHi+/7aPuPsDK22rXCpjak9a8nh+9vlkOwCcm31pefge7SCXXFQGJ4jtwK69e6jt1kPpsdsiL1u0sDBLbc0aj+SpL/PglNpCUGaIHHgxCMSoRuWwikEyvyIP1Ng2kc6fNrFrjPZptIMApZF0GScAmBznQTKtRlrSrQdSby0Iypo5x+XS885PrBLJMwcAICXHSiU+vwUSsNVo8HNqNXf2zwG4I9H+KXe/rf9vRUcXQmwtKzq7uz8EIH1rFUL8xLCe3+wfMrNjZnavmfG8x0KI64K1OvunAdwC4DYA5wB8gr3RzI6Y2SNm9kijRer4CiE2nTU5u7tfcPeOu3cBfAbA7cF7j7r7tLtPV8t8wUEIsbmsydnNbN9Vf74bwPGNGY4QYrNYjfT2BQBvBzBlZmcBfBTA283sNgAO4BSA31rV3oxHUU1N8J/9s/PpCDAPEm5FubgmdvCcZa999SFqq3haHly6wuWYxlIgodW4hNYKIsCabR555STuyQvBhAT7isKoSDUsAEC5kpbeSiNcehsf4vJak0Q+AkB3+RK1LS+mZbQzdV7W6vyZ09Q2dzGd4w8AWk3+WcfnKinl1OVSXqeTtkWS4orO7u7vTTR/dqV+QojrCz1BJ0QmyNmFyAQ5uxCZIGcXIhPk7EJkwkATTnq3i8ZyOlniUIlHV42RDJGLDS6fTO7kUt7hW9OJIwFgqMDDAJbm0hJbrcazW9bqXF6r1wN5jR8agpyNNOotkiIjfa0DvrNOsM1WM33cxWHeJ4qwG61WqW1sO5dSz51KRyQ+d/pp2ieSyYxEqAFAN5pkCzRMYrPwXsw+Fz4G3dmFyAQ5uxCZIGcXIhPk7EJkgpxdiEyQswuRCQOV3jrtNq5cSkeOdQIZrUJqio0MpyOrAODmgzupbcfIFWqrLfAIqlYrHdVUD+S1VotLIW3eDe0gKWa7y6/RzVZakqkGqpAHNcW6xuUwK/HTx0iCxSjx5bZJXrPthoOHqe3yJS6XPvntbyTbF+d4glMLjrkQSGgW1WYL6uKxbVoUckgSTrJaf4Du7EJkg5xdiEyQswuRCXJ2ITJBzi5EJgx0Nb7daePy5fTKaTdIaMYWrfft3kb77Jzg22u2eHmfZpBHrN5Ij6QZBLQ0lvmKaqPFba1u0K/Dr9Edls8sWN2vBBEtlaF0EBIQ55MbnpxKtk9OpUtoAcC+Q7cG4+Alns58/1+obW4mHbzkwUI3nMsk0d0xinUJ45BI8FK4L7Ypkptupe0JIV5GyNmFyAQ5uxCZIGcXIhPk7EJkgpxdiExYTfmnGwH8JYC96CW+Ouru95jZDgBfAnAQvRJQv+nus9G2ug7UiCLWDBKrjYymE5ft3jFC+5QLQbmgDpdWOu0gcIUEtUTBLg2u5KEdSGht45JXN8iDVhlLz1V1hEtXlWIQkdPhgRVDYzxwZfeBg8n2sQkeoDS5Iy3XAcCZMz+mtpNP/4jalpbT50EUs1Lo8nOxQAJQAMAC+bgU9GO2qE+FmApBHrzV3NnbAH7X3V8N4E0APmhmrwFwN4AH3f0wgAf7fwshrlNWdHZ3P+fu3+2/XgBwAsB+AHcCuK//tvsAvGuzBimEWD/X9JvdzA4CeAOAhwHscfdzQO+CAGD3Rg9OCLFxrPpxWTMbA/AVAB9293mLng18cb8jAI4AQCn6oSSE2FRW5X1mVkbP0T/v7l/tN18ws319+z4AycLV7n7U3afdfbq4yguEEGLjWdHZrXcL/yyAE+7+yatM9wO4q//6LgBf3/jhCSE2itV8jX8LgPcBeMLMHuu3fQTAxwF82czeD+BZAL+x0oYMQIFEWG0rc6lpWzk9TGtxea3VDKJ/SlwiiUr4OAmV6gbXzG6QR6xbKFMbSjy/XrkUlUJKy2EPPfUD2qcYlF162yEuh41vG6e2g7e+Ktk+Ms7lunq9Rm0/fOJ71Pb8JZ43EEQO67b5OeBR7reA4NPEWJmfI2bpc46V8gKANtlcFF23orO7+7fBI+p+caX+QojrA62YCZEJcnYhMkHOLkQmyNmFyAQ5uxCZMNCEk+4O76bDwIaDp+sK9XqyvTbHh7+8jUt5PsQFinqDS3a1WtoWRa91AnnNqjxhY3Vkgtra4FLZqfPpskbDFT4f1SEu812s8/m4eRsf48TOXcn20XGeJHQ2kNDqQfhgFB1WJueVB59ZnBySz8dw4E3jZS71VVjU2xoeQou66M4uRCbI2YXIBDm7EJkgZxciE+TsQmSCnF2ITBio9DZUNbzqYHqXOye5ZlCg1yQukpjziLhOILuwCCSAluRCO4h3ahX4FDeDGmuLl9I18QBg7soCtT39fFp6OzDJo80qgfT2raeeobbDN99Mbc3l9BhHgsSXw1U+V7e/5c3UtnjpIrWd/tHJZHs7qKVXBpfXquXgPA0SgYZRmEWyzTXUjvN1JpwUQrwMkLMLkQlydiEyQc4uRCbI2YXIhIGuxnc6jivz6VJDpeCys3MqHcSxbSwIMglW1Ws1vlK/sMT7zdfSY68U+eDHS3xJ9cLSIrWdvcBts0GuNhZuMTM/T/tcXlyitnabl4b6+2/9G7Wx1efXvPHnaJ+FK3PUNj/P5+OmWw9T28hEOvDm/ExatQCA2oXz1OZtPveNIj93gsV41Eg+vCgbM7MEVdR0ZxciF+TsQmSCnF2ITJCzC5EJcnYhMkHOLkQmWPTgPACY2Y0A/hLAXvSUnaPufo+ZfQzABwC8oGF8xN0fiLZVKZjvqqTVvm2BCDhUSedcq1a5NDEywq9jUTDD5XmukXSJrDEalPZZ4CofFppB3r0il7x+cDGdky9iMtA2o3JHV9qBZhTwpn170+OY2E77VEd5TruhICff8AS3jY6lS1SVh/gJV1vgEuD506eo7fQZHjS0HEifVSITx56Z5mS9hVonHeWzGp29DeB33f27ZjYO4FEz+2bf9il3/9M1jEkIMWBWU+vtHIBz/dcLZnYCwP7NHpgQYmO5pt/sZnYQwBsAPNxv+pCZHTOze82Mfz8TQmw5q3Z2MxsD8BUAH3b3eQCfBnALgNvQu/N/gvQ7YmaPmNkjQQVaIcQmsypnN7Myeo7+eXf/KgC4+wV377h7F8BnANye6uvuR9192t2ng1z+QohNZkVnNzMD8FkAJ9z9k1e177vqbe8GcHzjhyeE2ChWI729FcC/AngC/xdU9REA70XvK7wDOAXgt/qLeZRSwXyilF4TrER1a1YYY3JfkY3l/AIQBLBhpJqWAMtBZBuLaAKAsUA6PFfn0tvZOW5j7Bri+6q3uW0hGH/ENvI53xrJZMNpmQwARsd5Dr3y8Ai1VYn0NrFzB+0zNsbz5JWCE+RCEC335FPHqG12Jt3PPMhbR+TSs40W6t01Sm/u/m2kI+pCTV0IcX2hJ+iEyAQ5uxCZIGcXIhPk7EJkgpxdiExYUXrbSIpmPlZKy1eRLGBEloue0Unv5YXtRcZrN1WDp4WqgSxXCSTAbpAwk5YLAlAspfvValxCm29QEzodvq9SMJHlYvoTGKukk4cCQLXMy1BVKlU+jmCbHU/LlFEiTQse9ayQ8xcAxka5ZBfFDp6amUm2zy/yMl/slLvYbKFJpDfd2YXIBDm7EJkgZxciE+TsQmSCnF2ITJCzC5EJA631BvQS2l0rrIRWdKWKpI4owaKtQYrsBFJNvbM2abNg/OiKQSpCFpTlzo85OuQw5i2sRZa2NYP5cOPZOZtd/on6Mq8D1yH9WPtKRJLu7OxlahutcllxgsisFiQydXLO8RHozi5ENsjZhcgEObsQmSBnFyIT5OxCZIKcXYhMGKj05gBYlJ0HMg4Ta9aWChGh1rSWgLh0jFHfFsha0b48OLpu0LNFotQioakTzEckHEbzzzbpwRabQSRaL2P5te0LCMYYbK8QnIvRMbeD6Edv8tDCIaKXRlGF7TVUgtOdXYhMkLMLkQlydiEyQc4uRCbI2YXIhBVX481sCMBDAKr99/+tu3/UzA4B+CKAHQC+C+B97t5caXtsDTFcUSWLkmtMJbdm6BDXuOIeB/Ks7QiMDKYdrbgHuxorrk2wYTn02t1gPTtaYF7j+PlntjYFgs0vAFhwaK0oaIiMpRtIOZGCwljNnb0B4B3u/nr0arvdYWZvAvDHAD7l7ocBzAJ4/zXvXQgxMFZ0du/xQgxhuf/PAbwDwN/22+8D8K5NGaEQYkNYbX32opk9BmAGwDcBPA1gzv1/8/SeBbB/c4YohNgIVuXs7t5x99sAHABwO4BXp96W6mtmR8zsETN7ZHAZ6oUQL+WaVuPdfQ7AvwB4E4BJM3th9eYAgOdIn6PuPu3u05uxaCaEWB0rOruZ7TKzyf7rYQC/BOAEgH8G8Ov9t90F4OubNUghxPpZja6yD8B9ZlZE7+LwZXf/OzN7CsAXzeyPAHwPwGdXs0MWxBHlpmNXpOhKFZZ/CmyD/KkRBVUE1Z/iMZKOUZ+hAp+t4TI/RWot/qkxaSgK8CkGn0wUQBMFGzHCb5lhoFQszNFNBr1axNoMDqxL55ezorO7+zEAb0i0P4Pe73chxE8AeoJOiEyQswuRCXJ2ITJBzi5EJsjZhcgEYznhNmVnZs8DON3/cwrAxYHtnKNxvBiN48X8pI3jFe6+K2UYqLO/aMdmj7j79JbsXOPQODIch77GC5EJcnYhMmErnf3oFu77ajSOF6NxvJiXzTi27De7EGKw6Gu8EJmwJc5uZneY2Q/M7KSZ3b0VY+iP45SZPWFmj5nZIwPc771mNmNmx69q22Fm3zSzH/b/375F4/iYmf24PyePmdk7BzCOG83sn83shJk9aWa/028f6JwE4xjonJjZkJn9l5k93h/HH/bbD5nZw/35+JKZVa5pw+4+0H/oRZ8+DeBmABUAjwN4zaDH0R/LKQBTW7DftwF4I4DjV7X9CYC7+6/vBvDHWzSOjwH4vQHPxz4Ab+y/Hgfw3wBeM+g5CcYx0DlBL1Z2rP+6DOBh9BLGfBnAe/rtfw7gt69lu1txZ78dwEl3f8Z7qae/CODOLRjHluHuDwG4/JLmO9FL3AkMKIEnGcfAcfdz7v7d/usF9JKj7MeA5yQYx0DxHhue5HUrnH0/gDNX/b2VySodwDfM7FEzO7JFY3iBPe5+DuiddAB2b+FYPmRmx/pf8zf958TVmNlB9PInPIwtnJOXjAMY8JxsRpLXrXD2VDqPrZIE3uLubwTwqwA+aGZv26JxXE98GsAt6NUIOAfgE4PasZmNAfgKgA+7+/yg9ruKcQx8TnwdSV4ZW+HsZwHceNXfNFnlZuPuz/X/nwHwNWxt5p0LZrYPAPr/z2zFINz9Qv9E6wL4DAY0J2ZWRs/BPu/uX+03D3xOUuPYqjnp7/uak7wytsLZvwPgcH9lsQLgPQDuH/QgzGzUzMZfeA3gVwAcj3ttKvejl7gT2MIEni84V593YwBzYmaGXg7DE+7+yatMA50TNo5Bz8mmJXkd1ArjS1Yb34neSufTAH5/i8ZwM3pKwOMAnhzkOAB8Ab2vgy30vum8H8BOAA8C+GH//x1bNI6/AvAEgGPoOdu+AYzjreh9JT0G4LH+v3cOek6CcQx0TgD8DHpJXI+hd2H5g6vO2f8CcBLA3wCoXst29QSdEJmgJ+iEyAQ5uxCZIGcXIhPk7EJkgpxdiEyQswuRCXJ2ITJBzi5EJvwPaD2EgfNKccIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(poisoned_x[0].squeeze())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/attacks/test_backdoor_attack.py
+++ b/tests/attacks/test_backdoor_attack.py
@@ -90,25 +90,16 @@ class TestBackdoorAttack(TestBase):
         return np.expand_dims(add_single_bd(x.squeeze(3), pixel_value=max_val), axis=3)
 
     def poison_func_3(self, x):
-        return np.expand_dims(
-            insert_image(
-                x.squeeze(3), backdoor_path=self.backdoor_path, size=(5, 5), random=False, x_shift=3, y_shift=3
-            ),
-            axis=3,
-        )
+        return insert_image(x, backdoor_path=self.backdoor_path, size=(5, 5), random=False, x_shift=3, y_shift=3)
 
     def poison_func_4(self, x):
-        return np.expand_dims(
-            insert_image(x.squeeze(3), backdoor_path=self.backdoor_path, size=(5, 5), random=True), axis=3
-        )
+        return insert_image(x, backdoor_path=self.backdoor_path, size=(5, 5), random=True)
 
     def poison_func_5(self, x):
-        return np.expand_dims(
-            insert_image(x.squeeze(3), backdoor_path=self.backdoor_path, random=True, size=(100, 100)), axis=3
-        )
+        return insert_image(x, backdoor_path=self.backdoor_path, random=True, size=(100, 100))
 
     def poison_func_6(self, x):
-        return np.expand_dims(insert_image(x, backdoor_path=self.backdoor_path, random=True, size=(100, 100)), axis=3)
+        return insert_image(x, backdoor_path=self.backdoor_path, random=True, size=(100, 100))
 
     def test_backdoor_pattern(self):
         """


### PR DESCRIPTION
# Description

This PR extends functionality for image trigger perturbations. Users of ART can now blend images together and use both Grayscale + Color images. It's also adds a notebooks showing these changes.

This PR also includes new logging for the Clean Label Backdoor Attack when no change is detected after the PGD step.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
   - Inserting images of shape W x H is no longer supported. Grayscale images are now required to be of shape W x H x 1
- [ ] This change requires a documentation update

# Testing

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
