### PR TITLE
PyTorchClassifier: delete optimizer before calling set_param()

### DIFF
--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -516,6 +516,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         clone.reset()
         params = self.get_params()
         del params["model"]
+        del params["optimizer"]
         clone.set_params(**params)
         return clone
 


### PR DESCRIPTION
# Description

`Optimizer` should be deleted from params before calling set_param(), otherwise the cloned model will still get the old optimizer from params, defeating the purpose of creating a new optimizer binding to the newly cloned model's parameters.

Fixes #1732

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:
 - OS: macOS
 - Python version: 3.8.10
 - ART version or commit number: 1.10.3
 - PyTorch version: 1.10.2

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes