### PR TITLE
Fix import of matplotlib in laser attack utils

### DIFF
--- a/art/attacks/evasion/laser_attack/utils.py
+++ b/art/attacks/evasion/laser_attack/utils.py
@@ -27,7 +27,6 @@ import string
 from typing import Any, Callable, List, Tuple, Union
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 
 class Line:
@@ -256,6 +255,8 @@ def save_nrgb_image(image: np.ndarray, number=0, name_length=5, directory="attac
     :param name_length: Length of the random string in the name.
     :param directory: Directory where images will be saved.
     """
+    import matplotlib.pyplot as plt
+
     alphabet = np.array(list(string.ascii_letters))
     Path(directory).mkdir(exist_ok=True)
     im_name = f"{directory}/{number}_{''.join(np.random.choice(alphabet, size=name_length))}.jpg"


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request fixes the import of `matplotlib` in laser attack utils.

Fixes #1456

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
