### PR TITLE
Preprocessing defences in PyTorchGoturn and VideoCompression for [0, 1] range

### DIFF
--- a/art/attacks/evasion/laser_attack/utils.py
+++ b/art/attacks/evasion/laser_attack/utils.py
@@ -27,7 +27,6 @@ import string
 from typing import Any, Callable, List, Tuple, Union
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 
 class Line:
@@ -256,6 +255,8 @@ def save_nrgb_image(image: np.ndarray, number=0, name_length=5, directory="attac
     :param name_length: Length of the random string in the name.
     :param directory: Directory where images will be saved.
     """
+    import matplotlib.pyplot as plt
+
     alphabet = np.array(list(string.ascii_letters))
     Path(directory).mkdir(exist_ok=True)
     im_name = f"{directory}/{number}_{''.join(np.random.choice(alphabet, size=name_length))}.jpg"

--- a/art/defences/preprocessor/video_compression_pytorch.py
+++ b/art/defences/preprocessor/video_compression_pytorch.py
@@ -116,11 +116,17 @@ class VideoCompressionPyTorch(PreprocessorPyTorch):
         """
         Apply video compression to sample `x`.
 
-        :param x: Sample to compress of shape NCFHW or NFHWC. `x` values are expected to be in the data range [0, 255].
+        :param x: Sample to compress of shape NCFHW or NFHWC. `x` values are expected to be either in range [0, 1] or
+                  [0, 255].
         :param y: Labels of the sample `x`. This function does not affect them in any way.
         :return: Compressed sample.
         """
+        scale = 1
+        if x.min() >= 0 and x.max() <= 1.0:
+            scale = 255
+        x = x * scale
         x_compressed = self._compression_pytorch_numpy.apply(x)
+        x_compressed = x_compressed / scale
         return x_compressed, y
 
     def _check_params(self) -> None:

--- a/art/estimators/object_tracking/pytorch_goturn.py
+++ b/art/estimators/object_tracking/pytorch_goturn.py
@@ -665,11 +665,12 @@ class PyTorchGoturn(ObjectTrackerMixin, PyTorchEstimator):
 
         for i in range(x.shape[0]):
             if isinstance(x, np.ndarray):
-                x_i = torch.from_numpy(x[[i]]).to(self.device)
+                x_i = torch.from_numpy(x[i]).to(self.device)
             else:
-                x_i = x[[i]].to(self.device)
+                x_i = x[i].to(self.device)
 
             # Apply preprocessing
+            x_i = torch.unsqueeze(x_i, dim=0)
             x_i, _ = self._apply_preprocessing(x_i, y=None, fit=False, no_grad=False)
             x_i = torch.squeeze(x_i)
 

--- a/art/estimators/object_tracking/pytorch_goturn.py
+++ b/art/estimators/object_tracking/pytorch_goturn.py
@@ -665,15 +665,15 @@ class PyTorchGoturn(ObjectTrackerMixin, PyTorchEstimator):
 
         for i in range(x.shape[0]):
             if isinstance(x, np.ndarray):
-                x_i = torch.from_numpy(x[i]).to(self.device)
+                x_i = torch.from_numpy(x[[i]]).to(self.device)
             else:
-                x_i = x[i].to(self.device)
+                x_i = x[[i]].to(self.device)
 
             # Apply preprocessing
             x_i, _ = self._apply_preprocessing(x_i, y=None, fit=False, no_grad=False)
+            x_i = torch.squeeze(x_i)
 
             y_pred = self._track(x=x_i, y_init=y_init[i])
-
             prediction_dict = dict()
             if isinstance(x, np.ndarray):
                 prediction_dict["boxes"] = y_pred.detach().cpu().numpy()


### PR DESCRIPTION
# Description

This pull request fixes support for preprocessing defences in `PyTorchGoturn` and adds support for inputs in range [0, 1] in `VideoCompression` and `VideoCompressionPyTorch`.

Fixes #1469

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
