### PR TITLE
Add channel dimension to input in classifier_blackbox_tesseract

### DIFF
--- a/notebooks/classifier_blackbox_tesseract.ipynb
+++ b/notebooks/classifier_blackbox_tesseract.ipynb
@@ -19,18 +19,14 @@
     "\n",
     "import numpy as np\n",
     "import imageio\n",
-    "import visvis as vv\n",
     "from matplotlib import pyplot as plt\n",
     "from IPython.display import clear_output\n",
     "import os \n",
     "\n",
-    "from art import config\n",
     "from art.estimators.classification import BlackBoxClassifier\n",
     "from art.defences.preprocessor import JpegCompression\n",
     "from art.attacks.evasion import HopSkipJump\n",
-    "from art.attacks.evasion import ZooAttack\n",
-    "from art.utils import to_categorical\n",
-    "from art.utils import load_dataset, get_file, compute_accuracy"
+    "from art.utils import to_categorical"
    ]
   },
   {

--- a/notebooks/classifier_blackbox_tesseract.ipynb
+++ b/notebooks/classifier_blackbox_tesseract.ipynb
@@ -48,7 +48,11 @@
    "source": [
     "# read in images\n",
     "image_target = imageio.imread(os.path.join(os.path.dirname(os.getcwd()), 'utils/data/tesseract', 'dissent.png'))\n",
-    "image_init = imageio.imread(os.path.join(os.path.dirname(os.getcwd()), 'utils/data/tesseract', 'assent.png'))"
+    "image_init = imageio.imread(os.path.join(os.path.dirname(os.getcwd()), 'utils/data/tesseract', 'assent.png'))\n",
+    "\n",
+    "# add a channel dimension for jpeg compression\n",
+    "image_target = np.expand_dims(image_target, axis=-1)\n",
+    "image_init = np.expand_dims(image_init, axis=-1)"
    ]
   },
   {
@@ -65,7 +69,7 @@
     "    \n",
     "    for x_i in x:\n",
     "        # save image as intermediate png\n",
-    "        imageio.imsave('tmp.png', x_i.astype(np.uint8))\n",
+    "        imageio.imsave('tmp.png', x_i[:,:,0].astype(np.uint8))\n",
     "\n",
     "        # run tesseract\n",
     "        status = os.system(\"tesseract tmp.png out\")\n",
@@ -129,7 +133,7 @@
    ],
    "source": [
     "# this is the image we want to target\n",
-    "plt.imshow(image_target)\n",
+    "plt.imshow(image_target[:,:,0])\n",
     "plt.show()\n",
     "print('Tesseract output is: ' + label_dict[np.argmax(classifier.predict(np.array([image_target], dtype=np.float32)))])"
    ]
@@ -161,7 +165,7 @@
    ],
    "source": [
     "# this is the label we want to perturb to\n",
-    "plt.imshow(image_init)\n",
+    "plt.imshow(image_init[:,:,0])\n",
     "plt.show()\n",
     "print('Tesseract output is: ' + label_dict[np.argmax(classifier.predict(np.array([image_init], dtype=np.float32)))])"
    ]
@@ -305,7 +309,7 @@
     "        print(\"Adversarial image at step %d.\" % (i * iter_step), \"L2 error\", \n",
     "              np.linalg.norm(np.reshape(x_adv[0] - image_target, [-1])),\n",
     "              \"and Tesseract output %s.\" % label_dict[np.argmax(classifier.predict(x_adv)[0])])\n",
-    "        plt.imshow(x_adv[0])\n",
+    "        plt.imshow(x_adv[0,:,:,0])\n",
     "        plt.show(block=False)\n",
     "\n",
     "    attack.max_iter = iter_step"
@@ -356,7 +360,7 @@
    ],
    "source": [
     "# this is the image we want to target\n",
-    "plt.imshow(image_target)\n",
+    "plt.imshow(image_target[:,:,0])\n",
     "plt.show()\n",
     "print('Tesseract output is: ' + label_dict[np.argmax(classifier_def.predict(np.array([image_target], dtype=np.float32)))])"
    ]
@@ -388,7 +392,7 @@
    ],
    "source": [
     "# this is the label we want to perturb to\n",
-    "plt.imshow(image_init)\n",
+    "plt.imshow(image_init[:,:,0])\n",
     "plt.show()\n",
     "print('Tesseract output is: ' + label_dict[np.argmax(classifier_def.predict(np.array([image_init], dtype=np.float32)))])"
    ]
@@ -532,7 +536,7 @@
     "        print(\"Adversarial image at step %d.\" % (i * iter_step), \"L2 error\", \n",
     "              np.linalg.norm(np.reshape(x_adv[0] - image_target, [-1])),\n",
     "              \"and Tesseract output %s.\" % label_dict[np.argmax(classifier_def.predict(x_adv)[0])])\n",
-    "        plt.imshow(x_adv[0])\n",
+    "        plt.imshow(x_adv[0,:,:,0])\n",
     "        plt.show(block=False)\n",
     "\n",
     "    attack.max_iter = iter_step"


### PR DESCRIPTION
# Description

Add channel dimension to the input images to match the expected input shape of JpegCompression in classifier_blackbox_tesseract.ipynb.

Fixes #1514

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
