### PR TITLE
Resolving convergence issues in C&W L0

### DIFF
--- a/art/attacks/evasion/carlini.py
+++ b/art/attacks/evasion/carlini.py
@@ -992,7 +992,7 @@ class CarliniL0Method(CarliniL2Method):
         #   - Computes the gradients of the objective function evaluated at the adversarial instance
         #   - Fix the attribute with the lowest value (gradient * perturbation)
         # Repeat until the L_2 attack fails to find an adversarial examples.
-        for i in range(x.shape[1] + 1):
+        for _ in range(x.shape[1] + 1):
             # Compute perturbation with implicit batching
             nb_batches = int(np.ceil(x_adv.shape[0] / float(self.batch_size)))
             for batch_id in range(nb_batches):


### PR DESCRIPTION
# Description

This pull request fixes some convergence issues in Carlini&Wagner L0 attack. It includes:
- Disabling `warm_start` by default, since it is optional.
- The maximum number of iterations is limited by the number of features.
- When `warm_start` is activated, initialize `x_batch` only with the activated features.
- Fix the update of `objective_reduction` to add 0 to active features.

## Type of change

Please check all relevant options.

- [+] Improvement (non-breaking)
- [+] Bug fix (non-breaking)
- [-] New feature (non-breaking)
- [-] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [-] This change requires a documentation update

# Checklist

- [+] My code follows the style guidelines of this project
- [+] I have performed a self-review of my own code
- [-] I have commented my code
- [-] I have made corresponding changes to the documentation
- [-] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [-] New and existing unit tests pass locally with my changes
