### PR TITLE
Remove outdated comments in SimBA tests

### DIFF
--- a/tests/attacks/test_simba.py
+++ b/tests/attacks/test_simba.py
@@ -39,8 +39,6 @@ class TestSimBA(TestBase):
     A unittest class for testing the Simple Black-box Adversarial Attacks (SimBA).
 
     This module tests SimBA.
-    Note: SimBA runs only in Keras and TensorFlow (not in PyTorch)
-    This is due to the channel first format in PyTorch.
 
     | Paper link: https://arxiv.org/abs/1905.07121
     """
@@ -94,7 +92,6 @@ class TestSimBA(TestBase):
         classifier, sess = get_image_classifier_tf()
         self._test_attack(classifier, self.x_test_mnist, self.y_test_mnist, True)
 
-    # SimBA is not available for PyTorch
     def test_4_pytorch_mnist_targeted(self):
         """
         Test with the PyTorchClassifier. (Targeted Attack)


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request removes outdated comments in SimBA tests.

Fixes #1410

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
