### PR TITLE
Imperceptible asr bug detach

### DIFF
--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
@@ -409,7 +409,7 @@ class ImperceptibleASRPyTorch(EvasionAttack):
                 for local_batch_size_idx in range(local_batch_size):
                     if decoded_output[local_batch_size_idx] == y[local_batch_size_idx]:
                         # Adjust the rescale coefficient
-                        max_local_delta = np.max(np.abs(local_delta[local_batch_size_idx].detach().numpy()))
+                        max_local_delta = np.max(np.abs(local_delta[local_batch_size_idx].detach().cpu().numpy()))
 
                         if rescale[local_batch_size_idx][0] * self.eps > max_local_delta:
                             rescale[local_batch_size_idx] = max_local_delta / self.eps
@@ -564,7 +564,7 @@ class ImperceptibleASRPyTorch(EvasionAttack):
                 if decoded_output[local_batch_size_idx] == y[local_batch_size_idx]:
                     if loss_2nd_stage[local_batch_size_idx] < best_loss_2nd_stage[local_batch_size_idx]:
                         # Update best loss at 2nd stage
-                        best_loss_2nd_stage[local_batch_size_idx] = loss_2nd_stage[local_batch_size_idx].numpy()
+                        best_loss_2nd_stage[local_batch_size_idx] = loss_2nd_stage[local_batch_size_idx].detach().cpu().numpy()
 
                         # Save the best adversarial example
                         successful_adv_input[local_batch_size_idx] = masked_adv_input[local_batch_size_idx]

--- a/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
+++ b/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py
@@ -564,7 +564,9 @@ class ImperceptibleASRPyTorch(EvasionAttack):
                 if decoded_output[local_batch_size_idx] == y[local_batch_size_idx]:
                     if loss_2nd_stage[local_batch_size_idx] < best_loss_2nd_stage[local_batch_size_idx]:
                         # Update best loss at 2nd stage
-                        best_loss_2nd_stage[local_batch_size_idx] = loss_2nd_stage[local_batch_size_idx].detach().cpu().numpy()
+                        best_loss_2nd_stage[local_batch_size_idx] = (
+                            loss_2nd_stage[local_batch_size_idx].detach().cpu().numpy()
+                        )
 
                         # Save the best adversarial example
                         successful_adv_input[local_batch_size_idx] = masked_adv_input[local_batch_size_idx]


### PR DESCRIPTION
# Description

When running imperceptible ASR attack on `pytorch_deep_speech` on GPU, I sometimes run into this error:
```
File "/opt/conda/lib/python3.8/site-packages/art/attacks/evasion/imperceptible_asr/imperceptible_asr_pytorch.py", line 567, in _attack_2nd_stage[best_loss_2nd_stage[local_batch_size_idx] = loss_2nd_stage[local_batch_size_idx].numpy()
		RuntimeError^[[0m:^[[1m Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead
```
I believe it only occurs sometimes due to specific branching conditions being hit.
See also https://github.com/twosixlabs/armory/issues/1472

This update just ensures that when moving from Tensor to numpy array, `.detach().cpu().numpy()` is always called. This should always be safe (detach and cpu are no-ops if they are already true).

Fixes # (issue)

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
