### PR TITLE
Increase batch_size (set default batch_size=64) in BoundaryAttack and HopSkipJump

### DIFF
--- a/art/attacks/evasion/boundary.py
+++ b/art/attacks/evasion/boundary.py
@@ -67,6 +67,7 @@ class BoundaryAttack(EvasionAttack):
     def __init__(
         self,
         estimator: "CLASSIFIER_TYPE",
+        batch_size: int = 128,
         targeted: bool = True,
         delta: float = 0.01,
         epsilon: float = 0.01,
@@ -82,6 +83,7 @@ class BoundaryAttack(EvasionAttack):
         Create a boundary attack instance.
 
         :param estimator: A trained classifier.
+        :param batch_size: The size of the batch used by the estimator during inference.
         :param targeted: Should the attack target one specific class.
         :param delta: Initial step size for the orthogonal step.
         :param epsilon: Initial step size for the step towards the target.
@@ -104,7 +106,7 @@ class BoundaryAttack(EvasionAttack):
         self.sample_size = sample_size
         self.init_size = init_size
         self.min_epsilon = min_epsilon
-        self.batch_size = 1
+        self.batch_size = batch_size
         self.verbose = verbose
         self._check_params()
 

--- a/art/attacks/evasion/boundary.py
+++ b/art/attacks/evasion/boundary.py
@@ -67,7 +67,7 @@ class BoundaryAttack(EvasionAttack):
     def __init__(
         self,
         estimator: "CLASSIFIER_TYPE",
-        batch_size: int = 128,
+        batch_size: int = 64,
         targeted: bool = True,
         delta: float = 0.01,
         epsilon: float = 0.01,

--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -65,6 +65,7 @@ class HopSkipJump(EvasionAttack):
     def __init__(
         self,
         classifier: "CLASSIFIER_TYPE",
+        batch_size: int = 128,
         targeted: bool = False,
         norm: Union[int, float, str] = 2,
         max_iter: int = 50,
@@ -77,6 +78,7 @@ class HopSkipJump(EvasionAttack):
         Create a HopSkipJump attack instance.
 
         :param classifier: A trained classifier.
+        :param batch_size: The size of the batch used by the estimator during inference.
         :param targeted: Should the attack target one specific class.
         :param norm: Order of the norm. Possible values: "inf", np.inf or 2.
         :param max_iter: Maximum number of iterations.
@@ -93,7 +95,7 @@ class HopSkipJump(EvasionAttack):
         self.init_eval = init_eval
         self.init_size = init_size
         self.curr_iter = 0
-        self.batch_size = 1
+        self.batch_size = batch_size
         self.verbose = verbose
         self._check_params()
         self.curr_iter = 0

--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -65,7 +65,7 @@ class HopSkipJump(EvasionAttack):
     def __init__(
         self,
         classifier: "CLASSIFIER_TYPE",
-        batch_size: int = 10,
+        batch_size: int = 64,
         targeted: bool = False,
         norm: Union[int, float, str] = 2,
         max_iter: int = 50,

--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -65,7 +65,7 @@ class HopSkipJump(EvasionAttack):
     def __init__(
         self,
         classifier: "CLASSIFIER_TYPE",
-        batch_size: int = 1,
+        batch_size: int = 10,
         targeted: bool = False,
         norm: Union[int, float, str] = 2,
         max_iter: int = 50,

--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -95,7 +95,7 @@ class HopSkipJump(EvasionAttack):
         self.init_eval = init_eval
         self.init_size = init_size
         self.curr_iter = 0
-        self.batch_size = 1
+        self.batch_size = batch_size
         self.verbose = verbose
         self._check_params()
         self.curr_iter = 0

--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -65,7 +65,7 @@ class HopSkipJump(EvasionAttack):
     def __init__(
         self,
         classifier: "CLASSIFIER_TYPE",
-        batch_size: int = 128,
+        batch_size: int = 1,
         targeted: bool = False,
         norm: Union[int, float, str] = 2,
         max_iter: int = 50,

--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -95,7 +95,7 @@ class HopSkipJump(EvasionAttack):
         self.init_eval = init_eval
         self.init_size = init_size
         self.curr_iter = 0
-        self.batch_size = batch_size
+        self.batch_size = 1
         self.verbose = verbose
         self._check_params()
         self.curr_iter = 0


### PR DESCRIPTION
Use batch_size as an `__init__` argument (set default batch_size=64) to BoundaryAttack and HopSkipJump, and increase it to improve execution time.

Signed-off-by: Apostolos Modas <modas.apost@gmail.com>

# Description

This pull request improves the execution time of [BoundaryAttack](https://github.com/Trusted-AI/adversarial-robustness-toolbox/blob/dev_1.6.0/art/attacks/evasion/boundary.py) and [HopSkipJump](https://github.com/Trusted-AI/adversarial-robustness-toolbox/blob/main/art/attacks/evasion/hop_skip_jump.py).

In their current implementation, both `BoundaryAttack` and `HopSkipJump`] have a hardcoded `batch_size=1` in their code ([L107](https://github.com/Trusted-AI/adversarial-robustness-toolbox/blob/3a957076d0df87203e1056b442a59d4ff56a8810/art/attacks/evasion/boundary.py#L107) and [L96](https://github.com/Trusted-AI/adversarial-robustness-toolbox/blob/3a957076d0df87203e1056b442a59d4ff56a8810/art/attacks/evasion/hop_skip_jump.py#L96) respectively). In fact, `batch_size` is used to inform the classifier how many samples to fit/forward simultaneously, and then return the predictions for all the samples within the batch.

However, the hardcoded value `batch_size=1` is inefficient: whenever the attacks want to get the predictions of `N` samples, the classifier is feeding them one-by-one instead of feeding all `N` samples simultaneously. As a result, the whole forward process is quite slow, and the main benefit of parallelism in a GPU is technically lost!

I studied the code of both implementations to make sure that there is no **specific reason** (cases such as vectorization of the returned predictions etc.) for explicitly using `batch_size=1`. By experimenting **only** with PyTorch, it turned out that both algorithms **should work as expected for any `batch_size >= 1`**. I also believe that changing the backend (i.e., Tensorflow, Keras) will not change the behaviour (at least I do not see any reason why).

To demonstrate the benefit of setting `batch_size > 1`, I created a simple experiment where I deterministically evaluate both attacks (a) in their current state, and (b) with an increased `batch_size`. The code and results can be found in the Notebook embedded below (see Appendix).

In short, this pull request introduces the following changes:
- The `batch_size` in both `BoundaryAttack` and `HopSkipJump` can now be passed as an argument to `__init__`.
- The default value of `batch_size` in both `BoundaryAttack` and `HopSkipJump` is now: `batch_size: int = 64`.
- The value `self.batch_size` is not hardcoded to `1` anymore: it gets the value through the `__init__`.

Fixes #970.

## Type of change

Please check all relevant options.

- [X] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [X] (PyTorch) Compare the the execution time of `BoundaryAttack` **before** and **after** increasing the `batch_size`. The test code and results can be found in Notebook embedded in the Appendix.
- [X] (PyTorch) Compare the the execution time of `HopSkipJump` **before** and **after** increasing the `batch_size`. The test code and results can be found in Notebook embedded in the Appendix.

**Test Configuration**:
- OS: Red Hat Enterprise Linux 8.3 (fedora)
- Python version: 3.8.8
- ART version or commit number: ART v1.5.3 and ART dev_1.6.1 (commit: [ab26b12](https://github.com/Trusted-AI/adversarial-robustness-toolbox/commit/ab26b12c59edfd914513d4018e068058b7c8317c))
- PyTorch v1.6.0+cu92
**Note**: this PyTorch version, including Torchvision v0.7.0+cu92, are not the ones automatically selected by ART v1.5.3 requirements. Nevertheless, they were chosen as such, in order to test the code changes on a Tesla K40 GPU. The overall behaviour is not expected change if tested with higher version of PyTorch and Torchvision.

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [X] I have made corresponding changes to the documentation (docstring in file)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Appendix – Notebook

**Note**: the experiments use PyTorch v1.6.0+cu92 and Torchvision v0.7.0+cu92 since they are conducted on a Tesla K40 GPU. The overall behaviour is not expected to change if tested with higher version of PyTorch and Torchvision.

```python
global_seed = 999

import sys
import sys
!{sys.executable} -m pip install git+https://github.com/nottombrown/imagenet_stubs
sys.path.append('./adversarial-robustness-toolbox')

import imagenet_stubs
import numpy as np
import torch
import torch.nn as nn
import torchvision.models as models
import torchvision.transforms as transforms
import random
import time

import os
os.environ['PYTHONHASHSEED'] = str(global_seed)

from matplotlib import pyplot as plt
from PIL import Image

from art.estimators.classification import PyTorchClassifier
from art.attacks.evasion import BoundaryAttack, HopSkipJump
```

    Collecting git+https://github.com/nottombrown/imagenet_stubs
      Cloning https://github.com/nottombrown/imagenet_stubs to /tmp/pip-req-build-fr1ufr_e
      Running command git clone -q https://github.com/nottombrown/imagenet_stubs /tmp/pip-req-build-fr1ufr_e


### Set determinism for reproducibility


```python
def set_global_seed(seed):
    torch.manual_seed(seed)
    torch.cuda.manual_seed(seed)
    torch.cuda.manual_seed_all(seed)
    np.random.seed(seed)
    random.seed(seed)
    torch.manual_seed(seed)
    torch.backends.cudnn.benchmark = False
    torch.backends.cudnn.deterministic = True
```

### Load Torchvision model


```python
model = models.resnet18(pretrained=True).eval()

mean = np.asarray((0.485, 0.456, 0.406), dtype=np.float32).reshape((1, 3, 1, 1))
std = np.asarray((0.229, 0.224, 0.225), dtype=np.float32).reshape((1, 3, 1, 1))

classifier = PyTorchClassifier(
    model=model,
    clip_values=(0.0, 1.0),
    input_shape=(3, 224, 224),
    nb_classes=1000,
    use_amp=False,
    preprocessing=(mean, std),
    channels_first=True,
    loss=nn.CrossEntropyLoss()
)
```

### Define image transformation


```python
def tf(x):
    x = np.expand_dims(x, axis=0)
    return np.transpose(x, (0, 3, 1, 2))
```

### Load image


```python
original_image_name = 'standard_poodle.jpg'
for image_path in imagenet_stubs.get_image_paths():
    if image_path.endswith(original_image_name):
        original_image = Image.open(image_path)
        original_image = original_image.resize((224, 224))
        original_image = np.array(original_image) / 255.0
        original_image = original_image.astype(np.float32)

original_label = np.argmax(classifier.predict(tf(original_image)), axis=1)[0]
print("\nOriginal label is: %d\n" % original_label)

plt.imshow(original_image)
plt.show()
```

    
    Original label is: 267
   
    
![output_8_1](https://user-images.githubusercontent.com/25585560/111333254-d00f7600-8672-11eb-92b0-1878a3421058.png)

    

### BoundaryAttack parameters


```python
max_iterations = 1000
delta = 0.01
epsilon = 0.01
targeted = False
```

### BoundaryAttack (`batch_size=1`)


```python
set_global_seed(global_seed)

batch_size = 1  # <--- Current implementation (hardcoded) batch size
attack = BoundaryAttack(estimator=classifier,
                        targeted=targeted,
                        max_iter=max_iterations,
                        delta=delta,
                        epsilon=epsilon,
                        verbose=False,
                        batch_size=batch_size,
                        seed=global_seed)

t0 = time.time()
x_adv = attack.generate(x=tf(original_image), x_adv_init=None)
print('Elapsed time (sec):', time.time() - t0)

L2_err = np.linalg.norm(x_adv[0] - tf(original_image)[0])
pred_label = np.argmax(classifier.predict(x_adv)[0])
print("L2 error: %.2f \t | \t Adv. label: %d" % (L2_err, pred_label))
```

    Elapsed time (sec): 475.44113087654114
    L2 error: 31.02 	 | 	 Adv. label: 107


### BoundaryAttack (`batch_size=128`)


```python
set_global_seed(global_seed)

max_iterations = 1000
delta = 0.01
epsilon = 0.01
targeted = False

batch_size = 128  # <--- Increase batch size

attack = BoundaryAttack(estimator=classifier,
                        targeted=targeted,
                        max_iter=max_iterations,
                        delta=delta,
                        epsilon=epsilon,
                        verbose=False,
                        batch_size=batch_size,
                        seed=global_seed)

t0 = time.time()
x_adv = attack.generate(x=tf(original_image), x_adv_init=None)
print('Elapsed time (sec):', time.time() - t0)

L2_err = np.linalg.norm(x_adv[0] - tf(original_image)[0])
pred_label = np.argmax(classifier.predict(x_adv)[0])
print("L2 error: %.2f \t | \t Adv. label: %d" % (L2_err, pred_label))
```

    Elapsed time (sec): 243.049170255661
    L2 error: 31.02 	 | 	 Adv. label: 107


### HopSkipJump Attack parameters



```python
max_iterations = 200
max_eval = 1000
init_eval = 10
targeted = False
```

### HopSkipJump Attack (`batch_size=1`)


```python
set_global_seed(global_seed)

batch_size = 1  # <--- Current implementation (hardcoded) batch size
attack = HopSkipJump(classifier=classifier,
                     targeted=targeted,
                     max_iter=max_iterations,
                     max_eval=max_eval,
                     init_eval=init_eval,
                     verbose=False,
                     batch_size=batch_size,
                     seed=global_seed)

t0 = time.time()
x_adv = attack.generate(x=tf(original_image), x_adv_init=None)
print('Elapsed time (sec):', time.time() - t0)

L2_err = np.linalg.norm(x_adv[0] - tf(original_image)[0])
pred_label = np.argmax(classifier.predict(x_adv)[0])
print("L2 error: %.2f \t | \t Adv. label: %d" % (L2_err, pred_label))
```

    Elapsed time (sec): 392.41476559638977
    L2 error: 0.96 	 | 	 Adv. label: 183


### HopSkipJump Attack (`batch_size=128`)


```python
set_global_seed(global_seed)

batch_size = 128  # <--- Increase batch size
attack = HopSkipJump(classifier=classifier,
                     targeted=targeted,
                     max_iter=max_iterations,
                     max_eval=max_eval,
                     init_eval=init_eval,
                     verbose=False,
                     batch_size=batch_size,
                     seed=global_seed)

t0 = time.time()
x_adv = attack.generate(x=tf(original_image), x_adv_init=None)
print('Elapsed time (sec):', time.time() - t0)

L2_err = np.linalg.norm(x_adv[0] - tf(original_image)[0])
pred_label = np.argmax(classifier.predict(x_adv)[0])
print("L2 error: %.2f \t | \t Adv. label: %d" % (L2_err, pred_label))
```

    Elapsed time (sec): 228.36624002456665
    L2 error: 0.97 	 | 	 Adv. label: 183
