### PR TITLE
Fixes torchaudio.functional.magphase use for Deep Speech 2 version 3

### DIFF
--- a/.github/workflows/ci-deepspeech-v3.yml
+++ b/.github/workflows/ci-deepspeech-v3.yml
@@ -32,3 +32,16 @@ jobs:
         uses: codecov/codecov-action@v2.1.0
         with:
           fail_ci_if_error: true
+  test_deepspeech_v3_torch_1_10:
+    name: PyTorchDeepSpeech v3 / PyTorch 1.10
+    runs-on: ubuntu-latest
+    container: adversarialrobustnesstoolbox/art_testing_envs:deepspeech_v3_torch_1_10
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2.4.0
+      - name: Run Test Action
+        uses: ./.github/actions/deepspeech-v3
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2.1.0
+        with:
+          fail_ci_if_error: true

--- a/art/estimators/speech_recognition/pytorch_deep_speech.py
+++ b/art/estimators/speech_recognition/pytorch_deep_speech.py
@@ -23,7 +23,7 @@ Mandarin in PyTorch.
 """
 import logging
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
-from pkg_resources import packaging
+from pkg_resources import packaging  # type: ignore[attr-defined]
 
 import numpy as np
 

--- a/art/estimators/speech_recognition/pytorch_deep_speech.py
+++ b/art/estimators/speech_recognition/pytorch_deep_speech.py
@@ -23,6 +23,7 @@ Mandarin in PyTorch.
 """
 import logging
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from pkg_resources import packaging
 
 import numpy as np
 
@@ -788,10 +789,10 @@ class PyTorchDeepSpeech(PytorchSpeechRecognizerMixin, SpeechRecognizerMixin, PyT
             else:
                 transformed_input = transformer(x[i])
 
-            if self._version == 2:
-                spectrogram, _ = torchaudio.functional.magphase(transformed_input)
-            else:
+            if self._version == 3 and packaging.version.parse(torch.__version__) >= packaging.version.parse("1.10.0"):
                 spectrogram = torch.abs(transformed_input)
+            else:
+                spectrogram, _ = torchaudio.functional.magphase(transformed_input)
             spectrogram = torch.log1p(spectrogram)
 
             # Normalize data

--- a/art/estimators/speech_recognition/pytorch_deep_speech.py
+++ b/art/estimators/speech_recognition/pytorch_deep_speech.py
@@ -788,7 +788,10 @@ class PyTorchDeepSpeech(PytorchSpeechRecognizerMixin, SpeechRecognizerMixin, PyT
             else:
                 transformed_input = transformer(x[i])
 
-            spectrogram, _ = torchaudio.functional.magphase(transformed_input)
+            if self._version == 2:
+                spectrogram, _ = torchaudio.functional.magphase(transformed_input)
+            else:
+                spectrogram = torch.abs(transformed_input)
             spectrogram = torch.log1p(spectrogram)
 
             # Normalize data


### PR DESCRIPTION
# Description

Added conditional logic for version 3 to use updated torch.abs instead of torchaudio.functional.magphase.

Fixes #1549

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
