### PR TITLE
Allow Multiple Layers in Bullseye Polytope Attack

### DIFF
--- a/art/attacks/poisoning/bullseye_polytope_attack.py
+++ b/art/attacks/poisoning/bullseye_polytope_attack.py
@@ -174,9 +174,15 @@ class BullseyePolytopeAttackPyTorch(PoisoningAttackWhiteBox):
         for n, net in enumerate(self.subsistute_networks):
             # End to end training
             if self.endtoend:
-                block_feats = [
-                    feat.detach() for feat in net.get_activations(x, layer=self.feature_layer, framework=True)
-                ]
+                if isinstance(self.feature_layer, list):
+
+                    block_feats = [torch.stack([
+                        feat.detach() for feat in net.get_activations(x, layer=layer, framework=True)
+                    ], 0) for layer in self.feature_layer]
+                else:
+                    block_feats = [
+                        feat.detach() for feat in net.get_activations(x, layer=self.feature_layer, framework=True)
+                    ]
                 target_feat_list.append(block_feats)
                 s_coeff = [
                     torch.ones(n_poisons, 1).to(self.estimator.device) / n_poisons for _ in range(len(block_feats))
@@ -229,8 +235,8 @@ class BullseyePolytopeAttackPyTorch(PoisoningAttackWhiteBox):
         if self.max_iter < 1:
             raise ValueError("Value of max_iter at least 1")
 
-        if not isinstance(self.feature_layer, (str, int)):
-            raise TypeError("Feature layer should be a string or int")
+        if not isinstance(self.feature_layer, (str, int, list)):
+            raise TypeError("Feature layer should be a string or int or list of string or int")
 
         if self.opt.lower() not in ["adam", "sgd"]:
             raise ValueError("Optimizer must be 'adam' or 'sgd'")
@@ -250,8 +256,13 @@ class BullseyePolytopeAttackPyTorch(PoisoningAttackWhiteBox):
         if self.net_repeat < 1:
             raise ValueError("net_repeat must be at least 1")
 
-        if not 0 <= self.feature_layer < len(self.estimator.layer_names):
-            raise ValueError("Invalid feature layer")
+        if isinstance(self.feature_layer, list):
+            for layer in self.feature_layer:
+                if not 0 <= layer < len(self.estimator.layer_names):
+                    raise ValueError("Invalid feature layer")
+        else:
+            if not 0 <= self.feature_layer < len(self.estimator.layer_names):
+                raise ValueError("Invalid feature layer")
 
         if 1 < self.decay_coeff < 0:
             raise ValueError("Decay coefficient must be between zero and one")
@@ -272,7 +283,6 @@ def loss_from_center(
     subs_net_list, target_feat_list, poison_batch, net_repeat, end2end, feature_layer
 ) -> "torch.Tensor":
     import torch  # lgtm [py/repeated-import]
-
     if end2end:
         loss = 0
         for net, center_feats in zip(subs_net_list, target_feat_list):
@@ -287,7 +297,13 @@ def loss_from_center(
                         sum([poisons_feat_r[block_idx] for poisons_feat_r in poisons_feats_repeats]) / net_repeat
                     )
             elif net_repeat == 1:
-                poisons_feats = net.get_activations(poison_batch(), layer=feature_layer, framework=True)
+                if isinstance(feature_layer, list):
+                    poisons_feats = torch.cat([torch.flatten(net.get_activations(poison_batch(),
+                                                                                 layer=layer,
+                                                                                 framework=True), 0)
+                                               for layer in feature_layer], 0)
+                else:
+                    poisons_feats = net.get_activations(poison_batch(), layer=feature_layer, framework=True)
             else:
                 assert False, "net_repeat set to {}".format(net_repeat)
 


### PR DESCRIPTION
# Description

Added change that allows multiple layers to be targeted for Bullseye Polytope attack, increasing robustness in end-to-end scenarios.

Fixes # (issue)

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

- [x] added `test_poison_multiple_layers`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
