### PR TITLE
bug fix: zero the grads on the patch after each iteration

### DIFF
--- a/art/attacks/evasion/adversarial_texture/adversarial_texture_pytorch.py
+++ b/art/attacks/evasion/adversarial_texture/adversarial_texture_pytorch.py
@@ -170,6 +170,8 @@ class AdversarialTexturePyTorch(EvasionAttack):
                 y=None,
             )
 
+        self._patch.grad = torch.zeros(self._patch.grad.shape, device=self._patch.grad.device, dtype=self._patch.grad.dtype)
+
         with torch.no_grad():
             self._patch[:] = torch.clamp(
                 self._patch + gradients, min=self.estimator.clip_values[0], max=self.estimator.clip_values[1]


### PR DESCRIPTION
# Description

In the `AdversarialTexturePyTorch` attack, the gradients to the patch were not being zero'd after iteration; thus, they were be accumulated as the attack went on.

## Type of change

- [ ] Improvement (non-breaking)
- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

- Tested attacks on a few samples by hand.
- Used a modified version of the attack that accepts an initial patch as input; confirmed that, e.g. running the attack twice, sequentially, for N iterations each time, is equivalent to running it once for 2N iterations (which was *not* the case previously).

# Checklist

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
