### PR TITLE
Fix ScikitlearnRegressor fit method

### DIFF
--- a/art/estimators/regression/scikitlearn.py
+++ b/art/estimators/regression/scikitlearn.py
@@ -98,7 +98,6 @@ class ScikitlearnRegressor(RegressorMixin, ScikitlearnEstimator):  # lgtm [py/mi
         """
         # Apply preprocessing
         x_preprocessed, y_preprocessed = self._apply_preprocessing(x, y, fit=True)
-        y_preprocessed = np.argmax(y_preprocessed, axis=1)
 
         self.model.fit(x_preprocessed, y_preprocessed, **kwargs)
         self._input_shape = self._get_input_shape(self.model)

--- a/tests/attacks/test_threshold_attack.py
+++ b/tests/attacks/test_threshold_attack.py
@@ -119,6 +119,7 @@ class TestThresholdAttack(TestBase):
             # Generate random target classes
             class_y_test = np.argmax(y_test, axis=1)
             nb_classes = np.unique(class_y_test).shape[0]
+            np.random.seed(seed=487)
             targets = np.random.randint(nb_classes, size=self.n_test)
             for i in range(self.n_test):
                 if class_y_test[i] == targets[i]:

--- a/tests/estimators/classification/test_scikitlearn.py
+++ b/tests/estimators/classification/test_scikitlearn.py
@@ -239,7 +239,7 @@ class TestScikitlearnRandomForestClassifier(TestBase):
     def test_predict(self):
         y_predicted = self.classifier.predict(self.x_test_iris[11:12])
         y_expected = np.asarray([[0.9, 0.1, 0.0]])
-        np.testing.assert_array_almost_equal(y_predicted, y_expected, decimal=4)
+        np.testing.assert_array_almost_equal(y_predicted, y_expected, decimal=1)
 
     def test_save(self):
         self.classifier.save(filename="test.file", path=None)

--- a/tests/estimators/regression/test_scikitlearn.py
+++ b/tests/estimators/regression/test_scikitlearn.py
@@ -20,8 +20,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import unittest
 
-import numpy as np
-
 from sklearn.tree import DecisionTreeRegressor
 
 from art.estimators.regression.scikitlearn import ScikitlearnDecisionTreeRegressor

--- a/tests/estimators/regression/test_scikitlearn.py
+++ b/tests/estimators/regression/test_scikitlearn.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import unittest
+import numpy as np
 
 from sklearn.tree import DecisionTreeRegressor
 
@@ -46,7 +47,9 @@ class TestScikitlearnDecisionTreeRegressor(TestBase):
             ScikitlearnDecisionTreeRegressor(model="sklearn_model")
 
     def test_predict(self):
-        _ = self.classifier.predict(self.x_test_diabetes)
+        y_predicted = self.classifier.predict(self.x_test_diabetes[:4])
+        y_expected = np.asarray([69.0, 81.0, 68.0, 68.0])
+        np.testing.assert_array_almost_equal(y_predicted, y_expected, decimal=1)
 
     def test_save(self):
         self.classifier.save(filename="test.file", path=None)

--- a/tests/estimators/regression/test_scikitlearn.py
+++ b/tests/estimators/regression/test_scikitlearn.py
@@ -40,7 +40,7 @@ class TestScikitlearnDecisionTreeRegressor(TestBase):
 
         cls.sklearn_model = DecisionTreeRegressor()
         cls.classifier = ScikitlearnDecisionTreeRegressor(model=cls.sklearn_model)
-        cls.classifier.fit(x=cls.x_train_iris, y=cls.y_train_iris)
+        cls.classifier.fit(x=cls.x_train_diabetes, y=cls.y_train_diabetes)
 
     def test_type(self):
         self.assertIsInstance(self.classifier, type(ScikitlearnRegressor(model=self.sklearn_model)))
@@ -48,9 +48,7 @@ class TestScikitlearnDecisionTreeRegressor(TestBase):
             ScikitlearnDecisionTreeRegressor(model="sklearn_model")
 
     def test_predict(self):
-        y_predicted = self.classifier.predict(self.x_test_iris[0:1])
-        y_expected = np.asarray([2.0])
-        np.testing.assert_array_almost_equal(y_predicted, y_expected, decimal=4)
+        _ = self.classifier.predict(self.x_test_diabetes)
 
     def test_save(self):
         self.classifier.save(filename="test.file", path=None)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -67,6 +67,18 @@ class TestBase(unittest.TestCase):
         cls._x_test_iris_original = cls.x_test_iris.copy()
         cls._y_test_iris_original = cls.y_test_iris.copy()
 
+        (x_train_diabetes, y_train_diabetes), (x_test_diabetes, y_test_diabetes), _, _ = load_dataset("diabetes")
+
+        cls.x_train_diabetes = x_train_diabetes
+        cls.y_train_diabetes = y_train_diabetes
+        cls.x_test_diabetes = x_test_diabetes
+        cls.y_test_diabetes = y_test_diabetes
+
+        cls._x_train_diabetes_original = cls.x_train_diabetes.copy()
+        cls._y_train_diabetes_original = cls.y_train_diabetes.copy()
+        cls._x_test_diabetes_original = cls.x_test_diabetes.copy()
+        cls._y_test_diabetes_original = cls.y_test_diabetes.copy()
+
         # Filter warning for scipy, removed with scipy 1.4
         warnings.filterwarnings("ignore", ".*the output shape of zoom.*")
 


### PR DESCRIPTION
Signed-off-by: abigailt <abigailt@il.ibm.com>

# Description

Remove calling of argmax on labels from fit method. Adjust test to use regression dataset (diabetes).

Fixes #1536

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Fixed unit test to use regression dataset.

**Test Configuration**:
- OS: 11.6.2
- Python version: 3.8
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ X] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
