### PR TITLE
Feature/rename skip framework marker

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -74,10 +74,10 @@ def get_default_framework():
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--mlFramework",
+        "--framework",
         action="store",
         default=get_default_framework(),
-        help="ART tests allow you to specify which mlFramework to use. The default mlFramework used is `tensorflow`. "
+        help="ART tests allow you to specify which framework to use. The default framework used is `tensorflow`. "
         "Other options available are {0}".format(art_supported_frameworks),
     )
     parser.addoption(
@@ -643,7 +643,7 @@ def create_test_image(create_test_dir):
 
 @pytest.fixture(scope="session")
 def framework(request):
-    ml_framework = request.config.getoption("--mlFramework")
+    ml_framework = request.config.getoption("--framework")
     if ml_framework == "tensorflow":
         import tensorflow as tf
 
@@ -654,12 +654,12 @@ def framework(request):
 
     if ml_framework not in art_supported_frameworks:
         raise Exception(
-            "mlFramework value {0} is unsupported. Please use one of these valid values: {1}".format(
+            "framework value {0} is unsupported. Please use one of these valid values: {1}".format(
                 ml_framework, " ".join(art_supported_frameworks)
             )
         )
-    # if utils_test.is_valid_framework(mlFramework):
-    #     raise Exception("The mlFramework specified was incorrect. Valid options available
+    # if utils_test.is_valid_framework(framework):
+    #     raise Exception("The framework specified was incorrect. Valid options available
     #     are {0}".format(art_supported_frameworks))
     return ml_framework
 

--- a/conftest.py
+++ b/conftest.py
@@ -755,7 +755,7 @@ def get_mnist_dataset(load_mnist_dataset, mnist_shape):
     np.testing.assert_array_almost_equal(y_test_mnist_original, y_test_mnist, decimal=3)
 
 
-# ART test fixture to skip test for specific mlFramework values
+# ART test fixture to skip test for specific framework values
 # eg: @pytest.mark.only_with_platform("tensorflow")
 @pytest.fixture(autouse=True)
 def only_with_platform(request, framework):
@@ -764,13 +764,13 @@ def only_with_platform(request, framework):
             pytest.skip("skipped on this platform: {}".format(framework))
 
 
-# ART test fixture to skip test for specific mlFramework values
-# eg: @pytest.mark.skipMlFramework("tensorflow", "keras", "pytorch", "scikitlearn",
+# ART test fixture to skip test for specific framework values
+# eg: @pytest.mark.skip_framework("tensorflow", "keras", "pytorch", "scikitlearn",
 # "mxnet", "kerastf", "non_dl_frameworks", "dl_frameworks")
 @pytest.fixture(autouse=True)
 def skip_by_framework(request, framework):
-    if request.node.get_closest_marker("skipMlFramework"):
-        framework_to_skip_list = list(request.node.get_closest_marker("skipMlFramework").args)
+    if request.node.get_closest_marker("skip_framework"):
+        framework_to_skip_list = list(request.node.get_closest_marker("skip_framework").args)
         if "dl_frameworks" in framework_to_skip_list:
             framework_to_skip_list.extend(deep_learning_frameworks)
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -8,61 +8,61 @@ export TF_CPP_MIN_LOG_LEVEL="3"
 
 #NOTE: All the tests should be ran within this loop. All other tests are legacy tests that must be
 # made framework independent to be incorporated within this loop
-mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
-mlFramework=$1
+frameworkList=("tensorflow" "keras" "pytorch" "scikitlearn" "mxnet" "kerastf")
+framework=$1
 
-if [[ ${mlFramework} != "legacy" ]]
+if [[ ${framework} != "legacy" ]]
 then
     echo "#######################################################################"
-    echo "############## Running tests with framework $mlFramework ##############"
+    echo "############### Running tests with framework $framework ###############"
     echo "#######################################################################"
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/defences/detector/poison/test_spectral_signature_defense.py --mlFramework=$mlFramework --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/defences/detector/poison/test_spectral_signature_defense.py --framework=$framework --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/detector/poison/test_spectral_signature_defense.py tests"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/defences/preprocessor --mlFramework=$mlFramework --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/defences/preprocessor --framework=$framework --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor tests"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/defences/transformer --mlFramework=$mlFramework --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/defences/transformer --framework=$framework --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/transformer tests"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/preprocessing/audio --mlFramework=$mlFramework --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/preprocessing/audio --framework=$framework --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed preprocessing/audio tests"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/preprocessing/expectation_over_transformation --mlFramework=$mlFramework --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/preprocessing/expectation_over_transformation --framework=$framework --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed preprocessing/expectation_over_transformation tests"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/utils --mlFramework=$mlFramework --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/utils --framework=$framework --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed utils tests"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv -s tests/attacks/poison/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv -s tests/attacks/poison/ --framework=$framework  --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/poison tests"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv -s tests/attacks/evasion/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv -s tests/attacks/evasion/ --framework=$framework  --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_shadow_attack.py"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/estimators/speech_recognition/ --mlFramework=$mlFramework  --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/estimators/speech_recognition/ --framework=$framework  --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/speech_recognition tests"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/attacks/inference/ --mlFramework=$mlFramework --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/attacks/inference/ --framework=$framework --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/inference"; fi
 
-    pytest -q -s tests/attacks/evasion/test_brendel_and_bethge.py --mlFramework=$mlFramework --durations=0
+    pytest -q -s tests/attacks/evasion/test_brendel_and_bethge.py --framework=$framework --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evasion/test_brendel_and_bethge.py"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append -q -vv tests/classifiersFrameworks/  --mlFramework=$mlFramework --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append -q -vv tests/classifiersFrameworks/  --framework=$framework --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed classifiersFrameworks tests"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/defences/preprocessor/test_spatial_smoothing_pytorch.py  --mlFramework=$mlFramework --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/defences/preprocessor/test_spatial_smoothing_pytorch.py  --framework=$framework --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor/test_spatial_smoothing_pytorch.py tests"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/estimators/classification/test_deeplearning_common.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-    if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification/test_deeplearning_common.py $mlFramework"; fi
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/estimators/classification/test_deeplearning_common.py --framework=$framework --skip_travis=True --durations=0
+    if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification/test_deeplearning_common.py $framework"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/estimators/classification/test_deeplearning_specific.py --mlFramework=$mlFramework --skip_travis=True --durations=0
-    if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification tests for framework $mlFramework"; fi
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/estimators/classification/test_deeplearning_specific.py --framework=$framework --skip_travis=True --durations=0
+    if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed estimators/classification tests for framework $framework"; fi
 
-    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/metrics/privacy --mlFramework=$mlFramework --skip_travis=True --durations=0
+    pytest --cov-report=xml --cov=art --cov-append  -q -vv tests/metrics/privacy --framework=$framework --skip_travis=True --durations=0
     if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed metrics/privacy tests"; fi
 else
     declare -a attacks=("tests/attacks/test_adversarial_patch.py" \

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,8 @@ description-file = README.md
 pep8maxlinelength = 120
 pep8ignore = *.py E402 W503 E203 E231 E251 E701
 markers =
-    skipMlFramework: marks a test to be skipped for specific mlFramework values. Valid values are ("tensorflow" "keras" "pytorch" "scikitlearn")
-    only_with_platform: DEPRECATED only used for legacy tests. Use skipMlFramework instead. marks a test to be performed only for a specific mlFramework values
+    skip_framework: marks a test to be skipped for specific framework values. Valid values are ("tensorflow" "keras" "mxnet" "pytorch" "scikitlearn")
+    only_with_platform: DEPRECATED only used for legacy tests. Use skip_framework instead. marks a test to be performed only for a specific framework value
     framework_agnostic: marks a test to be agnostic to frameworks and run only for one default framework
     skip_travis: Skips a test marked with this decorator if the command line argument skip_travis is set to true
     skip_module: Skip the test if a module is not available in the current environment

--- a/tests/attacks/evasion/test_adversarial_asr.py
+++ b/tests/attacks/evasion/test_adversarial_asr.py
@@ -45,7 +45,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
     def test_implements_abstract_methods(self, art_warning, asr_dummy_estimator):
         try:
             CarliniWagnerASR(estimator=asr_dummy_estimator())
@@ -61,7 +61,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("tensorflow1", "mxnet", "kerastf", "non_dl_frameworks")
     def test_generate_batch(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data

--- a/tests/attacks/evasion/test_auto_attack.py
+++ b/tests/attacks/evasion/test_auto_attack.py
@@ -41,7 +41,7 @@ def fix_get_mnist_subset(get_mnist_dataset):
     yield x_train_mnist[:n_train], y_train_mnist[:n_train], x_test_mnist[:n_test], y_test_mnist[:n_test]
 
 
-@pytest.mark.skipMlFramework("tensorflow1", "keras", "pytorch", "non_dl_frameworks", "mxnet", "kerastf")
+@pytest.mark.skip_framework("tensorflow1", "keras", "pytorch", "non_dl_frameworks", "mxnet", "kerastf")
 def test_generate_default(art_warning, fix_get_mnist_subset, image_dl_estimator):
     try:
         classifier, _ = image_dl_estimator(from_logits=True)
@@ -60,7 +60,7 @@ def test_generate_default(art_warning, fix_get_mnist_subset, image_dl_estimator)
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("tensorflow1", "keras", "pytorch", "non_dl_frameworks", "mxnet", "kerastf")
+@pytest.mark.skip_framework("tensorflow1", "keras", "pytorch", "non_dl_frameworks", "mxnet", "kerastf")
 def test_generate_attacks_and_targeted(art_warning, fix_get_mnist_subset, image_dl_estimator):
     try:
         classifier, _ = image_dl_estimator(from_logits=True)

--- a/tests/attacks/evasion/test_auto_projected_gradient_descent.py
+++ b/tests/attacks/evasion/test_auto_projected_gradient_descent.py
@@ -38,7 +38,7 @@ def fix_get_mnist_subset(get_mnist_dataset):
     yield x_train_mnist[:n_train], y_train_mnist[:n_train], x_test_mnist[:n_test], y_test_mnist[:n_test]
 
 
-@pytest.mark.skipMlFramework("tensorflow1", "keras", "pytorch", "non_dl_frameworks", "mxnet", "kerastf")
+@pytest.mark.skip_framework("tensorflow1", "keras", "pytorch", "non_dl_frameworks", "mxnet", "kerastf")
 def test_generate(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:
         classifier = image_dl_estimator_for_attack(AutoProjectedGradientDescent)

--- a/tests/attacks/evasion/test_brendel_and_bethge.py
+++ b/tests/attacks/evasion/test_brendel_and_bethge.py
@@ -30,7 +30,7 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipMlFramework("tensorflow1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skip_framework("tensorflow1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("targeted", [True, False])
 @pytest.mark.parametrize("norm", [1, 2, np.inf, "inf"])
 def test_generate(art_warning, get_default_mnist_subset, image_dl_estimator_for_attack, targeted, norm):

--- a/tests/attacks/evasion/test_fast_gradient.py
+++ b/tests/attacks/evasion/test_fast_gradient.py
@@ -147,7 +147,7 @@ def test_minimal_perturbations_images(art_warning, fix_get_mnist_subset, image_d
 
 
 @pytest.mark.parametrize("norm", [np.inf, 1, 2])
-@pytest.mark.skipMlFramework("pytorch")  # temporarily skipping for pytorch until find bug fix in bounded test
+@pytest.mark.skip_framework("pytorch")  # temporarily skipping for pytorch until find bug fix in bounded test
 @pytest.mark.framework_agnostic
 def test_norm_images(art_warning, norm, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:
@@ -183,7 +183,7 @@ def test_norm_images(art_warning, norm, fix_get_mnist_subset, image_dl_estimator
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("scikitlearn")  # temporarily skipping for scikitlearn until find bug fix in bounded test
+@pytest.mark.skip_framework("scikitlearn")  # temporarily skipping for scikitlearn until find bug fix in bounded test
 @pytest.mark.parametrize("targeted, clipped", [(True, True), (True, False), (False, True), (False, False)])
 @pytest.mark.framework_agnostic
 def test_tabular(art_warning, tabular_dl_estimator, framework, get_iris_dataset, targeted, clipped):

--- a/tests/attacks/evasion/test_feature_adversaries.py
+++ b/tests/attacks/evasion/test_feature_adversaries.py
@@ -36,7 +36,7 @@ def fix_get_mnist_subset(get_mnist_dataset):
     yield x_train_mnist[:n_train], y_train_mnist[:n_train], x_test_mnist[:n_test], y_test_mnist[:n_test]
 
 
-@pytest.mark.skipMlFramework("pytorch")
+@pytest.mark.skip_framework("pytorch")
 @pytest.mark.framework_agnostic
 def test_images(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:

--- a/tests/attacks/evasion/test_frame_saliency.py
+++ b/tests/attacks/evasion/test_frame_saliency.py
@@ -40,7 +40,7 @@ def fix_get_mnist_subset(get_mnist_dataset):
     yield x_train_mnist[:n_train], y_train_mnist[:n_train], x_test_mnist[:n_test], y_test_mnist[:n_test]
 
 
-@pytest.mark.skipMlFramework("pytorch")
+@pytest.mark.skip_framework("pytorch")
 @pytest.mark.framework_agnostic
 def test_one_shot(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:
@@ -61,7 +61,7 @@ def test_one_shot(art_warning, fix_get_mnist_subset, image_dl_estimator_for_atta
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("pytorch")
+@pytest.mark.skip_framework("pytorch")
 @pytest.mark.framework_agnostic
 def test_iterative_saliency(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:
@@ -86,7 +86,7 @@ def test_iterative_saliency(art_warning, fix_get_mnist_subset, image_dl_estimato
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("pytorch")
+@pytest.mark.skip_framework("pytorch")
 @pytest.mark.framework_agnostic
 def test_iterative_saliency_refresh(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:

--- a/tests/attacks/evasion/test_imperceptible_asr.py
+++ b/tests/attacks/evasion/test_imperceptible_asr.py
@@ -34,21 +34,21 @@ class TestImperceptibleASR:
     Test the ImperceptibleASR attack.
     """
 
-    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_is_subclass(self, art_warning):
         try:
             assert issubclass(ImperceptibleASR, EvasionAttack)
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_implements_abstract_methods(self, art_warning, asr_dummy_estimator):
         try:
             ImperceptibleASR(estimator=asr_dummy_estimator(), masker=PsychoacousticMasker())
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_generate(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -62,7 +62,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_generate_batch(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -78,7 +78,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_adversarial(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -105,7 +105,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_imperceptible(self, art_warning, mocker, asr_dummy_estimator, audio_data):
         try:
             test_input, test_target = audio_data
@@ -132,7 +132,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("tensorflow", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("tensorflow", "mxnet", "kerastf", "non_dl_frameworks")
     def test_loss_gradient_masking_threshold(self, art_warning, asr_dummy_estimator, audio_data):
         try:
             test_input, _ = audio_data
@@ -150,7 +150,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_loss_gradient_masking_threshold_tf(self, art_warning, asr_dummy_estimator, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
@@ -175,7 +175,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("tensorflow", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("tensorflow", "mxnet", "kerastf", "non_dl_frameworks")
     def test_loss_gradient_masking_threshold_torch(self, art_warning, asr_dummy_estimator, audio_batch_padded):
         try:
             test_delta = audio_batch_padded
@@ -192,7 +192,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_approximate_power_spectral_density_tf(self, art_warning, asr_dummy_estimator, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
@@ -221,7 +221,7 @@ class TestImperceptibleASR:
         except ARTTestException as e:
             art_warning(e)
 
-    @pytest.mark.skipMlFramework("tensorflow", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("tensorflow", "mxnet", "kerastf", "non_dl_frameworks")
     def test_approximate_power_spectral_density_torch(self, art_warning, asr_dummy_estimator, audio_batch_padded):
         try:
             import torch

--- a/tests/attacks/evasion/test_imperceptible_asr_pytorch.py
+++ b/tests/attacks/evasion/test_imperceptible_asr_pytorch.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_module("apex.amp", "deepspeech_pytorch", "torchaudio")
-@pytest.mark.skipMlFramework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skip_framework("tensorflow", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("use_amp", [False, True])
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
 def test_imperceptible_asr_pytorch(art_warning, expected_values, use_amp, device_type):

--- a/tests/attacks/inference/attribute_inference/test_black_box.py
+++ b/tests/attacks/inference/attribute_inference/test_black_box.py
@@ -38,7 +38,7 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipMlFramework("dl_frameworks")
+@pytest.mark.skip_framework("dl_frameworks")
 def test_black_box(art_warning, decision_tree_estimator, get_iris_dataset):
     try:
         attack_feature = 2  # petal length
@@ -88,7 +88,7 @@ def test_black_box(art_warning, decision_tree_estimator, get_iris_dataset):
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("dl_frameworks")
+@pytest.mark.skip_framework("dl_frameworks")
 def test_black_box_with_model(art_warning, decision_tree_estimator, get_iris_dataset):
     try:
         attack_feature = 2  # petal length
@@ -146,7 +146,7 @@ def test_black_box_with_model(art_warning, decision_tree_estimator, get_iris_dat
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("dl_frameworks")
+@pytest.mark.skip_framework("dl_frameworks")
 def test_black_box_one_hot(art_warning, get_iris_dataset):
     try:
         attack_feature = 2  # petal length
@@ -207,7 +207,7 @@ def test_black_box_one_hot(art_warning, get_iris_dataset):
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("dl_frameworks")
+@pytest.mark.skip_framework("dl_frameworks")
 def test_black_box_one_hot_float(art_warning, get_iris_dataset):
     try:
         attack_feature = 2  # petal length

--- a/tests/attacks/inference/attribute_inference/test_white_box_decision_tree.py
+++ b/tests/attacks/inference/attribute_inference/test_white_box_decision_tree.py
@@ -31,7 +31,7 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipMlFramework("dl_frameworks")
+@pytest.mark.skip_framework("dl_frameworks")
 def test_white_box(art_warning, decision_tree_estimator, get_iris_dataset):
     try:
         attack_feature = 2  # petal length

--- a/tests/attacks/inference/attribute_inference/test_white_box_lifestyle_decision_tree.py
+++ b/tests/attacks/inference/attribute_inference/test_white_box_lifestyle_decision_tree.py
@@ -33,7 +33,7 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipMlFramework("dl_frameworks")
+@pytest.mark.skip_framework("dl_frameworks")
 def test_white_box_lifestyle(art_warning, decision_tree_estimator, get_iris_dataset):
     try:
         attack_feature = 2  # petal length

--- a/tests/attacks/inference/membership_inference/test_black_box.py
+++ b/tests/attacks/inference/membership_inference/test_black_box.py
@@ -66,7 +66,7 @@ def test_black_box_loss_tabular(art_warning, model_type, tabular_dl_estimator_fo
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("tensorflow", "pytorch", "scikitlearn", "mxnet", "kerastf")
+@pytest.mark.skip_framework("tensorflow", "pytorch", "scikitlearn", "mxnet", "kerastf")
 @pytest.mark.skipif(keras.__version__.startswith("2.2"), reason="requires Keras 2.3.0 or higher")
 def test_black_box_keras_loss(art_warning, get_iris_dataset):
     try:
@@ -116,7 +116,7 @@ def test_black_box_tabular_gb(art_warning, tabular_dl_estimator_for_attack, get_
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("tensorflow", "keras", "scikitlearn", "mxnet", "kerastf")
+@pytest.mark.skip_framework("tensorflow", "keras", "scikitlearn", "mxnet", "kerastf")
 def test_black_box_with_model(art_warning, tabular_dl_estimator_for_attack, estimator_for_attack, get_iris_dataset):
     try:
         classifier = tabular_dl_estimator_for_attack(MembershipInferenceBlackBox)

--- a/tests/attacks/poison/test_clean_label_backdoor_attack.py
+++ b/tests/attacks/poison/test_clean_label_backdoor_attack.py
@@ -30,7 +30,7 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks", "pytorch", "mxnet")
+@pytest.mark.skip_framework("non_dl_frameworks", "pytorch", "mxnet")
 def test_poison(art_warning, get_default_mnist_subset, image_dl_estimator):
     try:
         (x_train, y_train), (_, _) = get_default_mnist_subset
@@ -47,7 +47,7 @@ def test_poison(art_warning, get_default_mnist_subset, image_dl_estimator):
 
 
 @pytest.mark.parametrize("params", [dict(pp_poison=-0.2), dict(pp_poison=1.2)])
-@pytest.mark.skipMlFramework("non_dl_frameworks", "pytorch", "mxnet")
+@pytest.mark.skip_framework("non_dl_frameworks", "pytorch", "mxnet")
 def test_failure_modes(art_warning, get_default_mnist_subset, image_dl_estimator, params):
     try:
         (x_train, y_train), (_, _) = get_default_mnist_subset

--- a/tests/attacks/utils.py
+++ b/tests/attacks/utils.py
@@ -160,7 +160,7 @@ def backend_targeted_tabular(attack, fix_get_iris):
     logger.info("Success rate of targeted boundary on Iris: %.2f%%", (accuracy * 100))
 
 
-def back_end_untargeted_images(attack, fix_get_mnist_subset, fix_mlFramework):
+def back_end_untargeted_images(attack, fix_get_mnist_subset, fix_framework):
     (x_train_mnist, y_train_mnist, x_test_mnist, y_test_mnist) = fix_get_mnist_subset
 
     x_test_adv = attack.generate(x_test_mnist)
@@ -171,7 +171,7 @@ def back_end_untargeted_images(attack, fix_get_mnist_subset, fix_mlFramework):
     y_pred_adv = np.argmax(attack.estimator.predict(x_test_adv), axis=1)
     assert (y_pred != y_pred_adv).any()
 
-    if fix_mlFramework in ["keras"]:
+    if fix_framework in ["keras"]:
         k.clear_session()
 
 
@@ -181,7 +181,7 @@ def backend_untargeted_tabular(attack, iris_dataset, clipped):
     x_test_adv = attack.generate(x_test_iris)
 
     # TODO remove that platform specific case
-    # if mlFramework in ["scikitlearn"]:
+    # if framework in ["scikitlearn"]:
     #     np.testing.assert_array_almost_equal(np.abs(x_test_adv - x_test_iris), .1, decimal=5)
 
     check_adverse_example_x(x_test_adv, x_test_iris)

--- a/tests/defences/detector/poison/test_spectral_signature_defense.py
+++ b/tests/defences/detector/poison/test_spectral_signature_defense.py
@@ -45,7 +45,7 @@ def test_wrong_parameters(params, art_warning, get_default_mnist_subset, image_d
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks", "mxnet")
+@pytest.mark.skip_framework("non_dl_frameworks", "mxnet")
 def test_detect_poison(art_warning, get_default_mnist_subset, image_dl_estimator):
     try:
         (x_train_mnist, y_train_mnist), (_, _) = get_default_mnist_subset
@@ -66,7 +66,7 @@ def test_detect_poison(art_warning, get_default_mnist_subset, image_dl_estimator
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks", "mxnet")
+@pytest.mark.skip_framework("non_dl_frameworks", "mxnet")
 def test_evaluate_defense(art_warning, get_default_mnist_subset, image_dl_estimator):
     try:
         (x_train_mnist, y_train_mnist), (_, _) = get_default_mnist_subset

--- a/tests/defences/preprocessor/test_inverse_gan.py
+++ b/tests/defences/preprocessor/test_inverse_gan.py
@@ -36,7 +36,7 @@ def fix_get_mnist_subset(get_mnist_dataset):
     yield x_train_mnist[:n_train], y_train_mnist[:n_train], x_test_mnist[:n_test], y_test_mnist[:n_test]
 
 
-@pytest.mark.skipMlFramework("keras", "pytorch", "scikitlearn", "mxnet", "kerastf")
+@pytest.mark.skip_framework("keras", "pytorch", "scikitlearn", "mxnet", "kerastf")
 def test_inverse_gan(art_warning, fix_get_mnist_subset, image_dl_estimator_for_attack):
     try:
         (x_train_mnist, y_train_mnist, x_test_mnist, y_test_mnist) = fix_get_mnist_subset

--- a/tests/defences/preprocessor/test_mp3_compression.py
+++ b/tests/defences/preprocessor/test_mp3_compression.py
@@ -82,7 +82,7 @@ def test_non_temporal_data_error(art_warning, image_batch_small):
 
 
 @pytest.mark.parametrize("channels_first", [True, False])
-@pytest.mark.skipMlFramework("keras", "pytorch", "scikitlearn", "mxnet")
+@pytest.mark.skip_framework("keras", "pytorch", "scikitlearn", "mxnet")
 def test_mp3_compresssion(art_warning, audio_batch, channels_first):
     try:
         test_input, test_output, sample_rate = audio_batch

--- a/tests/defences/preprocessor/test_video_compression.py
+++ b/tests/defences/preprocessor/test_video_compression.py
@@ -43,7 +43,7 @@ def video_batch(channels_first):
 
 
 @pytest.mark.parametrize("channels_first", [True, False])
-@pytest.mark.skipMlFramework("keras", "pytorch", "scikitlearn", "mxnet")
+@pytest.mark.skip_framework("keras", "pytorch", "scikitlearn", "mxnet")
 def test_video_compresssion(art_warning, video_batch, channels_first):
     try:
         test_input, test_output = video_batch
@@ -54,7 +54,7 @@ def test_video_compresssion(art_warning, video_batch, channels_first):
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("keras", "pytorch", "scikitlearn", "mxnet")
+@pytest.mark.skip_framework("keras", "pytorch", "scikitlearn", "mxnet")
 def test_compress_video_call(art_warning):
     try:
         test_input = np.arange(12).reshape((1, 3, 1, 2, 2))

--- a/tests/defences/test_adversarial_trainer_FBF.py
+++ b/tests/defences/test_adversarial_trainer_FBF.py
@@ -73,7 +73,3 @@ def test_adversarial_trainer_fbf_pytorch_fit_and_predict(get_adv_trainer, fix_ge
 
     np.testing.assert_array_almost_equal(accuracy, 0.32, decimal=4)
     np.testing.assert_array_almost_equal(accuracy_new, 0.14, decimal=4)
-
-
-if __name__ == "__main__":
-    pytest.cmdline.main("-q -s {} --mlFramework=pytorch --durations=0".format(__file__).split(" "))

--- a/tests/estimators/classification/test_deeplearning_common.py
+++ b/tests/estimators/classification/test_deeplearning_common.py
@@ -15,7 +15,7 @@ from tests.utils import ARTTestException, ARTTestFixtureNotImplemented
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks", "tensorflow2")
+@pytest.mark.skip_framework("non_dl_frameworks", "tensorflow2")
 def test_layers(art_warning, get_default_mnist_subset, framework, image_dl_estimator):
     try:
         classifier, _ = image_dl_estimator(from_logits=True)
@@ -31,7 +31,7 @@ def test_layers(art_warning, get_default_mnist_subset, framework, image_dl_estim
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skip_framework("non_dl_frameworks")
 def test_loss_gradient_with_wildcard(art_warning, image_dl_estimator):
     try:
         classifier, _ = image_dl_estimator(wildcard=True)
@@ -50,7 +50,7 @@ def test_loss_gradient_with_wildcard(art_warning, image_dl_estimator):
 
 # Note: because mxnet only supports 1 concurrent version of a model if we fit that model, all expected values will
 # change for all other tests using that fitted model
-@pytest.mark.skipMlFramework("mxnet", "non_dl_frameworks")
+@pytest.mark.skip_framework("mxnet", "non_dl_frameworks")
 def test_fit(art_warning, get_default_mnist_subset, default_batch_size, image_dl_estimator):
     try:
         (x_train_mnist, y_train_mnist), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
@@ -68,7 +68,7 @@ def test_fit(art_warning, get_default_mnist_subset, default_batch_size, image_dl
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skip_framework("non_dl_frameworks")
 @pytest.mark.skipif(keras.__version__.startswith("2.2"), reason="requires Keras 2.3.0 or higher")
 def test_predict(
     art_warning, framework, get_default_mnist_subset, image_dl_estimator, expected_values, store_expected_values
@@ -84,7 +84,7 @@ def test_predict(
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skip_framework("non_dl_frameworks")
 def test_shapes(art_warning, get_default_mnist_subset, image_dl_estimator):
     try:
         (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
@@ -106,7 +106,7 @@ def test_shapes(art_warning, get_default_mnist_subset, image_dl_estimator):
 
 
 # TODO skipping with kerastf because overall tests are taking too long to run - unskip once tests run under limit time
-@pytest.mark.skipMlFramework("kerastf", "non_dl_frameworks")
+@pytest.mark.skip_framework("kerastf", "non_dl_frameworks")
 @pytest.mark.parametrize("from_logits", [True, False])
 @pytest.mark.parametrize(
     "loss_name",
@@ -155,7 +155,7 @@ def test_loss_functions(
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skip_framework("non_dl_frameworks")
 def test_pickle(art_warning, image_dl_estimator, image_dl_estimator_defended, tmp_path):
     try:
         full_path = os.path.join(tmp_path, "my_classifier.p")
@@ -175,7 +175,7 @@ def test_pickle(art_warning, image_dl_estimator, image_dl_estimator_defended, tm
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skip_framework("non_dl_frameworks")
 def test_functional_model(art_warning, image_dl_estimator):
     try:
         # Need to update the functional_model code to produce a model with more than one input and output layers...
@@ -190,7 +190,7 @@ def test_functional_model(art_warning, image_dl_estimator):
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("mxnet", "tensorflow", "pytorch", "non_dl_frameworks")
+@pytest.mark.skip_framework("mxnet", "tensorflow", "pytorch", "non_dl_frameworks")
 def test_fit_kwargs(art_warning, image_dl_estimator, get_default_mnist_subset, default_batch_size):
     try:
         (x_train_mnist, y_train_mnist), (_, _) = get_default_mnist_subset
@@ -214,7 +214,7 @@ def test_fit_kwargs(art_warning, image_dl_estimator, get_default_mnist_subset, d
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skip_framework("non_dl_frameworks")
 def test_defences_predict(art_warning, get_default_mnist_subset, image_dl_estimator_defended, image_dl_estimator):
     try:
         (_, _), (x_test_mnist, y_test_mnist) = get_default_mnist_subset
@@ -247,7 +247,7 @@ def test_defences_predict(art_warning, get_default_mnist_subset, image_dl_estima
 
 # Note: because mxnet only supports 1 concurrent version of a model if we fit that model, all expected values will
 # change for all other tests using that fitted model
-@pytest.mark.skipMlFramework("mxnet", "non_dl_frameworks", "tensorflow2")
+@pytest.mark.skip_framework("mxnet", "non_dl_frameworks", "tensorflow2")
 def test_fit_image_generator(
     art_warning, framework, image_dl_estimator, image_data_generator, get_default_mnist_subset
 ):
@@ -274,7 +274,7 @@ def test_fit_image_generator(
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skip_framework("non_dl_frameworks")
 @pytest.mark.skipif(keras.__version__.startswith("2.2"), reason="requires Keras 2.3.0 or higher")
 def test_loss_gradient(
     art_warning,
@@ -316,7 +316,7 @@ def test_loss_gradient(
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skip_framework("non_dl_frameworks")
 def test_nb_classes(art_warning, image_dl_estimator):
     try:
         classifier, _ = image_dl_estimator(from_logits=True)
@@ -325,7 +325,7 @@ def test_nb_classes(art_warning, image_dl_estimator):
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skip_framework("non_dl_frameworks")
 def test_input_shape(art_warning, image_dl_estimator, mnist_shape):
     try:
         classifier, _ = image_dl_estimator(from_logits=True)
@@ -334,7 +334,7 @@ def test_input_shape(art_warning, image_dl_estimator, mnist_shape):
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skip_framework("non_dl_frameworks")
 def test_save(art_warning, image_dl_estimator):
     try:
         classifier, _ = image_dl_estimator(from_logits=True)
@@ -357,7 +357,7 @@ def test_save(art_warning, image_dl_estimator):
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("non_dl_frameworks")
+@pytest.mark.skip_framework("non_dl_frameworks")
 def test_repr(art_warning, image_dl_estimator, framework, expected_values, store_expected_values):
     try:
         classifier, _ = image_dl_estimator(from_logits=True)
@@ -369,7 +369,7 @@ def test_repr(art_warning, image_dl_estimator, framework, expected_values, store
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("tensorflow", "non_dl_frameworks")
+@pytest.mark.skip_framework("tensorflow", "non_dl_frameworks")
 def test_save(art_warning, image_dl_estimator, get_default_mnist_subset, tmp_path):
     try:
         classifier, _ = image_dl_estimator()
@@ -385,7 +385,7 @@ def test_save(art_warning, image_dl_estimator, get_default_mnist_subset, tmp_pat
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("mxnet", "non_dl_frameworks")
+@pytest.mark.skip_framework("mxnet", "non_dl_frameworks")
 @pytest.mark.skipif(keras.__version__.startswith("2.2"), reason="requires Keras 2.3.0 or higher")
 def test_class_gradient(
     art_warning,

--- a/tests/estimators/classification/test_deeplearning_specific.py
+++ b/tests/estimators/classification/test_deeplearning_specific.py
@@ -147,7 +147,7 @@ def test_pickle(art_warning, get_default_mnist_subset, image_dl_estimator):
 
 
 @pytest.mark.skip_module("apex.amp")
-@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skip_framework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
 def test_loss_gradient_amp(
     art_warning, get_default_mnist_subset, image_dl_estimator, expected_values, mnist_shape, device_type,

--- a/tests/estimators/speech_recognition/test_pytorch_deep_speech.py
+++ b/tests/estimators/speech_recognition/test_pytorch_deep_speech.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_module("apex.amp", "deepspeech_pytorch")
-@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skip_framework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("use_amp", [False, True])
 @pytest.mark.parametrize("device_type", ["cpu", "gpu"])
 def test_pytorch_deep_speech(art_warning, expected_values, use_amp, device_type):

--- a/tests/estimators/speech_recognition/test_tensorflow_lingvo.py
+++ b/tests/estimators/speech_recognition/test_tensorflow_lingvo.py
@@ -40,7 +40,7 @@ class TestTensorFlowLingvoASR:
     """
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_is_subclass(self, art_warning):
         try:
             assert issubclass(TensorFlowLingvoASR, (SpeechRecognizerMixin, TensorFlowV2Estimator))
@@ -48,7 +48,7 @@ class TestTensorFlowLingvoASR:
             art_warning(e)
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_implements_abstract_methods(self, art_warning):
         try:
             import tensorflow.compat.v1 as tf1
@@ -58,7 +58,7 @@ class TestTensorFlowLingvoASR:
             art_warning(e)
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_load_model(self, art_warning):
         try:
             import tensorflow.compat.v1 as tf1
@@ -70,7 +70,7 @@ class TestTensorFlowLingvoASR:
             art_warning(e)
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_decoder_input(self, art_warning, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
@@ -96,7 +96,7 @@ class TestTensorFlowLingvoASR:
             art_warning(e)
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_create_log_mel_features(self, art_warning, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
@@ -112,7 +112,7 @@ class TestTensorFlowLingvoASR:
             art_warning(e)
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_pad_audio_input(self, art_warning):
         try:
             import tensorflow.compat.v1 as tf1
@@ -129,7 +129,7 @@ class TestTensorFlowLingvoASR:
             art_warning(e)
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_predict_batch(self, art_warning, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
@@ -164,7 +164,7 @@ class TestTensorFlowLingvoASR:
             art_warning(e)
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_predict(self, art_warning, audio_data):
         try:
             import tensorflow.compat.v1 as tf1
@@ -179,7 +179,7 @@ class TestTensorFlowLingvoASR:
             art_warning(e)
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_loss_gradient_tensor(self, art_warning, audio_batch_padded):
         try:
             import tensorflow.compat.v1 as tf1
@@ -200,7 +200,7 @@ class TestTensorFlowLingvoASR:
             art_warning(e)
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     @pytest.mark.parametrize("batch_mode", [True, False])
     def test_loss_gradient_batch_mode(self, art_warning, batch_mode, audio_data):
         try:
@@ -261,7 +261,7 @@ class TestTensorFlowLingvoASRLibriSpeechSamples:
     }
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     def test_predict(self, art_warning):
         try:
             import tensorflow.compat.v1 as tf1
@@ -283,7 +283,7 @@ class TestTensorFlowLingvoASRLibriSpeechSamples:
             art_warning(e)
 
     @pytest.mark.skip_module("lingvo")
-    @pytest.mark.skipMlFramework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
+    @pytest.mark.skip_framework("pytorch", "tensorflow1", "tensorflow2", "mxnet", "kerastf", "non_dl_frameworks")
     @pytest.mark.xfail(reason="Known issue that needs further investigation")
     def test_loss_gradient(self, art_warning):
         try:

--- a/tests/metrics/privacy/test_membership_leakage.py
+++ b/tests/metrics/privacy/test_membership_leakage.py
@@ -28,7 +28,7 @@ from tests.utils import ARTTestException
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipMlFramework("dl_frameworks")
+@pytest.mark.skip_framework("dl_frameworks")
 def test_membership_leakage_decision_tree(art_warning, decision_tree_estimator, get_iris_dataset):
     try:
         classifier = decision_tree_estimator()
@@ -45,7 +45,7 @@ def test_membership_leakage_decision_tree(art_warning, decision_tree_estimator, 
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("keras", "kerastf", "tensorflow1", "mxnet")
+@pytest.mark.skip_framework("keras", "kerastf", "tensorflow1", "mxnet")
 def test_membership_leakage_tabular(art_warning, tabular_dl_estimator, get_iris_dataset):
     try:
         classifier = tabular_dl_estimator()
@@ -60,7 +60,7 @@ def test_membership_leakage_tabular(art_warning, tabular_dl_estimator, get_iris_
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("keras", "kerastf", "tensorflow1", "mxnet")
+@pytest.mark.skip_framework("keras", "kerastf", "tensorflow1", "mxnet")
 def test_membership_leakage_image(art_warning, image_dl_estimator, get_default_mnist_subset):
     try:
         classifier, _ = image_dl_estimator()
@@ -76,7 +76,7 @@ def test_membership_leakage_image(art_warning, image_dl_estimator, get_default_m
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("keras", "kerastf", "tensorflow1", "mxnet")
+@pytest.mark.skip_framework("keras", "kerastf", "tensorflow1", "mxnet")
 def test_errors(art_warning, tabular_dl_estimator, get_iris_dataset, image_data_generator):
     try:
         classifier = tabular_dl_estimator()
@@ -94,7 +94,7 @@ def test_errors(art_warning, tabular_dl_estimator, get_iris_dataset, image_data_
         art_warning(e)
 
 
-@pytest.mark.skipMlFramework("pytorch", "tensorflow", "scikitlearn")
+@pytest.mark.skip_framework("pytorch", "tensorflow", "scikitlearn")
 def test_not_implemented(art_warning, tabular_dl_estimator, get_iris_dataset, image_data_generator):
     try:
         classifier = tabular_dl_estimator()

--- a/tests/preprocessing/audio/test_l_filter_pytorch.py
+++ b/tests/preprocessing/audio/test_l_filter_pytorch.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_module("torchaudio")
-@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skip_framework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 @pytest.mark.parametrize("fir_filter", [False, True])
 def test_audio_filter(fir_filter, art_warning, expected_values):
     try:
@@ -78,7 +78,7 @@ def test_audio_filter(fir_filter, art_warning, expected_values):
 
 
 @pytest.mark.skip_module("torchaudio")
-@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skip_framework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 def test_default(art_warning):
     try:
         # Small data for testing
@@ -99,7 +99,7 @@ def test_default(art_warning):
 
 
 @pytest.mark.skip_module("torchaudio")
-@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skip_framework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 def test_triple_clip_values_error(art_warning):
     try:
         exc_msg = "`clip_values` should be a tuple of 2 floats containing the allowed data range."
@@ -115,7 +115,7 @@ def test_triple_clip_values_error(art_warning):
 
 
 @pytest.mark.skip_module("torchaudio")
-@pytest.mark.skipMlFramework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
+@pytest.mark.skip_framework("tensorflow", "tensorflow2v1", "keras", "kerastf", "mxnet", "non_dl_frameworks")
 def test_relation_clip_values_error(art_warning):
     try:
         exc_msg = "Invalid `clip_values`: min >= max."

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -146,7 +146,7 @@ def check_adverse_predicted_sample_y(y_pred_adv, y_non_adv):
 def is_valid_framework(framework):
     if framework not in art_supported_frameworks:
         raise Exception(
-            "mlFramework value {0} is unsupported. Please use one of these valid values: {1}".format(
+            "Framework value {0} is unsupported. Please use one of these valid values: {1}".format(
                 framework, " ".join(art_supported_frameworks)
             )
         )

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -140,7 +140,3 @@ class TestDeprecatedKeyword:
         exc_msg = "Deprecated keyword argument must default to the Decorator singleton."
         with pytest.raises(ValueError, match=exc_msg):
             simple_addition(a=1)
-
-
-if __name__ == "__main__":
-    pytest.cmdline.main("-q -s {} --mlFramework=tensorflow --durations=0".format(__file__).split(" "))


### PR DESCRIPTION
# Description

The PR renames the `skipMlFramework` marker to `skip_framework`. The new name follows the naming convention of other markers. 

Furthermore, this PR renames the `mlFramework` argument for `pytest`. The new argument is plain `framework`. E.g to run evasion tests locally for `pytorch`-only, use `pytest tests/evasion --framework="pytorch"`

Closes #793

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
