### PR TITLE
Update check_and_transform_label_format for index labels

### DIFF
--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -156,7 +156,7 @@ class PixelThreshold(EvasionAttack):
                 raise ValueError(
                     "This attack has not yet been tested for binary classification with a single output classifier."
                 )
-            if len(y.shape) > 1:
+            if y.ndim > 1 and y.shape[1] > 1:
                 y = np.argmax(y, axis=1)
 
         if self.th is None:

--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -159,6 +159,8 @@ class PixelThreshold(EvasionAttack):
             if y.ndim > 1 and y.shape[1] > 1:
                 y = np.argmax(y, axis=1)
 
+        y = np.squeeze(y)
+
         if self.th is None:
             logger.info(
                 "Performing minimal perturbation Attack. \

--- a/art/estimators/classification/keras.py
+++ b/art/estimators/classification/keras.py
@@ -562,13 +562,14 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
                `fit_generator` function in Keras and will be passed to this function as such. Including the number of
                epochs or the number of steps per epoch as part of this argument will result in as error.
         """
+        y_ndim = y.ndim
         y = check_and_transform_label_format(y, self.nb_classes)
 
         # Apply preprocessing
         x_preprocessed, y_preprocessed = self._apply_preprocessing(x, y, fit=True)
 
         # Adjust the shape of y for loss functions that do not take labels in one-hot encoding
-        if self._reduce_labels:
+        if self._reduce_labels or y_ndim == 1:
             y_preprocessed = np.argmax(y_preprocessed, axis=1)
 
         self._model.fit(x=x_preprocessed, y=y_preprocessed, batch_size=batch_size, epochs=nb_epochs, **kwargs)

--- a/art/utils.py
+++ b/art/utils.py
@@ -535,21 +535,27 @@ def check_and_transform_label_format(
     :return: Labels with shape `(nb_samples, nb_classes)` (one-hot) or `(nb_samples,)` (index).
     """
     if labels is not None:
-        if len(labels.shape) == 2 and labels.shape[1] > 1:
+        if len(labels.shape) == 2 and labels.shape[1] > 1:  # multi-class, one-hot encoded
             if not return_one_hot:
                 labels = np.argmax(labels, axis=1)
-        elif len(labels.shape) == 2 and labels.shape[1] == 1 and nb_classes is not None and nb_classes > 2:
-            labels = np.squeeze(labels)
+                labels = np.expand_dims(labels, axis=1)
+        elif (
+            len(labels.shape) == 2 and labels.shape[1] == 1 and nb_classes is not None and nb_classes > 2
+        ):  # multi-class, index labels
             if return_one_hot:
                 labels = to_categorical(labels, nb_classes)
-        elif len(labels.shape) == 2 and labels.shape[1] == 1 and nb_classes is not None and nb_classes == 2:
-            pass
-        elif len(labels.shape) == 1:
+            else:
+                labels = np.expand_dims(labels, axis=1)
+        elif (
+            len(labels.shape) == 2 and labels.shape[1] == 1 and nb_classes is not None and nb_classes == 2
+        ):  # binary, index labels
             if return_one_hot:
-                if nb_classes == 2:
-                    labels = np.expand_dims(labels, axis=1)
-                else:
-                    labels = to_categorical(labels, nb_classes)
+                labels = to_categorical(labels, nb_classes)
+        elif len(labels.shape) == 1:  # index labels
+            if return_one_hot:
+                labels = to_categorical(labels, nb_classes)
+            else:
+                labels = np.expand_dims(labels, axis=1)
         else:
             raise ValueError(
                 "Shape of labels not recognised."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -171,26 +171,44 @@ class TestUtils(unittest.TestCase):
 
     def test_check_and_transform_label_format(self):
         labels_expected = np.array([[0, 0, 0, 1, 0], [0, 1, 0, 0, 0], [0, 0, 0, 0, 1]])
+        labels_expected_binary = np.array([[0, 1], [1, 0], [0, 1]])
 
         # test input shape (nb_samples,)
         labels = np.array([3, 1, 4])
-        labels_transformed = check_and_transform_label_format(labels, 5)
+        labels_transformed = check_and_transform_label_format(labels, nb_classes=5, return_one_hot=True)
         np.testing.assert_array_equal(labels_transformed, labels_expected)
 
         # test input shape (nb_samples, 1)
         labels = np.array([[3], [1], [4]])
-        labels_transformed = check_and_transform_label_format(labels, 5)
+        labels_transformed = check_and_transform_label_format(labels, nb_classes=5, return_one_hot=True)
         np.testing.assert_array_equal(labels_transformed, labels_expected)
+
+        # test input shape (nb_samples, 1) - binary
+        labels = np.array([[1], [0], [1]])
+        labels_transformed = check_and_transform_label_format(labels, nb_classes=2, return_one_hot=True)
+        np.testing.assert_array_equal(labels_transformed, labels_expected_binary)
+
+        # test input shape (nb_samples, 1) - binary
+        labels = np.array([[0, 1], [1, 0], [0, 1]])
+        labels_transformed = check_and_transform_label_format(labels, nb_classes=2, return_one_hot=True)
+        np.testing.assert_array_equal(labels_transformed, labels_expected_binary)
 
         # test input shape (nb_samples, nb_classes)
         labels = np.array([[0, 0, 0, 1, 0], [0, 1, 0, 0, 0], [0, 0, 0, 0, 1]])
-        labels_transformed = check_and_transform_label_format(labels, 5)
+        labels_transformed = check_and_transform_label_format(labels, nb_classes=5, return_one_hot=True)
         np.testing.assert_array_equal(labels_transformed, labels_expected)
 
         # test input shape (nb_samples, nb_classes) with return_one_hot=False
         labels = np.array([[0, 0, 0, 1, 0], [0, 1, 0, 0, 0], [0, 0, 0, 0, 1]])
-        labels_transformed = check_and_transform_label_format(labels, 5, return_one_hot=False)
-        np.testing.assert_array_equal(labels_transformed, np.argmax(labels_expected, axis=1))
+        labels_transformed = check_and_transform_label_format(labels, nb_classes=5, return_one_hot=False)
+        np.testing.assert_array_equal(labels_transformed, np.expand_dims(np.argmax(labels_expected, axis=1), axis=1))
+
+        # test input shape (nb_samples, 1) - binary
+        labels = np.array([[1], [0], [1]])
+        labels_transformed = check_and_transform_label_format(labels, nb_classes=2, return_one_hot=False)
+        np.testing.assert_array_equal(
+            labels_transformed, np.expand_dims(np.argmax(labels_expected_binary, axis=1), axis=1)
+        )
 
         # ValueError for len(labels.shape) > 2
         labels = np.array([[[0, 0, 0, 1, 0], [0, 1, 0, 0, 0], [0, 0, 0, 0, 1]]])


### PR DESCRIPTION
# Description

Fix missing transformation of binary index to one-hot encoded labels in `art.utils.check_and_transform_label_format`.

Fixes #1334

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
