### PR TITLE
Adding type preservation to insert_image

### DIFF
--- a/art/attacks/poisoning/perturbations/image_perturbations.py
+++ b/art/attacks/poisoning/perturbations/image_perturbations.py
@@ -124,6 +124,7 @@ def insert_image(
     if n_dim != 3:
         raise ValueError("Invalid array shape " + str(x.shape))
 
+    original_dtype = x.dtype
     data = np.copy(x)
     if channels_first:
         data = data.transpose([1, 2, 0])
@@ -168,4 +169,4 @@ def insert_image(
     if channels_first:
         res = res.transpose([2, 0, 1])
 
-    return res
+    return res.astype(original_dtype)


### PR DESCRIPTION
# Description

This PR address issue 1440. At the start of the function, the dtype of the original data is stored. Before returning the modified image, the return value is cast back to the original dtype.

Fixes # 1440

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
