### PR TITLE
Add labels to preprocessing in TensorFlowV2Classifier.loss_gradient

### DIFF
--- a/art/estimators/classification/tensorflow.py
+++ b/art/estimators/classification/tensorflow.py
@@ -1122,19 +1122,20 @@ class TensorFlowV2Classifier(ClassGradientsMixin, ClassifierMixin, TensorFlowV2E
                 if self.all_framework_preprocessing:
                     x_grad = tf.convert_to_tensor(x)
                     tape.watch(x_grad)
-                    x_input, _ = self._apply_preprocessing(x_grad, y=None, fit=False)
+                    x_input, y_input = self._apply_preprocessing(x_grad, y=y, fit=False)
                 else:
-                    x_preprocessed, _ = self._apply_preprocessing(x, y=None, fit=False)
+                    x_preprocessed, y_preprocessed = self._apply_preprocessing(x, y=y, fit=False)
                     x_grad = tf.convert_to_tensor(x_preprocessed)
                     tape.watch(x_grad)
                     x_input = x_grad
+                    y_input = y_preprocessed
 
                 predictions = self.model(x_input, training=training_mode)
 
                 if self._reduce_labels:
-                    loss = self._loss_object(np.argmax(y, axis=1), predictions)
+                    loss = self._loss_object(np.argmax(y_input, axis=1), predictions)
                 else:
-                    loss = self._loss_object(y, predictions)
+                    loss = self._loss_object(y_input, predictions)
 
             gradients = tape.gradient(loss, x_grad)
 


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request fixes bug by adding labels to preprocessing in `TensorFlowV2Classifier.loss_gradient`.

Fixes #1004 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
