### PR TITLE
feature_adversaries_numpy.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ scipy==1.7.0
 matplotlib==3.4.2
 scikit-learn>=0.22.2,<0.24.3
 six==1.16.0
-Pillow==8.2.0
+Pillow==8.3.0
 tqdm==4.61.1
 statsmodels==0.12.2
 pydub==0.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ catboost==0.26
 GPy==1.10.0
 lightgbm==3.2.1
 xgboost==1.4.2
-kornia~=0.5.4
+kornia~=0.5.5
 tensorboardX==2.3
 lief==0.11.5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ GPy==1.10.0
 lightgbm==3.2.1
 xgboost==1.4.2
 kornia~=0.5.5
-tensorboardX==2.3
+tensorboardX==2.4
 lief==0.11.5
 
 # Lingvo ASR dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ GPy==1.10.0
 lightgbm==3.2.1
 xgboost==1.4.2
 kornia~=0.5.4
-tensorboardX==2.2
+tensorboardX==2.3
 lief==0.11.5
 
 # Lingvo ASR dependencies


### PR DESCRIPTION
# Description

Updated feature_adversaries_numpy.py so that layer: Union[int, str, Tuple[int, ...], Tuple[str, ...]] = -1 rather than just integer. 
No dependencies changes needed. 

Fixes # (issue): 1185

## Type of change

Please check all relevant options.

- [ X] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

Test A: Using adv = fa.FeatureAdversariesNumpy(model, delta=0.1, layer = (14, 16), batch_size = batch_size) instead of
adv = fa.FeatureAdversariesNumpy(model, delta=0.1, layer = 14, batch_size = batch_size) to generate adversarial images

**Test Configuration**:
- OS 
NAME="Red Hat Enterprise Linux Server"
VERSION="7.4 (Maipo)"
- Python version: 3.8.5
- ART version or commit number: 1.7
- TensorFlow version: 2.2.0

# Checklist

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [X ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
