### PR TITLE
Support for video compression defence in PyTorch-specific attacks

### DIFF
--- a/art/defences/preprocessor/__init__.py
+++ b/art/defences/preprocessor/__init__.py
@@ -16,3 +16,4 @@ from art.defences.preprocessor.spatial_smoothing_tensorflow import SpatialSmooth
 from art.defences.preprocessor.thermometer_encoding import ThermometerEncoding
 from art.defences.preprocessor.variance_minimization import TotalVarMin
 from art.defences.preprocessor.video_compression import VideoCompression
+from art.defences.preprocessor.video_compression_pytorch import VideoCompressionPyTorch

--- a/art/defences/preprocessor/video_compression_pytorch.py
+++ b/art/defences/preprocessor/video_compression_pytorch.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2021
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the "Software"), to deal in the Software without restriction, including without limitation the

--- a/art/defences/preprocessor/video_compression_pytorch.py
+++ b/art/defences/preprocessor/video_compression_pytorch.py
@@ -90,6 +90,7 @@ class VideoCompressionPyTorch(PreprocessorPyTorch):
             """
             Function running Preprocessor.
             """
+
             @staticmethod
             def forward(ctx, input):  # pylint: disable=W0622,W0221
                 numpy_input = input.detach().cpu().numpy()

--- a/art/defences/preprocessor/video_compression_pytorch.py
+++ b/art/defences/preprocessor/video_compression_pytorch.py
@@ -89,13 +89,13 @@ class VideoCompressionPyTorch(PreprocessorPyTorch):
         class CompressionPyTorchNumpy(Function):
             @staticmethod
             def forward(ctx, input):
-                numpy_input = input.detach().numpy()
+                numpy_input = input.detach().cpu().numpy()
                 result, _ = self.compression_numpy(numpy_input)
                 return input.new(result)
 
             @staticmethod
             def backward(ctx, grad_output):
-                numpy_go = grad_output.numpy()
+                numpy_go = grad_output.cpu().numpy()
                 result = self.compression_numpy.estimate_gradient(None, numpy_go)
                 return grad_output.new(result)
 

--- a/art/defences/preprocessor/video_compression_pytorch.py
+++ b/art/defences/preprocessor/video_compression_pytorch.py
@@ -1,0 +1,122 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+This module implements a wrapper for video compression defence with FFmpeg.
+
+| Please keep in mind the limitations of defences. For details on how to evaluate classifier security in general,
+    see https://arxiv.org/abs/1902.06705.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+from typing import Optional, Tuple, TYPE_CHECKING
+
+import numpy as np
+
+from art.defences.preprocessor.preprocessor import PreprocessorPyTorch
+from art.defences.preprocessor.video_compression import VideoCompression
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    # pylint: disable=C0412
+    import torch
+
+
+class VideoCompressionPyTorch(PreprocessorPyTorch):
+    """
+    Implement FFmpeg wrapper for video compression defence based on H.264/MPEG-4 AVC.
+
+    Video compression uses H.264 video encoding. The video quality is controlled with the constant rate factor
+    parameter. More information on the constant rate factor: https://trac.ffmpeg.org/wiki/Encode/H.264.
+    """
+
+    params = ["video_format", "constant_rate_factor", "channels_first", "verbose"]
+
+    def __init__(
+        self,
+        *,
+        video_format: str,
+        constant_rate_factor: int = 28,
+        channels_first: bool = False,
+        apply_fit: bool = False,
+        apply_predict: bool = True,
+        verbose: bool = False,
+    ):
+        """
+        Create an instance of VideoCompression.
+
+        :param video_format: Specify one of supported video file extensions, e.g. `avi`, `mp4` or `mkv`.
+        :param constant_rate_factor: Specify constant rate factor (range 0 to 51, where 0 is lossless).
+        :param channels_first: Set channels first or last.
+        :param apply_fit: True if applied during fitting/training.
+        :param apply_predict: True if applied during predicting.
+        :param verbose: Show progress bars.
+        """
+        from torch.autograd import Function
+
+        super().__init__(is_fitted=True, apply_fit=apply_fit, apply_predict=apply_predict)
+        self.video_format = video_format
+        self.constant_rate_factor = constant_rate_factor
+        self.channels_first = channels_first
+        self.verbose = verbose
+        self._check_params()
+
+        self.compression_numpy = VideoCompression(
+            video_format=video_format,
+            constant_rate_factor=constant_rate_factor,
+            channels_first=channels_first,
+            apply_fit=apply_fit,
+            apply_predict=apply_predict,
+            verbose=verbose,
+        )
+
+        class CompressionPyTorchNumpy(Function):
+            @staticmethod
+            def forward(ctx, input):
+                numpy_input = input.detach().numpy()
+                result, _ = self.compression_numpy(numpy_input)
+                return input.new(result)
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                numpy_go = grad_output.numpy()
+                result = self.compression_numpy.estimate_gradient(None, numpy_go)
+                return grad_output.new(result)
+
+        self._compression_pytorch_numpy = CompressionPyTorchNumpy
+
+    def forward(
+        self, x: "torch.Tensor", y: Optional["torch.Tensor"] = None
+    ) -> Tuple["torch.Tensor", Optional["torch.Tensor"]]:
+        """
+        Apply video compression to sample `x`.
+
+        :param x: Sample to compress of shape NCFHW or NFHWC. `x` values are expected to be in the data range [0, 255].
+        :param y: Labels of the sample `x`. This function does not affect them in any way.
+        :return: Compressed sample.
+        """
+        x_compressed = self._compression_pytorch_numpy.apply(x)
+        return x_compressed, y
+
+    def _check_params(self) -> None:
+        if not (isinstance(self.constant_rate_factor, (int, np.int)) and 0 <= self.constant_rate_factor < 52):
+            raise ValueError("Constant rate factor must be an integer in the range [0, 51].")
+
+        if not isinstance(self.verbose, bool):
+            raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/defences/preprocessor/video_compression_pytorch.py
+++ b/art/defences/preprocessor/video_compression_pytorch.py
@@ -87,14 +87,17 @@ class VideoCompressionPyTorch(PreprocessorPyTorch):
         )
 
         class CompressionPyTorchNumpy(Function):
+            """
+            Function running Preprocessor.
+            """
             @staticmethod
-            def forward(ctx, input):
+            def forward(ctx, input):  # pylint: disable=W0622,W0221
                 numpy_input = input.detach().cpu().numpy()
                 result, _ = self.compression_numpy(numpy_input)
                 return input.new(result)
 
             @staticmethod
-            def backward(ctx, grad_output):
+            def backward(ctx, grad_output):  # pylint: disable=W0221
                 numpy_go = grad_output.cpu().numpy()
                 result = self.compression_numpy.estimate_gradient(None, numpy_go)
                 return grad_output.new(result)


### PR DESCRIPTION
# Description

This pull request adds support for `VideoCompression` preprocessing in PyTorch-specific attacks.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
