### PR TITLE
Randomised smoothing fix

### DIFF
--- a/art/estimators/certification/randomized_smoothing/numpy.py
+++ b/art/estimators/certification/randomized_smoothing/numpy.py
@@ -128,8 +128,6 @@ class NumpyRandomizedSmoothing(  # lgtm [py/conflicting-attributes] lgtm [py/mis
             x_rs = x_rs.astype(ART_NUMPY_DTYPE)
             self.classifier.fit(x_rs, y, batch_size=batch_size, nb_epochs=1, **kwargs)
 
-        return self.classifier
-
     def loss_gradient(  # pylint: disable=W0221
         self, x: np.ndarray, y: np.ndarray, training_mode: bool = False, **kwargs
     ) -> np.ndarray:

--- a/art/estimators/certification/randomized_smoothing/numpy.py
+++ b/art/estimators/certification/randomized_smoothing/numpy.py
@@ -25,11 +25,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 from typing import List, Union, TYPE_CHECKING, Tuple
 
+import warnings
 import numpy as np
 
+from art.config import ART_NUMPY_DTYPE
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin, NeuralNetworkMixin
 from art.estimators.certification.randomized_smoothing.randomized_smoothing import RandomizedSmoothingMixin
 from art.estimators.classification import ClassifierMixin, ClassGradientsMixin
+from art.defences.preprocessor.gaussian_augmentation import GaussianAugmentation
 
 if TYPE_CHECKING:
     from art.utils import CLASSIFIER_NEURALNETWORK_TYPE
@@ -69,6 +72,12 @@ class NumpyRandomizedSmoothing(  # lgtm [py/conflicting-attributes] lgtm [py/mis
         :param scale: Standard deviation of Gaussian noise added.
         :param alpha: The failure probability of smoothing
         """
+
+        warnings.warn(
+            "\n With the current backend (Pytorch) Gaussian noise will be added by Randomised Smoothing "
+            "BEFORE the application of preprocessing defences. Please ensure this conforms to your use case.\n"
+        )
+
         super().__init__(
             model=classifier.model,
             channels_first=classifier.channels_first,
@@ -112,7 +121,14 @@ class NumpyRandomizedSmoothing(  # lgtm [py/conflicting-attributes] lgtm [py/mis
         :param kwargs: Dictionary of framework-specific arguments. This parameter is not currently supported for PyTorch
                        and providing it takes no effect.
         """
-        return self.classifier.fit(x, y, batch_size=batch_size, nb_epochs=nb_epochs, **kwargs)
+
+        g_a = GaussianAugmentation(sigma=self.scale, augmentation=False)
+        for _ in range(nb_epochs):
+            x_rs, _ = g_a(x)
+            x_rs = x_rs.astype(ART_NUMPY_DTYPE)
+            self.classifier.fit(x_rs, y, batch_size=batch_size, nb_epochs=1, **kwargs)
+
+        return self.classifier
 
     def loss_gradient(  # pylint: disable=W0221
         self, x: np.ndarray, y: np.ndarray, training_mode: bool = False, **kwargs

--- a/art/estimators/certification/randomized_smoothing/numpy.py
+++ b/art/estimators/certification/randomized_smoothing/numpy.py
@@ -72,11 +72,11 @@ class NumpyRandomizedSmoothing(  # lgtm [py/conflicting-attributes] lgtm [py/mis
         :param scale: Standard deviation of Gaussian noise added.
         :param alpha: The failure probability of smoothing
         """
-
-        warnings.warn(
-            "\n With the current backend (Pytorch) Gaussian noise will be added by Randomised Smoothing "
-            "BEFORE the application of preprocessing defences. Please ensure this conforms to your use case.\n"
-        )
+        if classifier.preprocessing_defences is not None:
+            warnings.warn(
+                "\n With the current backend Gaussian noise will be added by Randomized Smoothing "
+                "BEFORE the application of preprocessing defences. Please ensure this conforms to your use case.\n"
+            )
 
         super().__init__(
             model=classifier.model,

--- a/art/estimators/certification/randomized_smoothing/pytorch.py
+++ b/art/estimators/certification/randomized_smoothing/pytorch.py
@@ -28,14 +28,12 @@ from typing import List, Optional, Tuple, Union, TYPE_CHECKING
 import warnings
 import random
 from tqdm import tqdm
+import numpy as np
 
 from art.config import ART_NUMPY_DTYPE
 from art.estimators.classification.pytorch import PyTorchClassifier
 from art.estimators.certification.randomized_smoothing.randomized_smoothing import RandomizedSmoothingMixin
 from art.utils import check_and_transform_label_format
-
-import numpy as np
-
 
 if TYPE_CHECKING:
     # pylint: disable=C0412

--- a/art/estimators/certification/randomized_smoothing/pytorch.py
+++ b/art/estimators/certification/randomized_smoothing/pytorch.py
@@ -178,6 +178,8 @@ class PyTorchRandomizedSmoothing(RandomizedSmoothingMixin, PyTorchClassifier):
             for m in range(num_batch):
                 i_batch = torch.from_numpy(x_preprocessed[ind[m * batch_size : (m + 1) * batch_size]]).to(self._device)
                 o_batch = torch.from_numpy(y_preprocessed[ind[m * batch_size : (m + 1) * batch_size]]).to(self._device)
+
+                # Add random noise for randomized smoothing
                 i_batch = i_batch + torch.randn_like(i_batch, device=self._device) * std
 
                 # Zero the parameter gradients

--- a/art/estimators/certification/randomized_smoothing/pytorch.py
+++ b/art/estimators/certification/randomized_smoothing/pytorch.py
@@ -26,15 +26,16 @@ import logging
 from typing import List, Optional, Tuple, Union, TYPE_CHECKING
 
 import warnings
-import numpy as np
 import random
+from tqdm import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.estimators.classification.pytorch import PyTorchClassifier
 from art.estimators.certification.randomized_smoothing.randomized_smoothing import RandomizedSmoothingMixin
 from art.utils import check_and_transform_label_format
 
-from tqdm import tqdm
+import numpy as np
+
 
 if TYPE_CHECKING:
     # pylint: disable=C0412

--- a/art/estimators/certification/randomized_smoothing/pytorch.py
+++ b/art/estimators/certification/randomized_smoothing/pytorch.py
@@ -99,11 +99,11 @@ class PyTorchRandomizedSmoothing(RandomizedSmoothingMixin, PyTorchClassifier):
         :param scale: Standard deviation of Gaussian noise added.
         :param alpha: The failure probability of smoothing.
         """
-
-        warnings.warn(
-            "\n With the current backend (Pytorch) Gaussian noise will be added by Randomised Smoothing "
-            "AFTER the application of preprocessing defences. Please ensure this conforms to your use case.\n"
-        )
+        if preprocessing_defences is not None:
+            warnings.warn(
+                "\n With the current backend (Pytorch) Gaussian noise will be added by Randomized Smoothing "
+                "AFTER the application of preprocessing defences. Please ensure this conforms to your use case.\n"
+            )
 
         super().__init__(
             model=model,

--- a/art/estimators/certification/randomized_smoothing/pytorch.py
+++ b/art/estimators/certification/randomized_smoothing/pytorch.py
@@ -127,6 +127,10 @@ class PyTorchRandomizedSmoothing(RandomizedSmoothingMixin, PyTorchClassifier):
         x = x.astype(ART_NUMPY_DTYPE)
         return PyTorchClassifier.predict(self, x=x, batch_size=batch_size, training_mode=training_mode, **kwargs)
 
+    def _fit_classifier(self, x: np.ndarray, y: np.ndarray, batch_size: int, nb_epochs: int, **kwargs) -> None:
+        x = x.astype(ART_NUMPY_DTYPE)
+        return PyTorchClassifier.fit(self, x, y, batch_size=batch_size, nb_epochs=nb_epochs, **kwargs)
+
     def fit(  # pylint: disable=W0221
         self,
         x: np.ndarray,

--- a/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
+++ b/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
@@ -26,11 +26,12 @@ from abc import ABC
 import logging
 from typing import Optional, Tuple
 
-import numpy as np
 from scipy.stats import norm
 from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 

--- a/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
+++ b/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
@@ -28,10 +28,9 @@ from typing import Optional, Tuple
 
 from scipy.stats import norm
 from tqdm.auto import tqdm
+import numpy as np
 
 from art.config import ART_NUMPY_DTYPE
-
-import numpy as np
 
 logger = logging.getLogger(__name__)
 

--- a/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
+++ b/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
@@ -141,9 +141,7 @@ class RandomizedSmoothingMixin(ABC):
         :param kwargs: Dictionary of framework-specific arguments. This parameter is not currently supported for PyTorch
                and providing it takes no effect.
         """
-        g_a = GaussianAugmentation(sigma=self.scale, augmentation=False)
-        x_rs, _ = g_a(x)
-        self._fit_classifier(x_rs, y, batch_size=batch_size, nb_epochs=nb_epochs, **kwargs)
+        self._fit_classifier(x, y, batch_size=batch_size, nb_epochs=nb_epochs, **kwargs)
 
     def certify(self, x: np.ndarray, n: int, batch_size: int = 32) -> Tuple[np.ndarray, np.ndarray]:
         """

--- a/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
+++ b/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
@@ -31,7 +31,6 @@ from scipy.stats import norm
 from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
-from art.defences.preprocessor.gaussian_augmentation import GaussianAugmentation
 
 logger = logging.getLogger(__name__)
 

--- a/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
+++ b/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
@@ -28,7 +28,6 @@ from typing import Optional, Tuple
 
 from scipy.stats import norm
 from tqdm.auto import tqdm
-import numpy as np
 
 from art.config import ART_NUMPY_DTYPE
 

--- a/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
+++ b/art/estimators/certification/randomized_smoothing/randomized_smoothing.py
@@ -26,6 +26,7 @@ from abc import ABC
 import logging
 from typing import Optional, Tuple
 
+import numpy as np
 from scipy.stats import norm
 from tqdm.auto import tqdm
 

--- a/art/estimators/certification/randomized_smoothing/tensorflow.py
+++ b/art/estimators/certification/randomized_smoothing/tensorflow.py
@@ -25,8 +25,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 from typing import Callable, List, Optional, Tuple, Union, TYPE_CHECKING
 
-import warnings
 from tqdm import tqdm
+import warnings
 import numpy as np
 
 from art.estimators.classification.tensorflow import TensorFlowV2Classifier

--- a/art/estimators/certification/randomized_smoothing/tensorflow.py
+++ b/art/estimators/certification/randomized_smoothing/tensorflow.py
@@ -154,6 +154,7 @@ class TensorFlowV2RandomizedSmoothing(RandomizedSmoothingMixin, TensorFlowV2Clas
 
         for _ in tqdm(range(nb_epochs)):
             for images, labels in train_ds:
+                # Add random noise for randomized smoothing
                 images += tf.random.normal(shape=images.shape, mean=0.0, stddev=self.scale)
                 self._train_step(self.model, images, labels)
 

--- a/art/estimators/certification/randomized_smoothing/tensorflow.py
+++ b/art/estimators/certification/randomized_smoothing/tensorflow.py
@@ -25,8 +25,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 from typing import Callable, List, Optional, Tuple, Union, TYPE_CHECKING
 
-from tqdm import tqdm
 import warnings
+from tqdm import tqdm
 import numpy as np
 
 from art.estimators.classification.tensorflow import TensorFlowV2Classifier

--- a/art/estimators/certification/randomized_smoothing/tensorflow.py
+++ b/art/estimators/certification/randomized_smoothing/tensorflow.py
@@ -26,13 +26,14 @@ import logging
 from typing import Callable, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import warnings
-import numpy as np
+from tqdm import tqdm
 
 from art.estimators.classification.tensorflow import TensorFlowV2Classifier
 from art.estimators.certification.randomized_smoothing.randomized_smoothing import RandomizedSmoothingMixin
 from art.utils import check_and_transform_label_format
 
-from tqdm import tqdm
+import numpy as np
+
 
 if TYPE_CHECKING:
     # pylint: disable=C0412

--- a/art/estimators/certification/randomized_smoothing/tensorflow.py
+++ b/art/estimators/certification/randomized_smoothing/tensorflow.py
@@ -97,7 +97,7 @@ class TensorFlowV2RandomizedSmoothing(RandomizedSmoothingMixin, TensorFlowV2Clas
         """
         if preprocessing_defences is not None:
             warnings.warn(
-                "\n With the current backend (Tensorflow), Gaussian noise will be added by Randomised Smoothing "
+                "\nWith the current backend (Tensorflow), Gaussian noise will be added by Randomized Smoothing "
                 "AFTER the application of preprocessing defences. Please ensure this conforms to your use case.\n"
             )
 

--- a/art/estimators/certification/randomized_smoothing/tensorflow.py
+++ b/art/estimators/certification/randomized_smoothing/tensorflow.py
@@ -27,13 +27,11 @@ from typing import Callable, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import warnings
 from tqdm import tqdm
+import numpy as np
 
 from art.estimators.classification.tensorflow import TensorFlowV2Classifier
 from art.estimators.certification.randomized_smoothing.randomized_smoothing import RandomizedSmoothingMixin
 from art.utils import check_and_transform_label_format
-
-import numpy as np
-
 
 if TYPE_CHECKING:
     # pylint: disable=C0412


### PR DESCRIPTION
# Description

The old implementation of randomised smoothing only added noise once to the data. We now add a new noise draw each time the data is seen. For torch and tensorflow we implement a slightly modified version of the normal fitting procedure which uses noise. For numpy we call `fit` with epoch=1 for the required amount. 

We add warnings to the user to be careful with the use of pre-processors as we are adding the noise after their application for torch/tensorflow and before their application for numpy. In either case, the use of pre-processors could cause the expected certification radius to vary.

Fixes #1617

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing
 existing tests for randomized smoothing pass 


**Test Configuration**:
- OS: RHEL 8
- Python version: 3.9
- ART version or commit number: 1.10.0
- TensorFlow / Keras / PyTorch / MXNet version: TF2.8, torch 1.11

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
