### PR TITLE
Fix a bug in bullseye polytope attack when attacking multiple layers of the underlying model

### DIFF
--- a/art/attacks/poisoning/bullseye_polytope_attack.py
+++ b/art/attacks/poisoning/bullseye_polytope_attack.py
@@ -337,13 +337,10 @@ def loss_from_center(
                     )
             elif net_repeat == 1:
                 if isinstance(feature_layer, list):
-                    poisons_feats = torch.cat(
-                        [
-                            torch.flatten(net.get_activations(poison_batch(), layer=layer, framework=True), 0)
-                            for layer in feature_layer
-                        ],
-                        0,
-                    )
+                    poisons_feats = [
+                        torch.flatten(net.get_activations(poison_batch(), layer=layer, framework=True), 0)
+                        for layer in feature_layer
+                    ]
                 else:
                     poisons_feats = net.get_activations(poison_batch(), layer=feature_layer, framework=True)
             else:


### PR DESCRIPTION
# Description

Fix an issue in bullseye polytope attack when attacking multiple layers of the underlying model, it creates a single poisoned image.

Fixes #1045

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing
Test it with the notebook provided in issue #1045. 


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
