### PR TITLE
fix for rescale not set bug

### DIFF
--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -97,6 +97,7 @@ class PixelThreshold(EvasionAttack):
         self._targeted = targeted
         self.verbose = verbose
         self.verbose_es = verbose_es
+        self.rescale = False
         PixelThreshold._check_params(self)
 
         if self.estimator.channels_first:


### PR DESCRIPTION
# Description

The pixel attack (pixel_threshold.py) in ART 1.9.1 throws the error "AttributeError: 'PixelAttack' object has no
attribute 'rescale'" if you do not need to rescale.
Solution is to set self.rescale = False in the init.

Fixes [#1571](https://github.com/Trusted-AI/adversarial-robustness-toolbox/issues/1571)

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Just created a classifier with clip_values=(0,255), initialized PixelAttack, call generate().

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- Ubuntu 20.04.3 LTS (GNU/Linux 5.4.0-91-generic x86_64)
- Python3.8
- ART 1.9.1
- PyTorch 1.10.2  

# Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
