### PR TITLE
Getting the shape from the correct matrix (Fixing issue #1289)

### DIFF
--- a/art/attacks/poisoning/perturbations/image_perturbations.py
+++ b/art/attacks/poisoning/perturbations/image_perturbations.py
@@ -128,7 +128,7 @@ def insert_image(
     if channels_first:
         data = data.transpose([1, 2, 0])
 
-    width, height, num_channels = x.shape
+    width, height, num_channels = data.shape
 
     no_color = num_channels == 1
     orig_img = Image.new("RGBA", (width, height), 0)


### PR DESCRIPTION
# Description

This fixes issue #1289 (https://github.com/Trusted-AI/adversarial-robustness-toolbox/issues/1289).
Originally, the shape was obtained from the old matrix before the transposition, producing a false error in an following assert statement.

Fixes #1289 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS: Linux Ubuntu 18.08
- Python version: 3.7
- ART version or commit number: dev_1.7.2
- TensorFlow / Keras / PyTorch / MXNet version: TF 2.1

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
