### PR TITLE
Remove call to detach() on a numpy array

### DIFF
--- a/art/estimators/regression/pytorch.py
+++ b/art/estimators/regression/pytorch.py
@@ -269,7 +269,7 @@ class PyTorchRegressor(RegressorMixin, PyTorchEstimator):  # lgtm [py/missing-ca
             output = model_outputs[-1]
             output = output.detach().cpu().numpy().astype(np.float32)
             if len(output.shape) == 1:
-                output = np.expand_dims(output.detach().cpu().numpy(), axis=1).astype(np.float32)
+                output = np.expand_dims(output, axis=1).astype(np.float32)
 
             results_list.append(output)
 


### PR DESCRIPTION
# Description

Remove .detach() call in line 272 of pytorch.py in art.estimators.regression because the object is a numpy array, not a tensor, as per line 270. 

Fixes #1823

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ x ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x ] Test A -- call .predict() on a PyTorchRegression who output has one dimension


**Test Configuration**:
- OS Mac Monterey 12.4
- Python version 3.8.10
- ART version or commit number: Main branch as of 8/18/22
- TensorFlow / Keras / PyTorch / MXNet version:  Pytorch 1.12.1

# Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ n/a ] I have commented my code
- [ n/a ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ n/a ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes - no, I was not able to get the unit tests to run even prior to making any changes, however, I see no reason why this would break any tests.
