### PR TITLE
BoundaryAttack: Fixed targeted/untargeted satisfied criterion + return min L2 norm adv. example

### DIFF
--- a/art/attacks/evasion/boundary.py
+++ b/art/attacks/evasion/boundary.py
@@ -291,7 +291,7 @@ class BoundaryAttack(EvasionAttack):
                     self.curr_epsilon /= self.step_adapt
 
                 if epsilon_ratio > 0:
-                    self._best_adv(original_sample, potential_advs[np.where(satisfied)[0]])
+                    x_adv = self._best_adv(original_sample, potential_advs[np.where(satisfied)[0]])
                     self.curr_adv = x_adv
                     break
             else:

--- a/art/attacks/evasion/boundary.py
+++ b/art/attacks/evasion/boundary.py
@@ -204,7 +204,8 @@ class BoundaryAttack(EvasionAttack):
             return x
 
         # If an initial adversarial example found, then go with boundary attack
-        x_adv = self._attack(initial_sample[0], x, y_p, initial_sample[1], self.delta, self.epsilon, clip_min, clip_max,)
+        x_adv = self._attack(initial_sample[0], x, y_p, initial_sample[1], self.delta, self.epsilon, clip_min,
+                             clip_max,)
 
         return x_adv
 


### PR DESCRIPTION
BoundaryAttack: Fixed targeted/untargeted satisfied criterion + return min L2 norm adv. example

Signed-off-by: Apostolos Modas <apostolos.modas@epfl.ch> or <modas.apost@gmail.com>

# Description

This pull requests fixes two issues of [BoundaryAttack](https://github.com/Trusted-AI/adversarial-robustness-toolbox/blob/dev_1.6.0/art/attacks/evasion/boundary.py):

1. The criterion for checking which adversarial candidates will be accepted/rejected during sampling (L251 and L273) was wrongly defined in a targeted fashion. However, in the untargeted settings, the criterion must be that the candidate adversarial predictions are different from the original image prediction. With this pull request, the criterion now takes into account if the attack is targeted/untargeted and acts accordingly.
2. Both in a normal (L282) and a suboptimal (L287) termination, the current implementation returns for no reason the first adversarial example out of the array of all the valid adversarial candidates. Since one of the goals of BoundaryAttack is to find minimal L2 adversarial perturbations, this pull request introduces a method that computes the minimum L2 distance between the candidate adversarial examples and the original image, and returns the one with the minimum L2 distance.

Fixes #923  

## Type of change

Please check all relevant options.

- [X] Improvement (non-breaking)
- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [X] (PyTorch) Compare the L2 norm and the predicted label **before** and **after** implementing the targeted/untargeted criterion. The code and results can be found in this Jupyter Notebook ([eval_targeted.ipynb.zip](https://github.com/Trusted-AI/adversarial-robustness-toolbox/files/6100866/eval_targeted.ipynb.zip)). Also, an in-line version of the Notebook is attached at the end of the comment (Appendix A)
- [X] (PyTorch) Compare the L2 norm **before** and **after** implementing the minimum L2 distance criterion (note: the targeted/untargeted criterion is also implemented). The code and results can be found in this Jupyter Notebook ([eval_min_L2.ipynb.zip](https://github.com/Trusted-AI/adversarial-robustness-toolbox/files/6100871/eval_min_L2.ipynb.zip)). Also, an in-line version of the Notebook is attached at the end of the comment (Appendix B)

**Test Configuration**:
- OS: Red Hat Enterprise Linux 8.3 (fedora)
- Python version: 3.8.8
- ART version or commit number: ART v1.5.2 and ART dev_1.6.0 (commit: [8840e80](https://github.com/Trusted-AI/adversarial-robustness-toolbox/commit/8840e80e8b85c208f5834f6b070d3bd15ce09583))
- PyTorch

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [X] I have made corresponding changes to the documentation (docstring in file)
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Appendix A: code and results for targeted/untargeted criterion

As you can see, the improvement in terms of L2 norm is significant compared to the previous version. Also, note how the predicted adversarial label changes (in contrast to the previous version).

```python
global_seed = 999

import sys
sys.path.append('./adversarial-robustness-toolbox')

import imagenet_stubs
import numpy as np
import torch
import torch.nn as nn
import torchvision.models as models
import torchvision.transforms as transforms
import random

import os
os.environ['PYTHONHASHSEED'] = str(global_seed)

from matplotlib import pyplot as plt
from PIL import Image

from art.estimators.classification import PyTorchClassifier
from art.attacks.evasion import BoundaryAttack
```

### Set determinism for reproducibility


```python
def set_global_seed(seed):
    torch.manual_seed(seed)
    torch.cuda.manual_seed(seed)
    torch.cuda.manual_seed_all(seed)
    np.random.seed(seed)
    random.seed(seed)
    torch.manual_seed(seed)
    torch.backends.cudnn.benchmark = False
    torch.backends.cudnn.deterministic = True
```

### Load Torchvision model


```python
model = models.resnet18(pretrained=True).eval()

mean = np.asarray((0.485, 0.456, 0.406), dtype=np.float32).reshape((1, 3, 1, 1))
std = np.asarray((0.229, 0.224, 0.225), dtype=np.float32).reshape((1, 3, 1, 1))

classifier = PyTorchClassifier(
    model=model,
    clip_values=(0.0, 1.0),
    input_shape=(3, 224, 224),
    nb_classes=1000,
    use_amp=False,
    preprocessing=(mean, std),
    channels_first=True,
    loss=nn.CrossEntropyLoss()
)
```

### Define image transformation


```python
def tf(x):
    x = np.expand_dims(x, axis=0)
    return np.transpose(x, (0, 3, 1, 2))
```

### Load image


```python
original_image_name = 'standard_poodle.jpg'
for image_path in imagenet_stubs.get_image_paths():
    if image_path.endswith(original_image_name):
        original_image = Image.open(image_path)
        original_image = original_image.resize((224, 224))
        original_image = np.array(original_image) / 255.0
        original_image = original_image.astype(np.float32)

original_label = np.argmax(classifier.predict(tf(original_image)), axis=1)[0]
print("\nOriginal label is: %d\n" % original_label)

plt.imshow(original_image)
plt.show()
```

    
    Original label is: 267
   
![output_8_1](https://user-images.githubusercontent.com/25585560/110311108-a1a2f280-8003-11eb-96f3-96fb4a84f004.png) 


### BoundaryAttack parameters


```python
max_iterations = 1000
delta = 0.01
epsilon = 0.01
targeted = False

iter_step = 50
```

### BoundaryAttack before fixing the targeted/untargeted adversarial check


```python
set_global_seed(global_seed)
use_modification = False

attack = BoundaryAttack(estimator=classifier,
                        targeted=targeted,
                        max_iter=0,
                        delta=delta,
                        epsilon=epsilon,
                        verbose=False,
                        use_modification=use_modification)

attack.rng = np.random.default_rng(seed=global_seed)

x_adv = None
for i in range(int(max_iterations / iter_step) + 1):
    x_adv = attack.generate(x=tf(original_image), x_adv_init=x_adv)

    #clear_output()
    L2_err = np.linalg.norm(x_adv[0] - tf(original_image)[0])
    pred_label = np.argmax(classifier.predict(x_adv)[0])
    
    if i == 0:
        print("[Init (rnd)] \t L2 error: %.2f \t | \t Class label: %d" % (L2_err,
                                                                           pred_label))
    else:
        print("[Iter %d] \t L2 error: %.2f \t | \t Class label: %d" % (i * iter_step,
                                                                    L2_err,
                                                                    pred_label))
    
    if hasattr(attack, 'curr_delta') and hasattr(attack, 'curr_epsilon'):
        attack.max_iter = iter_step 
        attack.delta = attack.curr_delta
        attack.epsilon = attack.curr_epsilon
    else:
        break
```

    [Init (rnd)] 	 L2 error: 151.05 	 | 	 Class label: 107
    [Iter 50] 	 L2 error: 90.13 	 | 	 Class label: 107
    [Iter 100] 	 L2 error: 84.27 	 | 	 Class label: 107
    [Iter 150] 	 L2 error: 78.92 	 | 	 Class label: 107
    [Iter 200] 	 L2 error: 71.42 	 | 	 Class label: 107
    [Iter 250] 	 L2 error: 65.56 	 | 	 Class label: 107
    [Iter 300] 	 L2 error: 60.66 	 | 	 Class label: 107
    [Iter 350] 	 L2 error: 55.42 	 | 	 Class label: 107
    [Iter 400] 	 L2 error: 50.90 	 | 	 Class label: 107
    [Iter 450] 	 L2 error: 47.86 	 | 	 Class label: 107
    [Iter 500] 	 L2 error: 45.06 	 | 	 Class label: 107
    [Iter 550] 	 L2 error: 43.16 	 | 	 Class label: 107
    [Iter 600] 	 L2 error: 41.19 	 | 	 Class label: 107
    [Iter 650] 	 L2 error: 39.18 	 | 	 Class label: 107
    [Iter 700] 	 L2 error: 37.34 	 | 	 Class label: 107
    [Iter 750] 	 L2 error: 36.15 	 | 	 Class label: 107
    [Iter 800] 	 L2 error: 34.91 	 | 	 Class label: 107
    [Iter 850] 	 L2 error: 33.46 	 | 	 Class label: 107
    [Iter 900] 	 L2 error: 32.56 	 | 	 Class label: 107
    [Iter 950] 	 L2 error: 31.16 	 | 	 Class label: 107
    [Iter 1000] 	 L2 error: 30.02 	 | 	 Class label: 107


### BoundaryAttack after fixing the targeted/untargeted adversarial check


```python
set_global_seed(global_seed)
use_modification = True

attack = BoundaryAttack(estimator=classifier,
                        targeted=targeted,
                        max_iter=0,
                        delta=delta,
                        epsilon=epsilon,
                        verbose=False,
                        use_modification=use_modification)

attack.rng = np.random.default_rng(seed=global_seed)

x_adv = None
for i in range(int(max_iterations / iter_step) + 1):
    x_adv = attack.generate(x=tf(original_image), x_adv_init=x_adv)

    #clear_output()
    L2_err = np.linalg.norm(x_adv[0] - tf(original_image)[0])
    pred_label = np.argmax(classifier.predict(x_adv)[0])
    
    if i == 0:
        print("[Init (rnd)] \t L2 error: %.2f \t | \t Class label: %d" % (L2_err,
                                                                           pred_label))
    else:
        print("[Iter %d] \t L2 error: %.2f \t | \t Class label: %d" % (i * iter_step,
                                                                    L2_err,
                                                                    pred_label))
    
    if hasattr(attack, 'curr_delta') and hasattr(attack, 'curr_epsilon'):
        attack.max_iter = iter_step 
        attack.delta = attack.curr_delta
        attack.epsilon = attack.curr_epsilon
    else:
        break
```

    [Init (rnd)] 	 L2 error: 151.05 	 | 	 Class label: 107
    [Iter 50] 	 L2 error: 27.55 	 | 	 Class label: 183
    [Iter 100] 	 L2 error: 17.69 	 | 	 Class label: 183
    [Iter 150] 	 L2 error: 12.42 	 | 	 Class label: 183
    [Iter 200] 	 L2 error: 9.39 	 | 	 Class label: 183
    [Iter 250] 	 L2 error: 7.21 	 | 	 Class label: 183
    [Iter 300] 	 L2 error: 6.25 	 | 	 Class label: 183
    [Iter 350] 	 L2 error: 5.54 	 | 	 Class label: 183
    [Iter 400] 	 L2 error: 4.90 	 | 	 Class label: 183
    [Iter 450] 	 L2 error: 4.49 	 | 	 Class label: 183
    [Iter 500] 	 L2 error: 4.10 	 | 	 Class label: 183
    [Iter 550] 	 L2 error: 3.78 	 | 	 Class label: 183
    [Iter 600] 	 L2 error: 3.54 	 | 	 Class label: 183
    [Iter 650] 	 L2 error: 3.29 	 | 	 Class label: 183
    [Iter 700] 	 L2 error: 3.10 	 | 	 Class label: 183
    [Iter 750] 	 L2 error: 2.99 	 | 	 Class label: 183
    [Iter 800] 	 L2 error: 2.84 	 | 	 Class label: 183
    [Iter 850] 	 L2 error: 2.74 	 | 	 Class label: 183
    [Iter 900] 	 L2 error: 2.63 	 | 	 Class label: 183
    [Iter 950] 	 L2 error: 2.53 	 | 	 Class label: 183
    [Iter 1000] 	 L2 error: 2.43 	 | 	 Class label: 183

# Appendix B: code and results for the min L2 criterion (targeted/untargeted criterion is also implemented)

As you can see the improvement is not that significant, but still the final L2 norm is slightly smaller. This makes sense since all the sampled adversarial candidates are very close to each other, hence the L2 norm from the original image should be roughly the same for all candidates. Note though that his effect might be stronger when applied on another image, or if some non-trivial geometric situations occur. Nevertheless, it seems like a proper criterion for having as the default, instead of just returning the first candidate.

```python
global_seed = 999

import sys
sys.path.append('./adversarial-robustness-toolbox')

import imagenet_stubs
import numpy as np
import torch
import torch.nn as nn
import torchvision.models as models
import torchvision.transforms as transforms
import random

import os
os.environ['PYTHONHASHSEED'] = str(global_seed)

from matplotlib import pyplot as plt
from PIL import Image

from art.estimators.classification import PyTorchClassifier
from art.attacks.evasion import BoundaryAttack
```

### Set determinism for reproducibility


```python
def set_global_seed(seed):
    torch.manual_seed(seed)
    torch.cuda.manual_seed(seed)
    torch.cuda.manual_seed_all(seed)
    np.random.seed(seed)
    random.seed(seed)
    torch.manual_seed(seed)
    torch.backends.cudnn.benchmark = False
    torch.backends.cudnn.deterministic = True
```

### Load Torchvision model


```python
model = models.resnet18(pretrained=True).eval()

mean = np.asarray((0.485, 0.456, 0.406), dtype=np.float32).reshape((1, 3, 1, 1))
std = np.asarray((0.229, 0.224, 0.225), dtype=np.float32).reshape((1, 3, 1, 1))

classifier = PyTorchClassifier(
    model=model,
    clip_values=(0.0, 1.0),
    input_shape=(3, 224, 224),
    nb_classes=1000,
    use_amp=False,
    preprocessing=(mean, std),
    channels_first=True,
    loss=nn.CrossEntropyLoss()
)
```

### Define image transformation


```python
def tf(x):
    x = np.expand_dims(x, axis=0)
    return np.transpose(x, (0, 3, 1, 2))
```

### Load image


```python
original_image_name = 'standard_poodle.jpg'
for image_path in imagenet_stubs.get_image_paths():
    if image_path.endswith(original_image_name):
        original_image = Image.open(image_path)
        original_image = original_image.resize((224, 224))
        original_image = np.array(original_image) / 255.0
        original_image = original_image.astype(np.float32)

original_label = np.argmax(classifier.predict(tf(original_image)), axis=1)[0]
print("\nOriginal label is: %d\n" % original_label)

plt.imshow(original_image)
plt.show()
```

    
    Original label is: 267
    

![output_8_1](https://user-images.githubusercontent.com/25585560/110311458-18d88680-8004-11eb-83af-9a8e7d3a870e.png)

    


### BoundaryAttack parameters


```python
max_iterations = 1000
delta = 0.01
epsilon = 0.01
targeted = False

iter_step = 50
```

### BoundaryAttack before fixing the min L2 criterion (targeted/untargeted already fixed)


```python
set_global_seed(global_seed)
use_modification = False

attack = BoundaryAttack(estimator=classifier,
                        targeted=targeted,
                        max_iter=0,
                        delta=delta,
                        epsilon=epsilon,
                        verbose=False,
                        use_modification=use_modification)

attack.rng = np.random.default_rng(seed=global_seed)

x_adv = None
for i in range(int(max_iterations / iter_step) + 1):
    x_adv = attack.generate(x=tf(original_image), x_adv_init=x_adv)

    #clear_output()
    L2_err = np.linalg.norm(x_adv[0] - tf(original_image)[0])
    pred_label = np.argmax(classifier.predict(x_adv)[0])
    
    if i == 0:
        print("[Init (rnd)] \t L2 error: %.2f \t | \t Class label: %d" % (L2_err,
                                                                           pred_label))
    else:
        print("[Iter %d] \t L2 error: %.2f \t | \t Class label: %d" % (i * iter_step,
                                                                    L2_err,
                                                                    pred_label))
    
    if hasattr(attack, 'curr_delta') and hasattr(attack, 'curr_epsilon'):
        attack.max_iter = iter_step 
        attack.delta = attack.curr_delta
        attack.epsilon = attack.curr_epsilon
    else:
        break
```

    [Init (rnd)] 	 L2 error: 151.05 	 | 	 Class label: 107
    [Iter 50] 	 L2 error: 27.55 	 | 	 Class label: 183
    [Iter 100] 	 L2 error: 17.69 	 | 	 Class label: 183
    [Iter 150] 	 L2 error: 12.42 	 | 	 Class label: 183
    [Iter 200] 	 L2 error: 9.39 	 | 	 Class label: 183
    [Iter 250] 	 L2 error: 7.21 	 | 	 Class label: 183
    [Iter 300] 	 L2 error: 6.25 	 | 	 Class label: 183
    [Iter 350] 	 L2 error: 5.54 	 | 	 Class label: 183
    [Iter 400] 	 L2 error: 4.90 	 | 	 Class label: 183
    [Iter 450] 	 L2 error: 4.49 	 | 	 Class label: 183
    [Iter 500] 	 L2 error: 4.10 	 | 	 Class label: 183
    [Iter 550] 	 L2 error: 3.78 	 | 	 Class label: 183
    [Iter 600] 	 L2 error: 3.54 	 | 	 Class label: 183
    [Iter 650] 	 L2 error: 3.29 	 | 	 Class label: 183
    [Iter 700] 	 L2 error: 3.10 	 | 	 Class label: 183
    [Iter 750] 	 L2 error: 2.99 	 | 	 Class label: 183
    [Iter 800] 	 L2 error: 2.84 	 | 	 Class label: 183
    [Iter 850] 	 L2 error: 2.74 	 | 	 Class label: 183
    [Iter 900] 	 L2 error: 2.63 	 | 	 Class label: 183
    [Iter 950] 	 L2 error: 2.53 	 | 	 Class label: 183
    [Iter 1000] 	 L2 error: 2.43 	 | 	 Class label: 183


### BoundaryAttack after fixing the min L2 criterion (targeted/untargeted already fixed)


```python
set_global_seed(global_seed)
use_modification = True

attack = BoundaryAttack(estimator=classifier,
                        targeted=targeted,
                        max_iter=0,
                        delta=delta,
                        epsilon=epsilon,
                        verbose=False,
                        use_modification=use_modification)

attack.rng = np.random.default_rng(seed=global_seed)

x_adv = None
for i in range(int(max_iterations / iter_step) + 1):
    x_adv = attack.generate(x=tf(original_image), x_adv_init=x_adv)

    #clear_output()
    L2_err = np.linalg.norm(x_adv[0] - tf(original_image)[0])
    pred_label = np.argmax(classifier.predict(x_adv)[0])
    
    if i == 0:
        print("[Init (rnd)] \t L2 error: %.2f \t | \t Class label: %d" % (L2_err,
                                                                           pred_label))
    else:
        print("[Iter %d] \t L2 error: %.2f \t | \t Class label: %d" % (i * iter_step,
                                                                    L2_err,
                                                                    pred_label))
    
    if hasattr(attack, 'curr_delta') and hasattr(attack, 'curr_epsilon'):
        attack.max_iter = iter_step 
        attack.delta = attack.curr_delta
        attack.epsilon = attack.curr_epsilon
    else:
        break
```

    [Init (rnd)] 	 L2 error: 151.05 	 | 	 Class label: 107
    [Iter 50] 	 L2 error: 29.31 	 | 	 Class label: 183
    [Iter 100] 	 L2 error: 21.10 	 | 	 Class label: 183
    [Iter 150] 	 L2 error: 14.83 	 | 	 Class label: 183
    [Iter 200] 	 L2 error: 10.65 	 | 	 Class label: 183
    [Iter 250] 	 L2 error: 8.19 	 | 	 Class label: 183
    [Iter 300] 	 L2 error: 6.72 	 | 	 Class label: 183
    [Iter 350] 	 L2 error: 5.49 	 | 	 Class label: 183
    [Iter 400] 	 L2 error: 4.75 	 | 	 Class label: 183
    [Iter 450] 	 L2 error: 4.31 	 | 	 Class label: 183
    [Iter 500] 	 L2 error: 3.94 	 | 	 Class label: 183
    [Iter 550] 	 L2 error: 3.67 	 | 	 Class label: 183
    [Iter 600] 	 L2 error: 3.42 	 | 	 Class label: 183
    [Iter 650] 	 L2 error: 3.22 	 | 	 Class label: 183
    [Iter 700] 	 L2 error: 3.04 	 | 	 Class label: 183
    [Iter 750] 	 L2 error: 2.89 	 | 	 Class label: 183
    [Iter 800] 	 L2 error: 2.76 	 | 	 Class label: 183
    [Iter 850] 	 L2 error: 2.65 	 | 	 Class label: 183
    [Iter 900] 	 L2 error: 2.55 	 | 	 Class label: 183
    [Iter 950] 	 L2 error: 2.44 	 | 	 Class label: 183
    [Iter 1000] 	 L2 error: 2.35 	 | 	 Class label: 183