### PR TITLE
fix: fixed np.sum in art/defences/postprocessor/gaussian_noise.py

### DIFF
--- a/art/defences/postprocessor/gaussian_noise.py
+++ b/art/defences/postprocessor/gaussian_noise.py
@@ -69,7 +69,7 @@ class GaussianNoise(Postprocessor):
             # Finally normalize probability output
             if all_probability:
                 post_preds[post_preds < 0.0] = 0.0
-                sums = np.sum(post_preds, axis=1)
+                sums = np.sum(post_preds, axis=1, keepdims=True)
                 post_preds /= sums
         else:
             post_preds[post_preds < 0.0] = 0.0


### PR DESCRIPTION
Signed-off-By: GianlucaMega <megagianluca.mg@gmail.com>

# Description

The GaussianNoise postprocessing defence could not handle mini-batches due to a problem with the `sums` variable, in particular with the np.sum. The original instruction has been changed into `np.sum(post_preds, axis=1, keepdims=True)`

Fixes #1675 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] tests/defences/test_gaussian_noise.py

**Test Configuration**:
- OS Kali Linux 2022.1
- Python version 3.9.7
- ART version or commit number 1.10.2
- TensorFlow / Keras / PyTorch / MXNet version TF:2.8.0, Keras:2.8.0, PyTorch:1.11.0+cu102, mx:1.8.0

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
