### PR TITLE
Fix scalar names for indicators 2 and 3 for aggregated losses

### DIFF
--- a/art/summary_writer.py
+++ b/art/summary_writer.py
@@ -276,7 +276,7 @@ class SummaryWriterDefault(SummaryWriter):
 
                 if np.ndim(self.i_2) == 0:
                     self.summary_writer.add_scalar(
-                        "loss/batch-{}".format(batch_id),
+                        "Attack Failure Indicator 2 - Break-point Angle/batch-{}".format(batch_id),
                         self.i_2,
                         global_step=global_step,
                     )
@@ -308,7 +308,7 @@ class SummaryWriterDefault(SummaryWriter):
 
             if np.ndim(self.i_3[str(batch_id)]) == 0:
                 self.summary_writer.add_scalar(
-                    "loss/batch-{}".format(batch_id),
+                    "Attack Failure Indicator 3 - Diverging Loss/batch-{}".format(batch_id),
                     self.i_3[str(batch_id)],
                     global_step=global_step,
                 )


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request fixes scalar names for indicators 2 and 3 for aggregated losses.

Fixes #1510

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
