### PR TITLE
Check scipy version for PixelThreshold attack

### DIFF
--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -22,7 +22,7 @@ The Pixel Attack is a generalisation of One Pixel Attack.
 | One Pixel Attack Paper link: https://arxiv.org/ans/1710.08864
 | Pixel and Threshold Attack Paper link: https://arxiv.org/abs/1906.06026
 """
-# pylint: disable=C0302,C0413
+# pylint: disable=C0302,C0413,E402
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -22,7 +22,7 @@ The Pixel Attack is a generalisation of One Pixel Attack.
 | One Pixel Attack Paper link: https://arxiv.org/ans/1710.08864
 | Pixel and Threshold Attack Paper link: https://arxiv.org/abs/1906.06026
 """
-# pylint: disable=C0302
+# pylint: disable=C0302,C0413
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
@@ -44,9 +44,9 @@ from scipy._lib._util import check_random_state
 
 scipy_version = list(map(int, scipy.__version__.lower().split(".")))
 if scipy_version[1] >= 8:
-    from scipy.optimize._optimize import _status_message
+    from scipy.optimize._optimize import _status_message  # pylint: disable=E0611
 else:
-    from scipy.optimize.optimize import _status_message
+    from scipy.optimize.optimize import _status_message  # pylint: disable=E0611
 from scipy.optimize import OptimizeResult, minimize
 from tqdm.auto import tqdm
 

--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -22,7 +22,7 @@ The Pixel Attack is a generalisation of One Pixel Attack.
 | One Pixel Attack Paper link: https://arxiv.org/ans/1710.08864
 | Pixel and Threshold Attack Paper link: https://arxiv.org/abs/1906.06026
 """
-# pylint: disable=C0302,C0413,E402
+# pylint: disable=C0302,C0413
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
@@ -47,14 +47,14 @@ if scipy_version[1] >= 8:
     from scipy.optimize._optimize import _status_message  # pylint: disable=E0611
 else:
     from scipy.optimize.optimize import _status_message  # pylint: disable=E0611
-from scipy.optimize import OptimizeResult, minimize
-from tqdm.auto import tqdm
+from scipy.optimize import OptimizeResult, minimize  # noqa
+from tqdm.auto import tqdm  # noqa
 
-from art.config import ART_NUMPY_DTYPE
-from art.attacks.attack import EvasionAttack
-from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin
-from art.estimators.classification.classifier import ClassifierMixin
-from art.utils import check_and_transform_label_format
+from art.config import ART_NUMPY_DTYPE  # noqa
+from art.attacks.attack import EvasionAttack  # noqa
+from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin  # noqa
+from art.estimators.classification.classifier import ClassifierMixin  # noqa
+from art.utils import check_and_transform_label_format  # noqa
 
 if TYPE_CHECKING:
     from art.utils import CLASSIFIER_NEURALNETWORK_TYPE

--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -39,8 +39,14 @@ import numpy as np
 # Otherwise may use Tensorflow's implementation of DE.
 
 from six import string_types
+import scipy
 from scipy._lib._util import check_random_state
-from scipy.optimize.optimize import _status_message
+
+scipy_version = list(map(int, scipy.__version__.lower().split(".")))
+if scipy_version[1] >= 8:
+    from scipy.optimize._optimize import _status_message
+else:
+    from scipy.optimize.optimize import _status_message
 from scipy.optimize import OptimizeResult, minimize
 from tqdm.auto import tqdm
 

--- a/tests/defences/trainer/test_adversarial_trainer_FBF.py
+++ b/tests/defences/trainer/test_adversarial_trainer_FBF.py
@@ -34,7 +34,7 @@ def get_adv_trainer(framework, image_dl_estimator):
             trainer = None
         if framework == "pytorch":
             classifier, _ = image_dl_estimator()
-            trainer = AdversarialTrainerFBFPyTorch(classifier, eps=0.1)
+            trainer = AdversarialTrainerFBFPyTorch(classifier, eps=0.05)
         if framework == "scikitlearn":
             trainer = None
 
@@ -75,7 +75,7 @@ def test_adversarial_trainer_fbf_pytorch_fit_and_predict(get_adv_trainer, fix_ge
     )
 
     assert accuracy == 0.32
-    assert accuracy_new == 0.58
+    assert accuracy_new == 0.63
 
     trainer.fit(x_train_mnist, y_train_mnist, nb_epochs=20, validation_data=(x_train_mnist, y_train_mnist))
 


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds a check for the version of `scipy` in `PixelThreshold` attacks to add support for scipt>=1.8.

Fixes #1568

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
