### PR TITLE
Fix batch-norm layers in PyTorchYolo._get_losses

### DIFF
--- a/art/estimators/object_detection/pytorch_yolo.py
+++ b/art/estimators/object_detection/pytorch_yolo.py
@@ -253,6 +253,8 @@ class PyTorchYolo(ObjectDetectorMixin, PyTorchEstimator):
         import torch  # lgtm [py/repeated-import]
 
         self._model.train()
+        self.set_batchnorm(train=False)
+        self.set_dropout(train=False)
 
         # Apply preprocessing
         if self.all_framework_preprocessing:


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request fixes batch-norm layers in `PyTorchYolo._get_losses`.

Fixes #1859

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
