### PR TITLE
Check for NaN in HopSkipJump

### DIFF
--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -443,6 +443,10 @@ class HopSkipJump(EvasionAttack):
             # Update current iteration
             self.curr_iter += 1
 
+            # If attack failed. return original sample
+            if np.isnan(current_sample).any():
+                return original_sample
+
         return current_sample
 
     def _binary_search(

--- a/art/attacks/evasion/hop_skip_jump.py
+++ b/art/attacks/evasion/hop_skip_jump.py
@@ -445,6 +445,7 @@ class HopSkipJump(EvasionAttack):
 
             # If attack failed. return original sample
             if np.isnan(current_sample).any():
+                logger.debug("NaN detected in sample, returning original sample.")
                 return original_sample
 
         return current_sample


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds a check for NaN in iterations of `HopSkipJump`. NaN can occur for example with estimators that have random preprocessing steps deployed that occasionally change the classifier's prediction, which is not expected by `HopSkipJump`. With this PR, `HopSkipJump` will return the original sample if NaN is detected in its current sample.

Fixes #307

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
