### PR TITLE
Add check for valid parameters in SimBA

### DIFF
--- a/art/attacks/evasion/simba.py
+++ b/art/attacks/evasion/simba.py
@@ -107,6 +107,15 @@ class SimBA(EvasionAttack):
         x = x.astype(ART_NUMPY_DTYPE)
         preds = self.estimator.predict(x, batch_size=self.batch_size)
 
+        if divmod(x.shape[2] - self.freq_dim, self.stride)[1] != 0:
+            raise ValueError(
+                "Incompatible value combination in image height/width, freq_dim and stride detected. "
+                "Adapt these parameters to fulfill the following conditions: "
+                "divmod(image_height - freq_dim, stride)[1] == 0 "
+                "and "
+                "divmod(image_width - freq_dim, stride)[1] == 0"
+            )
+
         if y is None:
             if self.targeted:
                 raise ValueError("Target labels `y` need to be provided for a targeted attack.")


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds a check for valid combinations of `stride`, `freq_dim` and image size in `SimBA`.

Fixes #998

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
