### PR TITLE
Support numpy arrays in logger of clean_label_backdoor_attack

### DIFF
--- a/art/attacks/poisoning/clean_label_backdoor_attack.py
+++ b/art/attacks/poisoning/clean_label_backdoor_attack.py
@@ -133,7 +133,7 @@ class PoisoningAttackCleanLabelBackdoor(PoisoningAttackBlackBox):
         if any(no_change_detected):  # pragma: no cover
             logger.warning("Perturbed input is the same as original data after PGD. Check params.")
             idx_no_change = np.arange(len(no_change_detected))[no_change_detected]
-            logger.warning("%d indices without change: %d", len(idx_no_change), idx_no_change)
+            logger.warning(f"{len(idx_no_change)} indices without change: {idx_no_change}")
 
         # Add backdoor and poison with the same label
         poisoned_input, _ = self.backdoor.poison(perturbed_input, self.target, broadcast=broadcast)

--- a/art/attacks/poisoning/clean_label_backdoor_attack.py
+++ b/art/attacks/poisoning/clean_label_backdoor_attack.py
@@ -133,7 +133,7 @@ class PoisoningAttackCleanLabelBackdoor(PoisoningAttackBlackBox):
         if any(no_change_detected):  # pragma: no cover
             logger.warning("Perturbed input is the same as original data after PGD. Check params.")
             idx_no_change = np.arange(len(no_change_detected))[no_change_detected]
-            logger.warning(f"{len(idx_no_change)} indices without change: {idx_no_change}")
+            logger.warning("%d indices without change: %s", len(idx_no_change), idx_no_change)
 
         # Add backdoor and poison with the same label
         poisoned_input, _ = self.backdoor.poison(perturbed_input, self.target, broadcast=broadcast)


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds support for numpy arrays in the logger of clean_label_backdoor_attack. Thank you @lcadalzo for the solution!

Fixes #1697

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
