### PR TITLE
Fix min_epsilon of BoundaryAttack to receive a non-negative value

### DIFF
--- a/art/attacks/evasion/boundary.py
+++ b/art/attacks/evasion/boundary.py
@@ -470,7 +470,7 @@ class BoundaryAttack(EvasionAttack):
         if self.step_adapt <= 0 or self.step_adapt >= 1:
             raise ValueError("The adaptation factor must be in the range (0, 1).")
 
-        if self.min_epsilon < 0:
+        if not isinstance(self.min_epsilon, (float, int)) or self.min_epsilon < 0:
             raise ValueError("The minimum epsilon must be non-negative.")
 
         if not isinstance(self.verbose, bool):

--- a/art/attacks/evasion/boundary.py
+++ b/art/attacks/evasion/boundary.py
@@ -76,7 +76,7 @@ class BoundaryAttack(EvasionAttack):
         num_trial: int = 25,
         sample_size: int = 20,
         init_size: int = 100,
-        min_epsilon: Optional[float] = None,
+        min_epsilon: float = 0,
         verbose: bool = True,
     ) -> None:
         """
@@ -327,7 +327,7 @@ class BoundaryAttack(EvasionAttack):
                 logger.warning("Adversarial example found but not optimal.")
                 return self._best_adv(original_sample, x_advs)
 
-            if self.min_epsilon is not None and self.curr_epsilon < self.min_epsilon:
+            if self.curr_epsilon < self.min_epsilon:
                 return x_adv
 
         return x_adv
@@ -470,8 +470,8 @@ class BoundaryAttack(EvasionAttack):
         if self.step_adapt <= 0 or self.step_adapt >= 1:
             raise ValueError("The adaptation factor must be in the range (0, 1).")
 
-        if self.min_epsilon is not None and (isinstance(self.min_epsilon, float) or self.min_epsilon <= 0):
-            raise ValueError("The minimum epsilon must be a positive float.")
+        if self.min_epsilon < 0:
+            raise ValueError("The minimum epsilon must be non-negative.")
 
         if not isinstance(self.verbose, bool):
             raise ValueError("The argument `verbose` has to be of type bool.")


### PR DESCRIPTION
Signed-off-by: kaitokishi <kishi.kaito@fujitsu.com>

# Description

Passing a positive float value into `min_epsilon` of `BoundaryAttack` raises Exception. This is because `_check_params()` raises `ValueError` even if `self.min_epsilon` is positive float. This PR is to fix this bug.

Also, this PR makes it simple to use `min_epsilon` by avoiding to use `None`.

Fixes #1258 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

- [x] Below code
```
attack = BoundaryAttack(model, batch_size=100, targeted=False, max_iter=20, epsilon=0.1, min_epsilon=0.02)
x_adv = attack.generate(x=x)
```
works.

**Test Configuration**:
- OS: Ubuntu 18.04.5 LTS
- Python version: 3.6.9
- ART version or commit number: 1.7.0
- TensorFlow version: 2.3.0

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
