### PR TITLE
Add back apply_fit and apply_predict check for Numpy-based preprocessing

### DIFF
--- a/art/estimators/pytorch.py
+++ b/art/estimators/pytorch.py
@@ -199,7 +199,12 @@ class PyTorchEstimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimator):
         ):
             # Compatible with non-PyTorch defences if no chaining.
             for preprocess in self.preprocessing_operations:
-                x, y = preprocess(x, y)
+                if fit:
+                    if preprocess.apply_fit:
+                        x, y = preprocess(x, y)
+                else:
+                    if preprocess.apply_predict:
+                        x, y = preprocess(x, y)
 
         else:
             raise NotImplementedError("The current combination of preprocessing types is not supported.")

--- a/art/estimators/tensorflow.py
+++ b/art/estimators/tensorflow.py
@@ -208,7 +208,12 @@ class TensorFlowV2Estimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimato
         ):
             # Compatible with non-TensorFlow defences if no chaining.
             for preprocess in self.preprocessing_operations:
-                x, y = preprocess(x, y)
+                if fit:
+                    if preprocess.apply_fit:
+                        x, y = preprocess(x, y)
+                else:
+                    if preprocess.apply_predict:
+                        x, y = preprocess(x, y)
 
         else:
             raise NotImplementedError("The current combination of preprocessing types is not supported.")


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds back `apply_fit` and `apply_predict` check for Numpy-based preprocessing in `TensorFlowV2Estimator` and `PyTorchEstimator`.

Fixes #1174

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
