### PR TITLE
New boundary attack

### DIFF
--- a/art/attacks/inference/membership_inference/label_only_boundary_distance.py
+++ b/art/attacks/inference/membership_inference/label_only_boundary_distance.py
@@ -207,7 +207,7 @@ class LabelOnlyDecisionBoundary(MembershipInferenceAttack):
     ):
         """
         Calibrate distance threshold on randomly generated samples, choosing the top-t percentile of the noise needed
-        to change the classifier's initial prediction.
+        to change the classifier's initial prediction. This method requires the model's clip_values to be set.
 
         | Paper link: https://arxiv.org/abs/2007.15528
 

--- a/art/attacks/inference/membership_inference/label_only_boundary_distance.py
+++ b/art/attacks/inference/membership_inference/label_only_boundary_distance.py
@@ -18,7 +18,8 @@
 """
 This module implements the Label-Only Inference Attack based on Decision Boundary.
 
-| Paper link: https://arxiv.org/abs/2007.14321
+| Paper link: https://arxiv.org/abs/2007.14321 (Choquette-Choo et al.) and https://arxiv.org/abs/2007.15528 (Li and
+Zhang)
 """
 import logging
 from typing import Optional, TYPE_CHECKING
@@ -40,7 +41,10 @@ class LabelOnlyDecisionBoundary(MembershipInferenceAttack):
     """
     Implementation of Label-Only Inference Attack based on Decision Boundary.
 
-    | Paper link: https://arxiv.org/abs/2007.14321
+    | Paper link: https://arxiv.org/abs/2007.14321 (Choquette-Choo et al.) and https://arxiv.org/abs/2007.15528 (Li
+    and Zhang)
+
+    You only need to call ONE of the calibrate methods, depending on which attack you want to launch.
     """
 
     attack_params = MembershipInferenceAttack.attack_params + [
@@ -135,6 +139,8 @@ class LabelOnlyDecisionBoundary(MembershipInferenceAttack):
     ):
         """
         Calibrate distance threshold maximising the membership inference accuracy on `x_train` and `x_test`.
+
+        | Paper link: https://arxiv.org/abs/2007.14321
 
         :param x_train: Training data.
         :param y_train: Labels of training data `x_train`.

--- a/art/attacks/inference/membership_inference/label_only_boundary_distance.py
+++ b/art/attacks/inference/membership_inference/label_only_boundary_distance.py
@@ -202,9 +202,7 @@ class LabelOnlyDecisionBoundary(MembershipInferenceAttack):
 
         self.distance_threshold_tau = distance_threshold_tau
 
-    def calibrate_distance_threshold_unsupervised(
-            self, top_t: int, num_samples: int, max_queries: int, **kwargs
-    ):
+    def calibrate_distance_threshold_unsupervised(self, top_t: int, num_samples: int, max_queries: int, **kwargs):
         """
         Calibrate distance threshold on randomly generated samples, choosing the top-t percentile of the noise needed
         to change the classifier's initial prediction.
@@ -226,8 +224,8 @@ class LabelOnlyDecisionBoundary(MembershipInferenceAttack):
 
         x_min, x_max = self.estimator.clip_values
 
-        x_rand = np.random.rand(*(num_samples, ) + self.estimator.input_shape).astype(np.float32)
-        x_rand *= (x_max - x_min)  # scale
+        x_rand = np.random.rand(*(num_samples,) + self.estimator.input_shape).astype(np.float32)
+        x_rand *= x_max - x_min  # scale
         x_rand += x_min  # shift
 
         y_rand = np.random.randint(0, self.estimator.nb_classes, num_samples)
@@ -254,10 +252,11 @@ class LabelOnlyDecisionBoundary(MembershipInferenceAttack):
             i += 1
 
         if len(distances) == 0:
-            raise RuntimeWarning("No successful adversarial examples were generated - no distances were obtained."
-                                 "Distance threshold will not be set.")
-        else:
-            self.distance_threshold_tau = np.percentile(distances, top_t)
+            raise RuntimeWarning(
+                "No successful adversarial examples were generated - no distances were obtained."
+                "Distance threshold will not be set."
+            )
+        self.distance_threshold_tau = np.percentile(distances, top_t)
 
     def _check_params(self) -> None:
         if self.distance_threshold_tau is not None and (

--- a/art/attacks/inference/membership_inference/label_only_boundary_distance.py
+++ b/art/attacks/inference/membership_inference/label_only_boundary_distance.py
@@ -196,6 +196,63 @@ class LabelOnlyDecisionBoundary(MembershipInferenceAttack):
 
         self.distance_threshold_tau = distance_threshold_tau
 
+    def calibrate_distance_threshold_unsupervised(
+            self, top_t: int, num_samples: int, max_queries: int, **kwargs
+    ):
+        """
+        Calibrate distance threshold on randomly generated samples, choosing the top-t percentile of the noise needed
+        to change the classifier's initial prediction.
+
+        | Paper link: https://arxiv.org/abs/2007.15528
+
+        :param top_t: Top-t percentile.
+        :param num_samples: Number of random samples to generate.
+        :param max_queries: Maximum number of queries.
+        :Keyword Arguments for HopSkipJump:
+            * *norm*: Order of the norm. Possible values: "inf", np.inf or 2.
+            * *max_iter*: Maximum number of iterations.
+            * *max_eval*: Maximum number of evaluations for estimating gradient.
+            * *init_eval*: Initial number of evaluations for estimating gradient.
+            * *init_size*: Maximum number of trials for initial generation of adversarial examples.
+            * *verbose*: Show progress bars.
+        """
+        from art.attacks.evasion.hop_skip_jump import HopSkipJump
+
+        x_min, x_max = self.estimator.clip_values
+
+        x_rand = np.random.rand(*(num_samples, ) + self.estimator.input_shape).astype(np.float32)
+        x_rand *= (x_max - x_min)  # scale
+        x_rand += x_min  # shift
+
+        y_rand = np.random.randint(0, self.estimator.nb_classes, num_samples)
+        y_rand = check_and_transform_label_format(y_rand, self.estimator.nb_classes)
+
+        hsj = HopSkipJump(classifier=self.estimator, targeted=False, **kwargs)
+
+        distances = []
+
+        i = 0
+        while len(x_rand) != 0 and i < max_queries:
+            x_adv = hsj.generate(x=x_rand, y=y_rand)
+
+            distance = np.linalg.norm((x_adv - x_rand).reshape((x_rand.shape[0], -1)), ord=2, axis=1)
+
+            y_pred = self.estimator.predict(x=x_adv)
+
+            changed_predictions = np.argmax(y_pred, axis=1) != np.argmax(y_rand, axis=1)
+
+            distances.extend(distance[changed_predictions])
+
+            x_rand, y_rand = x_adv[~changed_predictions], y_rand[~changed_predictions]
+
+            i += 1
+
+        if len(distances) == 0:
+            raise RuntimeWarning("No successful adversarial examples were generated - no distances were obtained."
+                                 "Distance threshold will not be set.")
+        else:
+            self.distance_threshold_tau = np.percentile(distances, top_t)
+
     def _check_params(self) -> None:
         if self.distance_threshold_tau is not None and (
             not isinstance(self.distance_threshold_tau, (int, float)) or self.distance_threshold_tau <= 0.0

--- a/notebooks/label_only_membership_inference.ipynb
+++ b/notebooks/label_only_membership_inference.ipynb
@@ -1,0 +1,498 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "12449643",
+   "metadata": {},
+   "source": [
+    "# Label-only Membership Inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8da9460",
+   "metadata": {},
+   "source": [
+    "## Intuition\n",
+    "\n",
+    "The basic intuition behind the attack is that samples used in training will be farther away from the decision boundary than non-training data.\n",
+    "\n",
+    "The attacker uses various means of **perturbations** to measure the amount of noise that is needed to \"change the classifier's mind\" about their prediction for a given sample. Since the ML model is more confident on training data, the attacker will need to perturb the input more to force the model to misclassify. Thus, the amount of perturbation needed will be analogue to the sample's distance from the decision boundary. Both of the below listed attacks use an adversarial perturbation techique called [**HopSkipJump**](https://arxiv.org/abs/1904.02144).\n",
+    "\n",
+    "![title](img/label_only_boundary_intuition.png)\n",
+    "\n",
+    "### Learning $\\tau$\n",
+    "\n",
+    "Given some estimate of a sample's distance from the model's decision boundary, the attacker compares it to a threshold $\\tau$. Any distance greater than $\\tau$ will cause the sample to be classified as a training sample. \n",
+    "\n",
+    "There are two ways to learn the distance threshold $\\tau$:\n",
+    "- with data (Choquette et al., https://arxiv.org/abs/2007.14321)\n",
+    "- without data (Li et al., https://arxiv.org/abs/2007.15528)\n",
+    "\n",
+    "#### With data\n",
+    "In this scenario, the attacker needs to know about a subset of the data if it had been used in training or not. It uses this data to calculate their distances to the decision boundary, and sets $\\tau$ such that it maximizes membership inference accuracy. Misclassified samples will be regarded as non-training samples.\n",
+    "\n",
+    "#### Without data\n",
+    "Here the attacker generates _random data_, and uses the same perturbation techniques as before to measure their distance from the decision threshold. In the end, the attacker chooses a suitable top t percentile over these distances to calibrate $\\tau$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "894fe18a",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "How to implement the attack using ART.\n",
+    "#### 1. [Preliminaries](#preliminaries)\n",
+    "1. [Load data and attacked model](#load)\n",
+    "2. [Wrap model in ART classifier wrapper](#wrap)\n",
+    "\n",
+    "#### 2. Attack ([w/ data](#attack), [w/o data](#attack_nodata))\n",
+    "1. Instantiate attack ([w/ data](#instantiate), [w/o data](#instantiate_nodata))\n",
+    "2. Calibrate distance threshold $\\tau$ ([w/ data](#calibrate), [w/o data](#calibrate_nodata))\n",
+    "3. Infer membership on evaluation data ([w/ data](#infer), [w/o data](#infer_nodata))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0eaff31a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn\n",
+    "import numpy as np\n",
+    "from models.mnist import Net"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c488e8b1",
+   "metadata": {},
+   "source": [
+    "<a id='preliminaries'></a>\n",
+    "## Preliminaries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1874f6a7",
+   "metadata": {},
+   "source": [
+    "<a id='load'></a>\n",
+    "### Load data and attacked model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "99751c07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "sys.path.insert(0, os.path.abspath('..'))\n",
+    "\n",
+    "from art.utils import load_mnist\n",
+    "\n",
+    "# data\n",
+    "(x_train, y_train), (x_test, y_test), _min, _max = load_mnist(raw=True)\n",
+    "\n",
+    "x_train = np.expand_dims(x_train, axis=1).astype(np.float32)\n",
+    "x_test = np.expand_dims(x_test, axis=1).astype(np.float32)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "b1e1dc48",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<All keys matched successfully>"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# model\n",
+    "state_dict = torch.load(\"models/mnist_cnn.pt\")\n",
+    "model = Net()\n",
+    "model.load_state_dict(state_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "352fb1ef",
+   "metadata": {},
+   "source": [
+    "<a id='wrap'></a>\n",
+    "### Wrap model in PyTorchClassifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "48416f14",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Base model accuracy:  0.9461\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch.optim as optim\n",
+    "from art.estimators.classification.pytorch import PyTorchClassifier\n",
+    "\n",
+    "criterion = nn.CrossEntropyLoss()\n",
+    "optimizer = optim.Adam(model.parameters())\n",
+    "\n",
+    "art_model = PyTorchClassifier(model=model, loss=criterion, optimizer=optimizer, channels_first=True, input_shape=(1,28,28,), nb_classes=10, clip_values=(_min,_max))\n",
+    "\n",
+    "pred = np.array([np.argmax(arr) for arr in art_model.predict(x_test)])\n",
+    "\n",
+    "print('Base model accuracy: ', np.sum(pred == y_test) / len(y_test))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a7a5c76",
+   "metadata": {},
+   "source": [
+    "<a id='attack'></a>\n",
+    "## Attack (supervised, with data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c1e11ea",
+   "metadata": {},
+   "source": [
+    "<a id='instantiate'></a>\n",
+    "### Instantiate attack"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "b723b28e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from art.attacks.inference.membership_inference import LabelOnlyDecisionBoundary\n",
+    "\n",
+    "mia_label_only = LabelOnlyDecisionBoundary(art_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1051952",
+   "metadata": {},
+   "source": [
+    "<a id='calibrate'></a>\n",
+    "### Calibrate distance threshold"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "id": "9f5097b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# number of samples used to calibrate distance threshold\n",
+    "attack_train_size = 1500\n",
+    "attack_test_size = 1500\n",
+    "\n",
+    "x = np.concatenate([x_train, x_test])\n",
+    "y = np.concatenate([y_train, y_test])\n",
+    "training_sample = np.array([1] * len(x_train) + [0] * len(x_test))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "bffeebe6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "751a0dbac4474243bcf1bc625699d531",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HopSkipJump:   0%|          | 0/1500 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aeebbf128fba46ce91a0fb301261bd9a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HopSkipJump:   0%|          | 0/1500 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "mia_label_only.calibrate_distance_threshold(x_train[:attack_train_size], y_train[:attack_train_size],\n",
+    "                                            x_test[:attack_test_size], y_test[:attack_test_size])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdb56c43",
+   "metadata": {},
+   "source": [
+    "<a id='infer'></a>\n",
+    "### Infer membeship on evaluation data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "id": "6066b6b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numpy.random import choice\n",
+    "\n",
+    "# evaluation data\n",
+    "n = 500\n",
+    "eval_data_idx = choice(len(x), n)\n",
+    "x_eval, y_eval = x[eval_data_idx], y[eval_data_idx]\n",
+    "eval_label = training_sample[eval_data_idx]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "id": "092d5244",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0377d816b6cb4b14a19a944039484cfc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HopSkipJump:   0%|          | 0/500 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pred_label = mia_label_only.infer(x_eval, y_eval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "id": "b0564416",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy: 0.716000\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.metrics import accuracy_score\n",
+    "\n",
+    "print(\"Accuracy: %f\" % accuracy_score(eval_label, pred_label))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0036adc",
+   "metadata": {},
+   "source": [
+    "<a id='attack_nodata'></a>\n",
+    "## Attack (unsupervised, without data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d3c8c6a",
+   "metadata": {},
+   "source": [
+    "<a id='instantiate_nodata'></a>\n",
+    "### Instantiate attack"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "id": "51c92ed3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mia_label_only_unsupervised = LabelOnlyDecisionBoundary(art_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e2e916b",
+   "metadata": {},
+   "source": [
+    "<a id='calibrate_nodata'></a>\n",
+    "### Calibrate distance threshold"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "id": "6f83780a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "287965a01bc54675af3268daf91aa280",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HopSkipJump:   0%|          | 0/500 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "823c1a3993d3426ea59a566460263c86",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HopSkipJump:   0%|          | 0/41 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# calibrate distance threshold in an UNSUPERVISED way, without data\n",
+    "mia_label_only_unsupervised.calibrate_distance_threshold_unsupervised(top_t=50, num_samples=500, max_queries=2, verbose=True, batch_size=256)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0f425d3",
+   "metadata": {},
+   "source": [
+    "<a id='infer_nodata'></a>\n",
+    "### Infer membeship on evaluation data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "id": "bdaeb2bc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4da3d8ea70364801881a7915d083ba49",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HopSkipJump:   0%|          | 0/500 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pred_label_unsuperviseed = mia_label_only_unsupervised.infer(x_eval, y_eval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "id": "d2de93fa",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy: 0.748000\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Accuracy: %f\" % accuracy_score(eval_label, pred_label_unsuperviseed))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5679956",
+   "metadata": {},
+   "source": [
+    "**As we can see, one does not need any data, their correct label or knowledge about their membership to perform a successful membership inference attack.**\n",
+    "\n",
+    "**The attacker needs only the observed output labels of the model.**"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "art_kernel",
+   "language": "python",
+   "name": "art_kernel"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/attacks/inference/membership_inference/test_label_only_boundary_distance.py
+++ b/tests/attacks/inference/membership_inference/test_label_only_boundary_distance.py
@@ -70,6 +70,26 @@ def test_label_only_boundary_distance_prob_calib(art_warning, get_default_mnist_
         art_warning(e)
 
 
+def test_label_only_boundary_distance_prob_calib_unsup(
+    art_warning, get_default_mnist_subset, image_dl_estimator_for_attack
+):
+    try:
+        classifier = image_dl_estimator_for_attack(LabelOnlyDecisionBoundary)
+        attack = LabelOnlyDecisionBoundary(classifier)
+        kwargs = {
+            "norm": 2,
+            "max_iter": 2,
+            "max_eval": 4,
+            "init_eval": 1,
+            "init_size": 1,
+            "verbose": False,
+        }
+        attack.calibrate_distance_threshold_unsupervised(50, 100, 1, **kwargs)
+        backend_check_membership_probabilities(attack, get_default_mnist_subset, attack_train_ratio)
+    except ARTTestException as e:
+        art_warning(e)
+
+
 def test_classifier_type_check_fail(art_warning):
     try:
         backend_test_classifier_type_check_fail(LabelOnlyDecisionBoundary, [BaseEstimator, ClassifierMixin])


### PR DESCRIPTION
# Description

This is an implementation of a new boundary attack by Li and Zhang (https://arxiv.org/abs/2007.15528).

Fixes #1167

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

I included a test in `tests/attacks/inference/membership_inference/test_label_only_boundary_distance.py` which runs the newly implemented calibration method (`calibrate_distance_threshold_unsupervised`). This test is basically a copy of `test_label_only_boundary_distance_prob_calib`.
- [x] `test_label_only_boundary_distance_prob_calib_unsup`

**Test Configuration**:
- Ubuntu 20.04 (Focal Fossa)
- Python 3.8.10
- commit number: `4c5b12eb`
- TensorFlow  2.3.2 / Keras 2.4.3 / PyTorch 1.8.1 / MXNet (not installed)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
