### PR TITLE
Fix exception in pytorch classifier predict method

### DIFF
--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -322,7 +322,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
             output = model_outputs[-1]
             output = output.detach().cpu().numpy().astype(np.float32)
             if len(output.shape) == 1:
-                output = np.expand_dims(output.detach().cpu().numpy(), axis=1).astype(np.float32)
+                output = np.expand_dims(output, axis=1).astype(np.float32)
 
             results_list.append(output)
 


### PR DESCRIPTION
Signed-off-by: abigailt <abigailt@il.ibm.com>

# Description

Remove redundant call to detach().cpu().numpy()

Fixes #1784

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
