### PR TITLE
Fix channels_first in perturbation function

### DIFF
--- a/art/attacks/poisoning/perturbations/image_perturbations.py
+++ b/art/attacks/poisoning/perturbations/image_perturbations.py
@@ -126,7 +126,7 @@ def insert_image(
 
     data = np.copy(x)
     if channels_first:
-        data = data.transpose([2, 0, 1])
+        data = data.transpose([1, 2, 0])
 
     width, height, num_channels = x.shape
 


### PR DESCRIPTION
# Description

Fix an issue with image perturbation function not transposing correctly when `channels_first=True`

Fixes #1006 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
