### PR TITLE
fix import error at model inversion attacks notebook

### DIFF
--- a/notebooks/model_inversion_attacks_mnist.ipynb
+++ b/notebooks/model_inversion_attacks_mnist.ipynb
@@ -34,7 +34,7 @@
     "seed(123)\n",
     "\n",
     "from art.estimators.classification import KerasClassifier\n",
-    "from art.attacks.inference import MIFace\n",
+    "from art.attacks.inference.model_inversion.mi_face import MIFace\n",
     "from art.utils import load_dataset\n",
     "\n",
     "%matplotlib inline\n",


### PR DESCRIPTION
# Description

Issue: meet import error when running the `notebook/model_inversion_attacks_mnist.ipynb` 
Reason: the art API of `MIFace` is redirected to `from art.attacks.inference.model_inversion.mi_face`, but the corresponding notebook is not updated. 

Fixes # (1311)

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS: mac
- Python version: python 3.6
- ART version or commit number 1.7.2
- TensorFlow

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
