### PR TITLE
Mp3Compression defense bug fix - handle case when input is 2D but not an object array

### DIFF
--- a/art/defences/preprocessor/mp3_compression.py
+++ b/art/defences/preprocessor/mp3_compression.py
@@ -115,6 +115,9 @@ class Mp3Compression(Preprocessor):
                 x_mp3 = x_mp3 * 2 ** -15
             return x_mp3.astype(x_dtype)
 
+        if x.dtype != object and x.ndim == 2:
+            x = x.astype(object)
+
         if x.dtype != object and x.ndim != 3:
             raise ValueError("Mp3 compression can only be applied to temporal data across at least one channel.")
 

--- a/art/defences/preprocessor/mp3_compression.py
+++ b/art/defences/preprocessor/mp3_compression.py
@@ -115,6 +115,7 @@ class Mp3Compression(Preprocessor):
                 x_mp3 = x_mp3 * 2 ** -15
             return x_mp3.astype(x_dtype)
 
+        x_orig_type = x.dtype
         if x.dtype != object and x.ndim == 2:
             x = x.astype(object)
 
@@ -148,6 +149,9 @@ class Mp3Compression(Preprocessor):
 
         if x.dtype != object and self.channels_first:
             x_mp3 = np.swapaxes(x_mp3, 1, 2)
+
+        if x_orig_type != object and x.dtype == object and x.ndim == 2:
+            x_mp3 = x_mp3.astype(x_orig_type)
 
         return x_mp3, y
 


### PR DESCRIPTION
Signed-off-by: David Slater <david.slater@twosixlabs.com>

# Description

The following code will succeed on the first call of preprocessor but fail on the second call:
```
import numpy as np                                                                       
from art.defences.preprocessor import Mp3Compression                                     
                                                                                         
sample_rate = 16000                                                                      
preprocessor = Mp3Compression(sample_rate)                                               
                                                                                         
x = np.random.randn(2, sample_rate)                                                      
x_prep = preprocessor(x.astype(object))                                                  
x_prep = preprocessor(x)  # Fails
```

The fix handles this case: it casts to object type in that case on input, then casts back to the original type on output (which prevents this causing a bug in Mp3CompressionPyTorch).

This bug was found when diagnosing a similar bug here: https://github.com/twosixlabs/armory/issues/1465
More updates related to that to follow.

Fixes # (issue)

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
