### PR TITLE
Replace x with x_preprocessed in PyTorchClassifier.get_activations

### DIFF
--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -849,9 +849,9 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
             raise TypeError("Layer must be of type str or int")
 
         if framework:
-            if isinstance(x, torch.Tensor):
-                return self._model(x)[layer_index]
-            return self._model(torch.from_numpy(x).to(self._device))[layer_index]
+            if isinstance(x_preprocessed, torch.Tensor):
+                return self._model(x_preprocessed)[layer_index]
+            return self._model(torch.from_numpy(x_preprocessed).to(self._device))[layer_index]
 
         # Run prediction with batch processing
         results = []

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -834,7 +834,11 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         self._model.eval()
 
         # Apply defences
-        x_preprocessed, _ = self._apply_preprocessing(x=x, y=None, fit=False)
+        if framework:
+            no_grad = False
+        else:
+            no_grad = True
+        x_preprocessed, _ = self._apply_preprocessing(x=x, y=None, fit=False, no_grad=no_grad)
 
         # Get index of the extracted layer
         if isinstance(layer, six.string_types):


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request replaces `x` with `x_preprocessed` in `PyTorchClassifier.get_activations` for `framework=True`.

Fixes #1468

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
