### PR TITLE
Add missing square in RBF kernel gradient. Fixes #921

### DIFF
--- a/art/estimators/classification/scikitlearn.py
+++ b/art/estimators/classification/scikitlearn.py
@@ -1265,7 +1265,7 @@ class ScikitlearnSVC(ClassGradientsMixin, LossGradientsMixin, ScikitlearnClassif
                 2
                 * self.model._gamma
                 * (-1)
-                * np.exp(-self.model._gamma * np.linalg.norm(x_sample - sv, ord=2))
+                * np.exp(-self.model._gamma * np.linalg.norm(x_sample - sv, ord=2) ** 2)
                 * (x_sample - sv)
             )
         elif self.model.kernel == "sigmoid":


### PR DESCRIPTION
# Description

Fixes a missing square in the gradient of the RBF kernel

Fixes #921 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

I ran the toy example in *classifier_scikitlearn_SVC_LinearSVC.ipynb* and found the result of the projected gradient descent attack to match the findings in [this paper](https://pralab.diee.unica.it/sites/default/files/biggio14-svm-chapter.pdf).

**Test Configuration**:
- Ubuntu 20.04
- Python 3.8
- ART 1.5.2

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
