### PR TITLE
Protect labels from overwriting in PyTorchFasterRCNN.loss_gradient

### DIFF
--- a/art/estimators/object_detection/pytorch_faster_rcnn.py
+++ b/art/estimators/object_detection/pytorch_faster_rcnn.py
@@ -171,10 +171,15 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
                 raise NotImplementedError
             else:
                 if y is not None and isinstance(y[0]["boxes"], np.ndarray):
+                    y_tensor = list()
                     for i, y_i in enumerate(y):
-                        y[i]["boxes"] = torch.from_numpy(y_i["boxes"]).type(torch.float).to(self._device)
-                        y[i]["labels"] = torch.from_numpy(y_i["labels"]).type(torch.int64).to(self._device)
-                        y[i]["scores"] = torch.from_numpy(y_i["scores"]).to(self._device)
+                        y_t = dict()
+                        y_t["boxes"] = torch.from_numpy(y_i["boxes"]).type(torch.float).to(self._device)
+                        y_t["labels"] = torch.from_numpy(y_i["labels"]).type(torch.int64).to(self._device)
+                        y_t["scores"] = torch.from_numpy(y_i["scores"]).to(self._device)
+                        y_tensor.append(y_t)
+                else:
+                    y_tensor = y
 
                 transform = torchvision.transforms.Compose([torchvision.transforms.ToTensor()])
                 image_tensor_list_grad = list()
@@ -190,7 +195,7 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
                     image_tensor_list_grad.append(x_grad)
                     x_grad_1 = torch.unsqueeze(x_grad, dim=0)
                     x_preprocessed_i, y_preprocessed_i = self._apply_preprocessing(
-                        x_grad_1, y=[y[i]], fit=False, no_grad=False
+                        x_grad_1, y=[y_tensor[i]], fit=False, no_grad=False
                     )
                     x_preprocessed_i = torch.squeeze(x_preprocessed_i)
                     y_preprocessed.append(y_preprocessed_i[0])
@@ -200,10 +205,14 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
             x_preprocessed, y_preprocessed = self._apply_preprocessing(x, y=y, fit=False, no_grad=True)
 
             if y_preprocessed is not None and isinstance(y_preprocessed[0]["boxes"], np.ndarray):
+                y_preprocessed_tensor = list()
                 for i, y_i in enumerate(y_preprocessed):
-                    y_preprocessed[i]["boxes"] = torch.from_numpy(y_i["boxes"]).type(torch.float).to(self._device)
-                    y_preprocessed[i]["labels"] = torch.from_numpy(y_i["labels"]).type(torch.int64).to(self._device)
-                    y_preprocessed[i]["scores"] = torch.from_numpy(y_i["scores"]).to(self._device)
+                    y_preprocessed_t = dict()
+                    y_preprocessed_t["boxes"] = torch.from_numpy(y_i["boxes"]).type(torch.float).to(self._device)
+                    y_preprocessed_t["labels"] = torch.from_numpy(y_i["labels"]).type(torch.int64).to(self._device)
+                    y_preprocessed_t["scores"] = torch.from_numpy(y_i["scores"]).to(self._device)
+                    y_preprocessed_tensor.append(y_preprocessed_t)
+                y_preprocessed = y_preprocessed_tensor
 
             transform = torchvision.transforms.Compose([torchvision.transforms.ToTensor()])
             image_tensor_list_grad = list()


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds updates to not overwrite the numpy array of labels provided to `PyTorchFasterRCNN.loss_gradient` with torch Tensors. This should not affect the `PyTorchFasterRCNN` but will avoid unexpected modifications the user's label data type.

Fixes #928

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
