### PR TITLE
fix: ImperceptibleASRPyTorch may produce NAN loss

### DIFF
--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
@@ -752,14 +752,14 @@ class ImperceptibleASRPyTorch(EvasionAttack):
             win_length=self.win_length,
             center=False,
             window=window_fn(self.win_length).to(self.estimator.device),
+            return_complex=True
         ).to(self.estimator.device)
 
         # Take abs of complex STFT results
-        transformed_delta = torch.sqrt(torch.sum(torch.square(delta_stft), -1))
+        transformed_delta = torch.real(delta_stft)**2 + torch.imag(delta_stft)**2
 
         # Compute the psd matrix
-        psd = (8.0 / 3.0) * transformed_delta / self.win_length
-        psd = psd ** 2
+        psd = ((8.0 / 3.0 / self.win_length) ** 2) * transformed_delta
         psd = (
             torch.pow(torch.tensor(10.0).type(torch.float64), torch.tensor(9.6).type(torch.float64)).to(
                 self.estimator.device

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
@@ -755,7 +755,7 @@ class ImperceptibleASRPyTorch(EvasionAttack):
             return_complex=True
         ).to(self.estimator.device)
 
-        # Take abs of complex STFT results
+        # Take the square of complex STFT results
         transformed_delta = torch.real(delta_stft)**2 + torch.imag(delta_stft)**2
 
         # Compute the psd matrix


### PR DESCRIPTION
# Description

fix: ImperceptibleASRPyTorch may produce NAN loss
change the way of computing transformed_delta and psd to avoid NAN loss and redundant computations.
modify a line of comment and add signed-off-by message
Fixes #1664 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
