### PR TITLE
Add adversarial_accuracy as a metric

### DIFF
--- a/art/metrics/metrics.py
+++ b/art/metrics/metrics.py
@@ -75,6 +75,7 @@ def get_crafter(classifier: "CLASSIFIER_TYPE", attack: str, params: Optional[Dic
     try:
         crafter = SUPPORTED_METHODS[attack]["class"](classifier)
     except Exception:  # pragma: no cover
+        logger.warning("Available attacks include %s." % ", ".join(SUPPORTED_METHODS.keys()))
         raise NotImplementedError(f"{attack} crafting method not supported.") from Exception
 
     if "params" in SUPPORTED_METHODS[attack]:
@@ -113,7 +114,7 @@ def adversarial_accuracy(
 
     if attack_crafter is None:
         if attack_name is None:
-            raise ValueError("At least one of `attack_name` or `attack_crafter` must be specified.")
+            raise ValueError("At least one of `attack_name` or `attack_crafter` must be specified. Available values for `attack_name' include %s." % ", ".join(SUPPORTED_METHODS.keys()))
 
         if x.max() > 1.0 or x.min() < 0:
             logger.warning("The input range is outside [0,1]. Please consider using `attack_crafter` instead.")

--- a/art/metrics/metrics.py
+++ b/art/metrics/metrics.py
@@ -33,6 +33,7 @@ from tqdm.auto import tqdm
 
 from art.config import ART_NUMPY_DTYPE
 from art.attacks.attack import EvasionAttack
+from art.attacks.evasion.auto_attack import AutoAttack
 from art.attacks.evasion.fast_gradient import FastGradientMethod
 from art.attacks.evasion.hop_skip_jump import HopSkipJump
 from art.utils import random_sphere
@@ -44,6 +45,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 SUPPORTED_METHODS: Dict[str, Dict[str, Any]] = {
+    "auto": {
+        "class": AutoAttack,
+        "params": {"eps_step": 0.1, "eps_max": 1.0},
+    },
     "fgsm": {
         "class": FastGradientMethod,
         "params": {"eps_step": 0.1, "eps_max": 1.0, "clip_min": 0.0, "clip_max": 1.0},
@@ -71,9 +76,11 @@ def get_crafter(classifier: "CLASSIFIER_TYPE", attack: str, params: Optional[Dic
     """
     try:
         crafter = SUPPORTED_METHODS[attack]["class"](classifier)
-    except Exception:  # pragma: no cover
+    except Exception as e:  # pragma: no cover
         raise NotImplementedError(f"{attack} crafting method not supported.") from Exception
 
+    if "params" in SUPPORTED_METHODS[attack]:
+        crafter.set_params(**SUPPORTED_METHODS[attack]["params"])
     if params:
         crafter.set_params(**params)
 

--- a/art/metrics/metrics.py
+++ b/art/metrics/metrics.py
@@ -121,7 +121,7 @@ def adversarial_accuracy(
     y = classifier.predict(x)
     y_pred = classifier.predict(adv_x)
 
-    idxs = np.argmax(y_pred, axis=1) != np.argmax(y, axis=1)
+    idxs = np.argmax(y_pred, axis=1) == np.argmax(y, axis=1)
     return np.sum(idxs) / len(y)
 
 

--- a/art/metrics/metrics.py
+++ b/art/metrics/metrics.py
@@ -39,7 +39,6 @@ from art.attacks.evasion.hop_skip_jump import HopSkipJump
 from art.utils import random_sphere
 
 if TYPE_CHECKING:
-    from art.attacks.attack import EvasionAttack
     from art.utils import CLASSIFIER_TYPE, CLASSIFIER_LOSS_GRADIENTS_TYPE, CLASSIFIER_CLASS_LOSS_GRADIENTS_TYPE
 
 logger = logging.getLogger(__name__)
@@ -96,8 +95,8 @@ def adversarial_accuracy(
 ) -> float:
     """
     Compute the adversarial accuracy of a classifier object over the sample `x` for a given adversarial crafting
-    method `attack`. `attack_name` can be specified to use a preset attack, or `attack_crafter` for wider choices and customized parameters.
-    Note that the score does not exclude wrong predictions by the classifier.
+    method `attack`. `attack_name` can be specified to use a preset attack, or `attack_crafter` for wider choices
+    and customized parameters. Note that the score does not exclude wrong predictions by the classifier.
 
     :param classifier: A trained model.
     :param x: Input samples of shape that can be fed into `classifier`.

--- a/art/metrics/metrics.py
+++ b/art/metrics/metrics.py
@@ -117,8 +117,8 @@ def adversarial_accuracy(
         if attack_name is None:
             supported_methods = ", ".join(SUPPORTED_METHODS.keys())
             raise ValueError(
-                "At least one of `attack_name` or `attack_crafter` must be specified." \
-                    + f"Available values for `attack_name' include {supported_methods}."
+                "At least one of `attack_name` or `attack_crafter` must be specified."
+                + f"Available values for `attack_name' include {supported_methods}."
             )
 
         if x.max() > 1.0 or x.min() < 0:

--- a/art/metrics/metrics.py
+++ b/art/metrics/metrics.py
@@ -76,7 +76,7 @@ def get_crafter(classifier: "CLASSIFIER_TYPE", attack: str, params: Optional[Dic
     try:
         crafter = SUPPORTED_METHODS[attack]["class"](classifier)
     except Exception:  # pragma: no cover
-        logger.warning("Available attacks include %s." % ", ".join(SUPPORTED_METHODS.keys()))
+        logger.warning("Available attacks include %s.", ", ".join(SUPPORTED_METHODS.keys()))
         raise NotImplementedError(f"{attack} crafting method not supported.") from Exception
 
     if "params" in SUPPORTED_METHODS[attack]:
@@ -115,9 +115,10 @@ def adversarial_accuracy(
 
     if attack_crafter is None:
         if attack_name is None:
+            supported_methods = ", ".join(SUPPORTED_METHODS.keys())
             raise ValueError(
-                "At least one of `attack_name` or `attack_crafter` must be specified. Available values for `attack_name' include %s."
-                % ", ".join(SUPPORTED_METHODS.keys())
+                "At least one of `attack_name` or `attack_crafter` must be specified." \
+                    + f"Available values for `attack_name' include {supported_methods}."
             )
 
         if x.max() > 1.0 or x.min() < 0:
@@ -135,11 +136,11 @@ def adversarial_accuracy(
     if y is None:
         idxs = y_pred == y_orig
         return np.sum(idxs) / len(y_orig)
-    else:
-        if len(y.shape) > 1:
-            y = np.argmax(y, axis=1)
-        y_corr = y_orig == y
-        return np.sum((y_pred != y_orig) & y_corr) / np.sum(y_corr)
+        
+    if len(y.shape) > 1:
+        y = np.argmax(y, axis=1)
+    y_corr = y_orig == y
+    return np.sum((y_pred != y_orig) & y_corr) / np.sum(y_corr)
 
 
 def empirical_robustness(

--- a/art/metrics/metrics.py
+++ b/art/metrics/metrics.py
@@ -76,7 +76,7 @@ def get_crafter(classifier: "CLASSIFIER_TYPE", attack: str, params: Optional[Dic
     """
     try:
         crafter = SUPPORTED_METHODS[attack]["class"](classifier)
-    except Exception as e:  # pragma: no cover
+    except Exception:  # pragma: no cover
         raise NotImplementedError(f"{attack} crafting method not supported.") from Exception
 
     if "params" in SUPPORTED_METHODS[attack]:

--- a/art/metrics/metrics.py
+++ b/art/metrics/metrics.py
@@ -63,7 +63,6 @@ SUPPORTED_METHODS: Dict[str, Dict[str, Any]] = {
     },
 }
 
-
 def get_crafter(classifier: "CLASSIFIER_TYPE", attack: str, params: Optional[Dict[str, Any]] = None) -> "EvasionAttack":
     """
     Create an attack instance to craft adversarial samples.
@@ -89,19 +88,22 @@ def get_crafter(classifier: "CLASSIFIER_TYPE", attack: str, params: Optional[Dic
 def adversarial_accuracy(
     classifier: "CLASSIFIER_TYPE",
     x: np.ndarray,
+    y: np.ndarray = None,
     attack_name: str = None,
     attack_params: Optional[Dict[str, Any]] = None,
     attack_crafter: EvasionAttack = None,
 ) -> float:
     """
     Compute the adversarial accuracy of a classifier object over the sample `x` for a given adversarial crafting
-    method `attack`. `attack_name` can be specified to use a preset attack, or `attack_crafter` for wider choices
-    and customized parameters. Note that the score does not exclude wrong predictions by the classifier.
+    method `attack`, with optional true labels `y`. `attack_name` can be specified
+    to use a preset attack, or `attack_crafter` for wider choices
+    and customized parameters.
+    Note that if `y` is not specified, the score does not exclude wrong predictions by the classifier.
 
     :param classifier: A trained model.
     :param x: Input samples of shape that can be fed into `classifier`.
-    :param attack_name: A string specifying the attack to be used. Currently supported attacks are {`fgsm', `hsj`}
-                        (Fast Gradient Sign Method, Hop Skip Jump).
+    :param y: True labels of `x`.
+    :param attack_name: A string specifying the attack to be used as a key to `art.metrics.metrics.SUPPORTED_METHODS`.
     :param attack_params: A dictionary with attack-specific parameters. If the attack has a norm attribute, then it will
                           be used as the norm for calculating the robustness; otherwise the standard Euclidean distance
                           is used (norm=2).
@@ -112,17 +114,27 @@ def adversarial_accuracy(
     if attack_crafter is None:
         if attack_name is None:
             raise ValueError("At least one of `attack_name` or `attack_crafter` must be specified.")
+
+        if x.max() > 1.0 or x.min() < 0:
+            logger.warning("The input range is outside [0,1]. Please consider using `attack_crafter` instead.")
+
         attack_crafter = get_crafter(classifier, attack_name, attack_params)
         attack_crafter.set_params(**{"minimal": True})
 
     adv_x = attack_crafter.generate(x)
 
     # Predict the labels for adversarial examples
-    y = classifier.predict(x)
-    y_pred = classifier.predict(adv_x)
+    y_orig = np.argmax(classifier.predict(x), axis=1)
+    y_pred = np.argmax(classifier.predict(adv_x), axis=1)
 
-    idxs = np.argmax(y_pred, axis=1) == np.argmax(y, axis=1)
-    return np.sum(idxs) / len(y)
+    if y is None:
+        idxs = y_pred == y_orig
+        return np.sum(idxs) / len(y_orig)
+    else:
+        if len(y.shape) > 1:
+            y = np.argmax(y, axis=1)
+        y_corr = y_orig == y
+        return np.sum((y_pred != y_orig) & y_corr) / np.sum(y_corr)
 
 
 def empirical_robustness(
@@ -140,8 +152,7 @@ def empirical_robustness(
 
     :param classifier: A trained model.
     :param x: Data sample of shape that can be fed into `classifier`.
-    :param attack_name: A string specifying the attack to be used. Currently supported attacks are {`fgsm', `hsj`}
-                        (Fast Gradient Sign Method, Hop Skip Jump).
+    :param attack_name: A string specifying the attack to be used as a key to `art.metrics.metrics.SUPPORTED_METHODS`.
     :param attack_params: A dictionary with attack-specific parameters. If the attack has a norm attribute, then it will
                           be used as the norm for calculating the robustness; otherwise the standard Euclidean distance
                           is used (norm=2).

--- a/art/metrics/metrics.py
+++ b/art/metrics/metrics.py
@@ -136,11 +136,11 @@ def adversarial_accuracy(
     if y is None:
         idxs = y_pred == y_orig
         return np.sum(idxs) / len(y_orig)
-        
+
     if len(y.shape) > 1:
         y = np.argmax(y, axis=1)
     y_corr = y_orig == y
-    return np.sum((y_pred != y_orig) & y_corr) / np.sum(y_corr)
+    return np.sum((y_pred == y_orig) & y_corr) / np.sum(y_corr)
 
 
 def empirical_robustness(

--- a/art/metrics/metrics.py
+++ b/art/metrics/metrics.py
@@ -63,6 +63,7 @@ SUPPORTED_METHODS: Dict[str, Dict[str, Any]] = {
     },
 }
 
+
 def get_crafter(classifier: "CLASSIFIER_TYPE", attack: str, params: Optional[Dict[str, Any]] = None) -> "EvasionAttack":
     """
     Create an attack instance to craft adversarial samples.
@@ -114,7 +115,10 @@ def adversarial_accuracy(
 
     if attack_crafter is None:
         if attack_name is None:
-            raise ValueError("At least one of `attack_name` or `attack_crafter` must be specified. Available values for `attack_name' include %s." % ", ".join(SUPPORTED_METHODS.keys()))
+            raise ValueError(
+                "At least one of `attack_name` or `attack_crafter` must be specified. Available values for `attack_name' include %s."
+                % ", ".join(SUPPORTED_METHODS.keys())
+            )
 
         if x.max() > 1.0 or x.min() < 0:
             logger.warning("The input range is outside [0,1]. Please consider using `attack_crafter` instead.")

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -29,8 +29,10 @@ import torch.optim as optim
 from art.estimators.classification.keras import KerasClassifier
 from art.estimators.classification.pytorch import PyTorchClassifier
 from art.estimators.classification.tensorflow import TensorFlowClassifier
-from art.metrics.metrics import empirical_robustness, clever_t, clever_u, clever, loss_sensitivity, wasserstein_distance
+from art.metrics.metrics import adversarial_accuracy, empirical_robustness, clever_t, clever_u, clever, loss_sensitivity, wasserstein_distance
 from art.utils import load_mnist
+
+from art.attacks.evasion.auto_attack import AutoAttack
 
 from tests.utils import master_seed
 
@@ -65,6 +67,26 @@ class TestMetrics(unittest.TestCase):
         params = {"eps_step": 0.1, "eps": 0.2}
         emp_robust = empirical_robustness(classifier, x_train, str("fgsm"), params)
         self.assertLessEqual(emp_robust, 0.65)
+
+
+    def test_adv_acc_mnist(self):
+        (x_train, y_train), (_, _), _, _ = load_mnist()
+        x_train, y_train = x_train[:NB_TRAIN], y_train[:NB_TRAIN]
+
+        # Get classifier
+        classifier = self._cnn_mnist_k([28, 28, 1])
+        classifier.fit(x_train, y_train, batch_size=BATCH_SIZE, nb_epochs=2, verbose=0)
+
+        # Compute minimal perturbations
+        params = {"eps_step": 1.0, "eps": 1.0}
+        emp_robust = adversarial_accuracy(classifier, x_train, str("fgsm"), params)
+        self.assertAlmostEqual(emp_robust, 1.000369094488189, 3)
+
+        params = {"eps_step": 1.0, "eps": 1.0}
+        adv_crafter = AutoAttack(classifier, **params)
+        emp_robust = adversarial_accuracy(classifier, x_train, attack_crafter=adv_crafter)
+        self.assertLessEqual(emp_robust, 0.65)
+
 
     def test_loss_sensitivity(self):
         (x_train, y_train), (_, _), _, _ = load_mnist()

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -77,15 +77,15 @@ class TestMetrics(unittest.TestCase):
         classifier = self._cnn_mnist_k([28, 28, 1])
         classifier.fit(x_train, y_train, batch_size=BATCH_SIZE, nb_epochs=2, verbose=0)
 
-        # Compute minimal perturbations
+        # Compute adversarial accuracies
         params = {"eps_step": 1.0, "eps": 1.0}
-        emp_robust = adversarial_accuracy(classifier, x_train, str("fgsm"), params)
-        self.assertAlmostEqual(emp_robust, 1.000369094488189, 3)
+        adv_acc = adversarial_accuracy(classifier, x_train, str("auto"), params)
+        self.assertAlmostEqual(adv_acc, 0)
 
         params = {"eps_step": 1.0, "eps": 1.0}
         adv_crafter = AutoAttack(classifier, **params)
-        emp_robust = adversarial_accuracy(classifier, x_train, attack_crafter=adv_crafter)
-        self.assertLessEqual(emp_robust, 0.65)
+        adv_acc = adversarial_accuracy(classifier, x_train, attack_crafter=adv_crafter)
+        self.assertAlmostEqual(adv_acc, 0)
 
 
     def test_loss_sensitivity(self):

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -29,7 +29,15 @@ import torch.optim as optim
 from art.estimators.classification.keras import KerasClassifier
 from art.estimators.classification.pytorch import PyTorchClassifier
 from art.estimators.classification.tensorflow import TensorFlowClassifier
-from art.metrics.metrics import adversarial_accuracy, empirical_robustness, clever_t, clever_u, clever, loss_sensitivity, wasserstein_distance
+from art.metrics.metrics import (
+    adversarial_accuracy,
+    empirical_robustness,
+    clever_t,
+    clever_u,
+    clever,
+    loss_sensitivity,
+    wasserstein_distance,
+)
 from art.utils import load_mnist
 
 from art.attacks.evasion.auto_attack import AutoAttack
@@ -68,7 +76,6 @@ class TestMetrics(unittest.TestCase):
         emp_robust = empirical_robustness(classifier, x_train, str("fgsm"), params)
         self.assertLessEqual(emp_robust, 0.65)
 
-
     def test_adv_acc_mnist(self):
         (x_train, y_train), (_, _), _, _ = load_mnist()
         x_train, y_train = x_train[:NB_TRAIN], y_train[:NB_TRAIN]
@@ -86,7 +93,6 @@ class TestMetrics(unittest.TestCase):
         adv_crafter = AutoAttack(classifier, **params)
         adv_acc = adversarial_accuracy(classifier, x_train, attack_crafter=adv_crafter)
         self.assertAlmostEqual(adv_acc, 0)
-
 
     def test_loss_sensitivity(self):
         (x_train, y_train), (_, _), _, _ = load_mnist()

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -25,6 +25,7 @@ import tensorflow as tf
 import torch.nn as nn
 import torch.nn.functional as f
 import torch.optim as optim
+from art.attacks.evasion.hop_skip_jump import HopSkipJump
 
 from art.estimators.classification.keras import KerasClassifier
 from art.estimators.classification.pytorch import PyTorchClassifier
@@ -39,8 +40,6 @@ from art.metrics.metrics import (
     wasserstein_distance,
 )
 from art.utils import load_mnist
-
-from art.attacks.evasion.auto_attack import AutoAttack
 
 from tests.utils import master_seed
 
@@ -86,13 +85,13 @@ class TestMetrics(unittest.TestCase):
 
         # Compute adversarial accuracies
         params = {"eps_step": 1.0, "eps": 1.0}
-        adv_acc = adversarial_accuracy(classifier, x_train, str("auto"), params)
+        adv_acc = adversarial_accuracy(classifier, x_train, str("fgsm"), params)
         self.assertAlmostEqual(adv_acc, 0)
 
-        params = {"eps_step": 1.0, "eps": 1.0}
-        adv_crafter = AutoAttack(classifier, **params)
+        params = {"max_iter": 10,"max_eval": 100, "init_eval": 10, "init_size": 10}
+        adv_crafter = HopSkipJump(classifier, **params)
         adv_acc = adversarial_accuracy(classifier, x_train, attack_crafter=adv_crafter)
-        self.assertAlmostEqual(adv_acc, 0)
+        self.assertLess(adv_acc, 0.1)
 
     def test_loss_sensitivity(self):
         (x_train, y_train), (_, _), _, _ = load_mnist()

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -88,7 +88,7 @@ class TestMetrics(unittest.TestCase):
         adv_acc = adversarial_accuracy(classifier, x_train, str("fgsm"), params)
         self.assertAlmostEqual(adv_acc, 0)
 
-        params = {"max_iter": 10,"max_eval": 100, "init_eval": 10, "init_size": 10}
+        params = {"max_iter": 10, "max_eval": 100, "init_eval": 10, "init_size": 10}
         adv_crafter = HopSkipJump(classifier, **params)
         adv_acc = adversarial_accuracy(classifier, x_train, attack_crafter=adv_crafter)
         self.assertLess(adv_acc, 0.1)

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -85,7 +85,11 @@ class TestMetrics(unittest.TestCase):
 
         # Compute adversarial accuracies
         params = {"eps_step": 1.0, "eps": 1.0}
-        adv_acc = adversarial_accuracy(classifier, x_train, str("fgsm"), params)
+        adv_acc = adversarial_accuracy(classifier, x_train, attack_name=str("fgsm"), attack_params=params)
+        self.assertAlmostEqual(adv_acc, 0)
+
+        params = {"eps_step": 1.0, "eps": 1.0}
+        adv_acc = adversarial_accuracy(classifier, x_train, y_train, attack_name=str("fgsm"), attack_params=params)
         self.assertAlmostEqual(adv_acc, 0)
 
         params = {"max_iter": 10, "max_eval": 100, "init_eval": 10, "init_size": 10}


### PR DESCRIPTION
# Description

This PR adds `adversarial_accuracy` as discussed in #1775.

Fixes #1775

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Test A
- [x] Test B

**Test Configuration**:
- OS: Ubuntu 18.04.6 LTS
- Python version: 3.8.12
- ART version or commit number: 50ade3b62836ec8588d0c88fbd0cad56675cc58d
- TensorFlow / Keras / PyTorch / MXNet version: Tensorflow==2.4.1, Keras==2.7.0, PyTorch==1.10.2

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
