### PR TITLE
Add targeted option to AdversarialPatch and AdversarialPatchNumpy

### DIFF
--- a/art/attacks/evasion/adversarial_patch/adversarial_patch.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch.py
@@ -56,6 +56,7 @@ class AdversarialPatch(EvasionAttack):
         "learning_rate",
         "max_iter",
         "batch_size",
+        "targeted",
         "verbose",
     ]
 
@@ -71,6 +72,7 @@ class AdversarialPatch(EvasionAttack):
         max_iter: int = 500,
         batch_size: int = 16,
         patch_shape: Optional[Tuple[int, int, int]] = None,
+        targeted: bool = True,
         verbose: bool = True,
     ):
         """
@@ -89,6 +91,7 @@ class AdversarialPatch(EvasionAttack):
         :param patch_shape: The shape of the adversarial patch as a tuple of shape (width, height, nb_channels).
                             Currently only supported for `TensorFlowV2Classifier`. For classifiers of other frameworks
                             the `patch_shape` is set to the shape of the input samples.
+        :param targeted: Indicates whether the attack is targeted (True) or untargeted (False).
         :param verbose: Show progress bars.
         """
         super().__init__(estimator=classifier)
@@ -106,6 +109,7 @@ class AdversarialPatch(EvasionAttack):
                 max_iter=max_iter,
                 batch_size=batch_size,
                 patch_shape=patch_shape,
+                targeted=targeted,
                 verbose=verbose,
             )
         elif isinstance(self.estimator, PyTorchClassifier):
@@ -121,6 +125,7 @@ class AdversarialPatch(EvasionAttack):
                     batch_size=batch_size,
                     patch_shape=patch_shape,
                     patch_type="circle",
+                    targeted=targeted,
                     verbose=verbose,
                 )
             else:
@@ -134,6 +139,7 @@ class AdversarialPatch(EvasionAttack):
                 learning_rate=learning_rate,
                 max_iter=max_iter,
                 batch_size=batch_size,
+                targeted=targeted,
                 verbose=verbose,
             )
         self._check_params()
@@ -240,6 +246,9 @@ class AdversarialPatch(EvasionAttack):
             raise ValueError("The batch size must be of type int.")
         if not self._attack.batch_size > 0:
             raise ValueError("The batch size must be greater than 0.")
+
+        if not isinstance(self._attack.targeted, bool):
+            raise ValueError("The argument `targeted` has to be of type bool.")
 
         if not isinstance(self._attack.verbose, bool):
             raise ValueError("The argument `verbose` has to be of type bool.")

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
@@ -74,6 +74,7 @@ class AdversarialPatchNumpy(EvasionAttack):
         max_iter: int = 500,
         clip_patch: Union[list, tuple, None] = None,
         batch_size: int = 16,
+        targeted: bool = True,
         verbose: bool = True,
     ) -> None:
         """
@@ -92,6 +93,8 @@ class AdversarialPatchNumpy(EvasionAttack):
         :param clip_patch: The minimum and maximum values for each channel in the form
                [(float, float), (float, float), (float, float)].
         :param batch_size: The size of the training batch.
+        :param targeted: Indicates whether the attack is targeted (True) or untargeted (False). Currently only targeted
+               attacks are supported.
         :param verbose: Show progress bars.
         """
         super().__init__(estimator=classifier)
@@ -104,6 +107,7 @@ class AdversarialPatchNumpy(EvasionAttack):
         self.max_iter = max_iter
         self.batch_size = batch_size
         self.clip_patch = clip_patch
+        self.targeted = targeted
         self.verbose = verbose
         self._check_params()
 
@@ -298,6 +302,12 @@ class AdversarialPatchNumpy(EvasionAttack):
             raise ValueError("The batch size must be of type int.")
         if self.batch_size <= 0:
             raise ValueError("The batch size must be greater than 0.")
+
+        if not isinstance(self.targeted, bool) and not self.targeted:
+            raise ValueError(
+                "The argument `targeted` has to be of type bool. Currently AdversarialPatchNumpy only supports targeted"
+                "attacks."
+            )
 
         if not isinstance(self.verbose, bool):
             raise ValueError("The argument `verbose` has to be of type bool.")


### PR DESCRIPTION
# Description

This pull request adds `targeted` option to `AdversarialPatch` and `AdversarialPatchNumpy`.

Fixes #1662

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
