### PR TITLE
Remove duplicate application of preprocessing in fallback BaseEstimator.fit_generator

### DIFF
--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -443,11 +443,8 @@ class NeuralNetworkMixin(ABC):
             ):  # type: ignore
                 x, y = generator.get_batch()
 
-                # Apply preprocessing and defences
-                x_preprocessed, y_preprocessed = self._apply_preprocessing(x, y, fit=True)  # type: ignore
-
                 # Fit for current batch
-                self.fit(x_preprocessed, y_preprocessed, nb_epochs=1, batch_size=generator.batch_size, **kwargs)
+                self.fit(x, y, nb_epochs=1, batch_size=generator.batch_size, **kwargs)
 
     @abstractmethod
     def get_activations(


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request removes the unnecessary duplicate application of preprocessing in fallback `BaseEstimator.fit_generator`.

Fixes #1217

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
