### PR TITLE
Fix get_started_keras

### DIFF
--- a/art/estimators/classification/keras.py
+++ b/art/estimators/classification/keras.py
@@ -569,9 +569,7 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
         if self._reduce_labels:
             y_preprocessed = np.argmax(y_preprocessed, axis=1)
 
-        gen = generator_fit(x_preprocessed, y_preprocessed, batch_size)
-        steps_per_epoch = max(int(x_preprocessed.shape[0] / batch_size), 1)
-        self._model.fit_generator(gen, steps_per_epoch=steps_per_epoch, epochs=nb_epochs, **kwargs)
+        self._model.fit(x=x_preprocessed, y=y_preprocessed, batch_size=batch_size, epochs=nb_epochs, **kwargs)
 
     def fit_generator(self, generator: "DataGenerator", nb_epochs: int = 20, **kwargs) -> None:
         """

--- a/examples/get_started_keras.py
+++ b/examples/get_started_keras.py
@@ -4,9 +4,13 @@ and creates adversarial examples using the Fast Gradient Sign Method. Here we us
 it would also be possible to provide a pretrained model to the ART classifier.
 The parameters are chosen for reduced computational requirements of the script and not optimised for accuracy.
 """
-import keras
-from keras.models import Sequential
-from keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
+import tensorflow as tf
+
+tf.compat.v1.disable_eager_execution()
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
+from tensorflow.keras.losses import categorical_crossentropy
+from tensorflow.keras.optimizers import Adam
 import numpy as np
 
 from art.attacks.evasion import FastGradientMethod
@@ -28,9 +32,7 @@ model.add(Flatten())
 model.add(Dense(100, activation="relu"))
 model.add(Dense(10, activation="softmax"))
 
-model.compile(
-    loss=keras.losses.categorical_crossentropy, optimizer=keras.optimizers.Adam(lr=0.01), metrics=["accuracy"]
-)
+model.compile(loss=categorical_crossentropy, optimizer=Adam(learning_rate=0.01), metrics=["accuracy"])
 
 # Step 3: Create the ART classifier
 

--- a/tests/estimators/classification/test_input_filter.py
+++ b/tests/estimators/classification/test_input_filter.py
@@ -52,7 +52,7 @@ class TestInputFilter(TestBase):
         logger.info("Accuracy: %.2f%%", (acc2 * 100))
 
         self.assertEqual(acc, 0.32)
-        self.assertEqual(acc2, 0.73)
+        self.assertEqual(acc2, 0.77)
 
         classifier.fit(self.x_train_mnist, y=self.y_train_mnist, batch_size=BATCH_SIZE, nb_epochs=2)
         classifier.fit(x=self.x_train_mnist, y=self.y_train_mnist, batch_size=BATCH_SIZE, nb_epochs=2)


### PR DESCRIPTION
# Description

It looks like the most recent versions of TensorFlow (2.5, 2.4) and Keras 2.4.3 result in error for certain tools (e.g. Adam optimizer) if imported from `keras`. This is fixed by importing from `tensorflow.keras`.

Fixes #1180 #1159

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
