### PR TITLE
Gradient matching unknown input shape support

### DIFF
--- a/art/attacks/poisoning/gradient_matching_attack.py
+++ b/art/attacks/poisoning/gradient_matching_attack.py
@@ -190,7 +190,7 @@ class GradientMatchingAttack(Attack):
         y_true_poison = Input(shape=np.shape(y_poison)[1:])
         embedding_layer = Embedding(
             len(x_poison),
-            np.prod(input_poison.shape[1:]),
+            np.prod(x_poison.shape[1:]),
             embeddings_initializer=tf.keras.initializers.RandomNormal(stddev=self.epsilon * 0.01),
         )
         embeddings = embedding_layer(input_indices)

--- a/art/attacks/poisoning/gradient_matching_attack.py
+++ b/art/attacks/poisoning/gradient_matching_attack.py
@@ -151,8 +151,8 @@ class GradientMatchingAttack(Attack):
 
         :param x_trigger: A list of samples to use as triggers.
         :param y_trigger: A list of target classes to classify the triggers into.
-        :param x_train: A list of training data to poison a portion of.
-        :param y_train: A list of labels for x_train.
+        :param x_poison: A list of training data to poison a portion of.
+        :param y_poison: A list of true labels for x_poison.
         """
         # pylint: disable=no-name-in-module
         from tensorflow.keras import backend as K


### PR DESCRIPTION
# Description

This fix adds a support for gradient matching poisoning attack to consider a case when a model input is not completely known. It now pulls the shape from the data instead of the model.

Fixes # (issue)

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Test A
- [x] Test B

**Test Configuration**:
- OS: Ubuntu 18.04.6 LTS
- Python version: 3.8.12
- ART version or commit number: https://github.com/Trusted-AI/adversarial-robustness-toolbox/commit/917a19755a2612cbbcbba85e9d5a218637f1f2d0
- TensorFlow / Keras / PyTorch / MXNet version: Tensorflow==2.4.1, Keras==2.7.0, PyTorch==1.10.2

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
