### PR TITLE
allow SquareAttack on rectangular images

### DIFF
--- a/art/attacks/evasion/square_attack.py
+++ b/art/attacks/evasion/square_attack.py
@@ -228,7 +228,7 @@ class SquareAttack(EvasionAttack):
 
                     sample_loss_init = self.loss(x_robust, y_robust)
 
-                    height_tile = max(int(round(math.sqrt(percentage_of_elements * height * width))), 1)
+                    height_tile = max(int(round(math.sqrt(percentage_of_elements * min(height, width) ** 2))), 1)
 
                     height_mid = np.random.randint(0, height - height_tile)
                     width_start = np.random.randint(0, width - height_tile)


### PR DESCRIPTION
# Description

allow SquareAttack on rectangular images, the edges of perturbation will always be shorter than height and width of input  #images

Fixes  #1244

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B
- [x] I don't know what these two tests mean but I tested with some [128, 188 , 1] images and no error raised

**Test Configuration**:
- OS: Manjaro
- Python version: 3.9
- ART version or commit number: 1.7.0
- TensorFlow / Keras / PyTorch / MXNet version: tensorflow-gpu 2.5.0

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
