### PR TITLE
DPatch: def parameter updated to accept true labels

### DIFF
--- a/art/attacks/evasion/dpatch.py
+++ b/art/attacks/evasion/dpatch.py
@@ -134,8 +134,6 @@ class DPatch(EvasionAttack):
         channel_index = 1 if self.estimator.channels_first else x.ndim - 1
         if x.shape[channel_index] != self.patch_shape[channel_index - 1]:
             raise ValueError("The color channel index of the images and the patch have to be identical.")
-        if y is not None:
-            raise ValueError("The DPatch attack does not use target labels.")
         if x.ndim != 4:  # pragma: no cover
             raise ValueError("The adversarial patch can only be applied to images.")
         if target_label is not None:
@@ -160,7 +158,7 @@ class DPatch(EvasionAttack):
         )
         patch_target: List[Dict[str, np.ndarray]] = []
 
-        if self.target_label:
+        if self.target_label and y is None:
 
             for i_image in range(patched_images.shape[0]):
                 if isinstance(self.target_label, int):
@@ -190,7 +188,7 @@ class DPatch(EvasionAttack):
 
         else:
 
-            predictions = self.estimator.predict(x=patched_images, standardise_output=True)
+            predictions = y if y is not None else self.estimator.predict(x=patched_images, standardise_output=True)
 
             for i_image in range(patched_images.shape[0]):
                 target_dict = {}

--- a/art/attacks/evasion/dpatch.py
+++ b/art/attacks/evasion/dpatch.py
@@ -107,7 +107,12 @@ class DPatch(EvasionAttack):
         Generate DPatch.
 
         :param x: Sample images.
-        :param y: Target labels for object detector.
+        :param y: True labels of type `List[Dict[np.ndarray]]` for untargeted attack, one dictionary per input image. The
+                  keys and values of the dictionary are:
+                  
+                  - boxes [N, 4]: the boxes in [x1, y1, x2, y2] format, with 0 <= x1 < x2 <= W and 0 <= y1 < y2 <= H.
+                  - labels [N]: the labels for each image
+                  - scores [N]: the scores or each prediction.
         :param target_label: The target label of the DPatch attack.
         :param mask: An boolean array of shape equal to the shape of a single samples (1, H, W) or the shape of `x`
                      (N, H, W) without their channel dimensions. Any features for which the mask is True can be the

--- a/art/attacks/evasion/dpatch.py
+++ b/art/attacks/evasion/dpatch.py
@@ -107,9 +107,9 @@ class DPatch(EvasionAttack):
         Generate DPatch.
 
         :param x: Sample images.
-        :param y: True labels of type `List[Dict[np.ndarray]]` for untargeted attack, one dictionary per input image. The
-                  keys and values of the dictionary are:
-                  
+        :param y: True labels of type `List[Dict[np.ndarray]]` for untargeted attack, one dictionary per input image.
+                  The keys and values of the dictionary are:
+
                   - boxes [N, 4]: the boxes in [x1, y1, x2, y2] format, with 0 <= x1 < x2 <= W and 0 <= y1 < y2 <= H.
                   - labels [N]: the labels for each image
                   - scores [N]: the scores or each prediction.

--- a/tests/attacks/evasion/test_dpatch.py
+++ b/tests/attacks/evasion/test_dpatch.py
@@ -72,9 +72,6 @@ def test_generate(art_warning, fix_get_mnist_subset, fix_get_rcnn):
         with pytest.raises(ValueError):
             _ = attack.generate(x=np.repeat(x_test_mnist, axis=3, repeats=2))
 
-        with pytest.raises(ValueError):
-            _ = attack.generate(x=x_test_mnist, y=y_test_mnist)
-
     except ARTTestException as e:
         art_warning(e)
 


### PR DESCRIPTION
# Description

This pull request updates DPatch so that it accepts the true labels `y`.

Fixes # (issue)

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Test A
- [x] Test B

**Test Configuration**:
- OS: Ubuntu 18.04.5 LTS
- Python version: 3.7.13
- ART version or commit number: 2be96ee580f15bd6aacd64f2320cc8ccf47fe891 70d6ed29c1b91f17513abb213aff8a2c1491da96
- TensorFlow / Keras / PyTorch / MXNet version: 2.8.2 / 2.8.0 / 1.12.0

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
