### PR TITLE
Fix numpy version for style-checks

### DIFF
--- a/.github/workflows/ci-style-checks.yml
+++ b/.github/workflows/ci-style-checks.yml
@@ -45,6 +45,7 @@ jobs:
           pip install types-PyYAML
           pip install types-setuptools
           pip install click==8.0.2
+          pip install numpy==1.21.6
           pip list
       - name: pycodestyle
         run: pycodestyle --ignore=C0330,C0415,E203,E231,W503 --max-line-length=120 art


### PR DESCRIPTION
# Description

This pull request fixes the version of `numpy` for the style-check workflow.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
