### PR TITLE
Return None in BaseEstimator._set_preprocessing for None input

### DIFF
--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -114,9 +114,7 @@ class BaseEstimator(ABC):
         from art.defences.preprocessor.preprocessor import Preprocessor
 
         if preprocessing is None:
-            from art.preprocessing.standardisation_mean_std.standardisation_mean_std import StandardisationMeanStd
-
-            return StandardisationMeanStd(mean=0.0, std=1.0)
+            return None
         elif isinstance(preprocessing, tuple):
             from art.preprocessing.standardisation_mean_std.standardisation_mean_std import StandardisationMeanStd
 


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request changes `BaseEstimator` to preserve `preprocessing=None`.

Fixes #915

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
