### PR TITLE
Fix random_sphere() with norm=1

### DIFF
--- a/art/utils.py
+++ b/art/utils.py
@@ -531,7 +531,8 @@ def random_sphere(
     norm: Union[int, float, str],
 ) -> np.ndarray:
     """
-    Generate randomly `m x n`-dimension points with radius `radius` and centered around 0.
+    Generate uniformly at random `m x n`-dimension points in the `norm`-norm ball with radius `radius` and centered
+    around 0.
 
     :param nb_points: Number of random data points.
     :param nb_dims: Dimensionality of the sphere.

--- a/art/utils.py
+++ b/art/utils.py
@@ -546,13 +546,11 @@ def random_sphere(
                 "The parameter `radius` of type `np.ndarray` is not supported to use with norm 1."
             )
 
-        a_tmp = np.zeros(shape=(nb_points, nb_dims + 1))
-        a_tmp[:, -1] = np.sqrt(np.random.uniform(0, radius ** 2, nb_points))
-
-        for i in range(nb_points):
-            a_tmp[i, 1:-1] = np.sort(np.random.uniform(0, a_tmp[i, -1], nb_dims - 1))
-
-        res = (a_tmp[:, 1:] - a_tmp[:, :-1]) * np.random.choice([-1, 1], (nb_points, nb_dims))
+        u = np.random.uniform(size=(nb_points, nb_dims))
+        v = np.sort(u)
+        v_pre = np.concatenate((np.zeros((nb_points, 1)), v[:, :nb_dims-1]), axis=-1)
+        x = v - v_pre
+        res = radius * x * np.random.choice([-1, 1], (nb_points, nb_dims))
 
     elif norm == 2:
         if isinstance(radius, np.ndarray):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -154,10 +154,31 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(np.all(np.sum(np.abs(x), axis=1) <= 1.0))
 
         x = random_sphere(10, 10, 1, 2)
+        self.assertEqual(x.shape, (10, 10))
         self.assertTrue(np.all(np.linalg.norm(x, axis=1) < 1.0))
 
         x = random_sphere(10, 10, 1, np.inf)
+        self.assertEqual(x.shape, (10, 10))
         self.assertTrue(np.all(np.abs(x) < 1.0))
+
+        x = random_sphere(10, 10, 0.5, 1)
+        self.assertTrue(np.all(np.sum(np.abs(x), axis=1) <= 0.5))
+
+        x = random_sphere(10, 10, 0.5, 2)
+        self.assertTrue(np.all(np.linalg.norm(x, axis=1) < 0.5))
+
+        x = random_sphere(10, 10, 0.5, np.inf)
+        self.assertTrue(np.all(np.abs(x) < 0.5))
+
+        x = random_sphere(1, 10000, 1, 1)
+        self.assertTrue(np.abs(np.sum(np.abs(x), axis=1) - 1.0) < 1e-2)
+
+        x = random_sphere(1, 10000, 1, 2)
+        self.assertTrue(np.abs(np.linalg.norm(x, axis=1) - 1.0) < 1e-2)
+
+        x = random_sphere(1, 10000, 1, np.inf)
+        self.assertTrue(np.abs(np.max(np.abs(x), axis=1) - 1.0) < 1e-2)
+
 
     def test_to_categorical(self):
         y = np.array([3, 1, 4, 1, 5, 9])


### PR DESCRIPTION
# Description

Partial fix of #1799 :
- Fix `art.utils.random_sphere()` when `norm=1` which now correctly sample uniformly in the L1 ball. The sampling method comes from [this reference](https://mathoverflow.net/a/9188/488767), which is also used by [foolbox](https://github.com/bethgelab/foolbox/blob/12abe74e2f1ec79edb759454458ad8dd9ce84939/foolbox/attacks/gradient_descent_base.py#L197).
- Improve unit tests of `art.utils.random_sphere()`: 
    - check that the norm of the point in high dimension is close to `radius`
    - check a smaller `radius` than default
    - check the shape of all norms
- The docstring of `art.utils.random_sphere()` now specifies that the function samples in the p-norm ball (instead of the surface of the sphere)

(This PR replaces #1800 )

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

The norm in low and high dimensions is close to what was expected.

```python
import numpy as np
from art.utils import random_sphere
p=1
for d in [10, 10000]:
    points = random_sphere(nb_points=5, nb_dims=d, radius=10, norm=p)
    norm = np.linalg.norm(points, ord=p, axis=1)
    print(f'{p}-norm of {d}-dim points: {norm}')

# 1-norm of 10-dim points: [9.42352505 8.55454679 8.58168686 9.40038438 9.09817243]
# 1-norm of 10000-dim points: [9.99686352 9.99781933 9.99959791 9.99949611 9.99997998]
```

Check  2D scatterplot

```python
import matplotlib.pyplot as plt
points = random_sphere(nb_points=10000, nb_dims=2, radius=1, norm=1)
plt.scatter(points[:,0], points[:,1])
```
![scaltter_l1_ball](https://user-images.githubusercontent.com/1850174/181861860-33ec832b-004e-4f77-a417-a5ef9072b05b.png)


The three unit tests about the norm in high dimension should not be flaky, as the largest norm over 100000 runs is always approximately 1 order of magnitude lower than the chosen threshold:
```python
# max diffrence between the norm of 100K points in the L1 unit balls and 1.
a = [np.abs(np.sum(np.abs(random_sphere(1, 10000, 1, 1)), axis=1) - 1.0) for i in range(100000)]
np.max(a) < 1e-2  # True
print(np.max(a)) # 0.0011441126974902627
# same for L2
a = [np.abs(np.linalg.norm(random_sphere(1, 10000, 1, 2), axis=1) - 1.0) for i in range(100000)]
np.max(a) < 1e-2  # True
print(np.max(a)) # 0.001347197437172154
# same for Linf
a = [np.abs(np.max(np.abs(random_sphere(1, 10000, 1, np.inf)), axis=1) - 1.0) for i in range(100000)]
np.max(a) < 1e-2  # True
print(np.max(a)) # 0.0011067893448932775
```

**Test Configuration**:


- OS: MacOS
- Python version: 3.8.8
- ART version or commit number: e7f3b7faa68f5efac082ed2b2b79b8ee3dda78a5
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
