### PR TITLE
Small clarification fix for verification alg

### DIFF
--- a/art/metrics/verification_decisions_trees.py
+++ b/art/metrics/verification_decisions_trees.py
@@ -26,6 +26,8 @@ from typing import Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 import numpy as np
 from tqdm.auto import trange
 
+from art.utils import check_and_transform_label_format
+
 if TYPE_CHECKING:
     from art.estimators.classification.classifier import ClassifierDecisionTree
 
@@ -192,7 +194,8 @@ class RobustnessVerificationTreeModelsCliqueMethod:
         Verify the robustness of the classifier on the dataset `(x, y)`.
 
         :param x: Feature data of shape `(nb_samples, nb_features)`.
-        :param y: Labels, one-vs-rest encoding of shape `(nb_samples, nb_classes)`.
+        :param y: Labels, one-hot-encoded of shape `(nb_samples, nb_classes)` or indices of shape
+                  (nb_samples,)`.
         :param eps_init: Attack budget for the first search step.
         :param norm: The norm to apply epsilon.
         :param nb_search_steps: The number of search steps.
@@ -200,8 +203,11 @@ class RobustnessVerificationTreeModelsCliqueMethod:
         :param max_level: The maximum number of clique search levels.
         :return: A tuple of the average robustness bound and the verification error at `eps`.
         """
+        if np.min(x) < 0 or np.max(x) > 1:
+            raise ValueError("There are features not in the range [0,1].")
+
         self.x: np.ndarray = x
-        self.y: np.ndarray = np.argmax(y, axis=1)
+        self.y: np.ndarray = check_and_transform_label_format(y, nb_classes=self._classifier.nb_classes, return_one_hot=False)
         self.max_clique: int = max_clique
         self.max_level: int = max_level
 

--- a/art/metrics/verification_decisions_trees.py
+++ b/art/metrics/verification_decisions_trees.py
@@ -204,7 +204,10 @@ class RobustnessVerificationTreeModelsCliqueMethod:
         :return: A tuple of the average robustness bound and the verification error at `eps`.
         """
         if np.min(x) < 0 or np.max(x) > 1:
-            raise ValueError("There are features not in the range [0,1].")
+        raise ValueError(
+            "There are features not in the range [0, 1]. The current implementation only supports normalized input"
+            "valuesfeatures in range [0 1]."
+        )
 
         self.x: np.ndarray = x
         self.y: np.ndarray = check_and_transform_label_format(

--- a/art/metrics/verification_decisions_trees.py
+++ b/art/metrics/verification_decisions_trees.py
@@ -206,7 +206,7 @@ class RobustnessVerificationTreeModelsCliqueMethod:
         if np.min(x) < 0 or np.max(x) > 1:
         raise ValueError(
             "There are features not in the range [0, 1]. The current implementation only supports normalized input"
-            "valuesfeatures in range [0 1]."
+            "values in range [0 1]."
         )
 
         self.x: np.ndarray = x

--- a/art/metrics/verification_decisions_trees.py
+++ b/art/metrics/verification_decisions_trees.py
@@ -207,7 +207,9 @@ class RobustnessVerificationTreeModelsCliqueMethod:
             raise ValueError("There are features not in the range [0,1].")
 
         self.x: np.ndarray = x
-        self.y: np.ndarray = check_and_transform_label_format(y, nb_classes=self._classifier.nb_classes, return_one_hot=False)
+        self.y: np.ndarray = check_and_transform_label_format(
+            y, nb_classes=self._classifier.nb_classes, return_one_hot=False
+        )
         self.max_clique: int = max_clique
         self.max_level: int = max_level
 

--- a/art/metrics/verification_decisions_trees.py
+++ b/art/metrics/verification_decisions_trees.py
@@ -204,10 +204,10 @@ class RobustnessVerificationTreeModelsCliqueMethod:
         :return: A tuple of the average robustness bound and the verification error at `eps`.
         """
         if np.min(x) < 0 or np.max(x) > 1:
-        raise ValueError(
-            "There are features not in the range [0, 1]. The current implementation only supports normalized input"
-            "values in range [0 1]."
-        )
+            raise ValueError(
+                "There are features not in the range [0, 1]. The current implementation only supports normalized input"
+                "values in range [0 1]."
+            )
 
         self.x: np.ndarray = x
         self.y: np.ndarray = check_and_transform_label_format(


### PR DESCRIPTION
# Description

In verification_decisions_trees.py, the code does not specify that the input data need to be in the [0,1] range. It also only permits one-hot vectors as inputs for y. I've made some small changes to check the input data range and to format the data if `y` is in the shape(nb_samples, 1)

## Type of change

Please check all relevant options.

- [X] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
