### PR TITLE
Improve Psychoacoustic model and some ASR maintenance

### DIFF
--- a/art/attacks/evasion/adversarial_asr.py
+++ b/art/attacks/evasion/adversarial_asr.py
@@ -81,5 +81,6 @@ class CarliniWagnerASR(ImperceptibleASR):
         # set remaining stage 2 params to some random values
         self.alpha = 0.1
         self.learning_rate_2 = 0.1
+        self._loss_theta_min = 0.0
 
         self._check_params()

--- a/art/attacks/evasion/adversarial_asr.py
+++ b/art/attacks/evasion/adversarial_asr.py
@@ -68,7 +68,7 @@ class CarliniWagnerASR(ImperceptibleASR):
         """
         # pylint: disable=W0231
 
-        # re-implement init such that inherrited methods work
+        # re-implement init such that inherited methods work
         EvasionAttack.__init__(self, estimator=estimator)  # pylint: disable=W0233
         self.masker = None
         self.eps = eps
@@ -81,6 +81,12 @@ class CarliniWagnerASR(ImperceptibleASR):
         # set remaining stage 2 params to some random values
         self.alpha = 0.1
         self.learning_rate_2 = 0.1
-        self._loss_theta_min = 0.0
+        self.loss_theta_min = 0.0
+        self.decrease_factor_eps: float = 1.0
+        self.num_iter_decrease_eps: int = 1
+        self.increase_factor_alpha: float = 1.0
+        self.num_iter_increase_alpha: int = 1
+        self.decrease_factor_alpha: float = 1.0
+        self.num_iter_decrease_alpha: int = 1
 
         self._check_params()

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
@@ -669,7 +669,8 @@ class ImperceptibleASRPyTorch(EvasionAttack):
 
         psd = abs(transformed_x / win_length)
         original_max_psd = np.max(psd * psd)
-        psd = 10 * np.log10(psd * psd + 10e-20)
+        with np.errstate(divide='ignore'):
+            psd = (20 * np.log10(psd)).clip(min=-200)
         psd = 96 - np.max(psd) + psd
 
         # Compute freqs and barks

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
@@ -658,21 +658,12 @@ class ImperceptibleASRPyTorch(EvasionAttack):
         hop_length = int(sample_rate * window_stride)
         win_length = n_fft
 
-        window = self.estimator.model.audio_conf.window.value
+        window_name = self.estimator.model.audio_conf.window.value
 
-        if window == "hamming":
-            window_fn = scipy.signal.windows.hamming
-        elif window == "hann":
-            window_fn = scipy.signal.windows.hann
-        elif window == "blackman":
-            window_fn = scipy.signal.windows.blackman
-        elif window == "bartlett":
-            window_fn = scipy.signal.windows.bartlett
-        else:
-            raise NotImplementedError("Spectrogram window %s not supported." % window)
+        window = scipy.signal.get_window(window_name, win_length, fftbins=True)
 
         transformed_x = librosa.core.stft(
-            y=x, n_fft=n_fft, hop_length=hop_length, win_length=win_length, window=window_fn, center=False
+            y=x, n_fft=n_fft, hop_length=hop_length, win_length=win_length, window=window, center=False
         )
         transformed_x *= np.sqrt(8.0 / 3.0)
 

--- a/art/estimators/speech_recognition/pytorch_deep_speech.py
+++ b/art/estimators/speech_recognition/pytorch_deep_speech.py
@@ -275,10 +275,9 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
         :param batch_size: Batch size.
         :param transcription_output: Indicate whether the function will produce probability or transcription as
                                      prediction output. If transcription_output is not available, then probability
-                                     output is returned.
-        :type transcription_output: `bool`
+                                     output is returned. Default: True
         :return: Predicted probability (if transcription_output False) or transcription (default, if
-                 transcription_output is True or None):
+                 transcription_output is True):
                  - Probability return is a tuple of (probs, sizes), where `probs` is the probability of characters of
                  shape (nb_samples, seq_length, nb_classes) and `sizes` is the real sequence length of shape
                  (nb_samples,).
@@ -346,9 +345,9 @@ class PyTorchDeepSpeech(SpeechRecognizerMixin, PyTorchEstimator):
         result_outputs[batch_idx] = result_outputs_
 
         # Check if users want transcription outputs
-        transcription_output = kwargs.get("transcription_output")
+        transcription_output = kwargs.get("transcription_output", True)
 
-        if transcription_output is None or transcription_output is False:
+        if transcription_output is False:
             return result_outputs, result_output_sizes
 
         # Now users want transcription outputs

--- a/art/estimators/speech_recognition/tensorflow_lingvo.py
+++ b/art/estimators/speech_recognition/tensorflow_lingvo.py
@@ -513,7 +513,9 @@ class TensorFlowLingvoASR(SpeechRecognizerMixin, TensorFlowV2Estimator):
             gradient = gradient_padded[:length]
             gradients.append(gradient)
 
-        return np.array(gradients, dtype=object)
+        # for ragged input, use np.object dtype
+        dtype = np.float32 if x.ndim != 1 else np.object
+        return np.array(gradients, dtype=dtype)
 
     def _loss_gradient_per_sequence(self, x: np.ndarray, y: np.ndarray) -> np.ndarray:
         """
@@ -539,7 +541,9 @@ class TensorFlowLingvoASR(SpeechRecognizerMixin, TensorFlowV2Estimator):
             gradient = self._sess.run(self._loss_gradient_op, feed_dict)
             gradients.append(np.squeeze(gradient))
 
-        return np.array(gradients, dtype=object)
+        # for ragged input, use np.object dtype
+        dtype = np.float32 if x.ndim != 1 else np.object
+        return np.array(gradients, dtype=dtype)
 
     def set_learning_phase(self, train: bool) -> None:
         raise NotImplementedError

--- a/art/utils.py
+++ b/art/utils.py
@@ -1231,7 +1231,8 @@ def pad_sequence_input(x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     max_length = max(map(len, x))
     batch_size = x.shape[0]
 
-    x_padded = np.zeros((batch_size, max_length))
+    # note: use dtype of inner elements
+    x_padded = np.zeros((batch_size, max_length), dtype=x[0].dtype)
     x_mask = np.zeros((batch_size, max_length), dtype=bool)
 
     for i, x_i in enumerate(x):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ resampy==0.2.2
 ffmpeg-python==0.2.0
 cma==3.0.3
 pandas==1.1.4
+librosa==0.8.0
 
 # frameworks
 h5py==2.10.0


### PR DESCRIPTION
# Description

This PR fixes the Psychoacoustic model and stabilizes the imperceptible loss. Especially, switching to `librosa`'s STFT and using scalar PSD maximum, fixes stability issues with the imperceptible loss.

Fixes #929

Furthermore, the PR includes several minor improvements to ensure that framework-agnostic imperceptible ASR works as expected. These include:

* Return transcription as default in predict as explained in docstring  (Deepspeech estimator)
* Fix wrong gradient shape if `batch_size=1` as explained in docstring (Deepspeech estimator)
* Use periodic window for STFT instead symmetric window (Deepspeech-specific attack)
* Ensure correct `dtype` and streamline formulas to increase numerical stability (Psychoacoustic models)
* Refactor loss theta to only calculate masking thresholds once (Framework-agnostic attack)
* Add early stopping if loss theta < 0.05 to avoid running into gradients with `nan` values (Framework-agnostic attack)

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [x] Bug fix (non-breaking)

# Testing

Changes have been tested against the ten LibriSpeech test samples provided by Qin et al.

**Test Configuration**:
- Fedora 33
- Python 3.6.10
- ART 1.5.3 development

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
