### PR TITLE
Bug fix sleeper agent

### DIFF
--- a/art/attacks/poisoning/sleeper_agent_attack.py
+++ b/art/attacks/poisoning/sleeper_agent_attack.py
@@ -229,6 +229,11 @@ class SleeperAgentAttack(GradientMatchingAttack):
                 best_B = B_  # pylint: disable=C0103
                 best_x_poisoned = x_poisoned
                 best_indices_poison = self.indices_poison
+        if best_B == np.finfo(np.float32).max:
+            logger.warning("Attack unsuccessful: all loss values were non-finite. Defaulting to final trial.")
+            best_B = B_  # pylint: disable=C0103
+            best_x_poisoned = x_poisoned
+            best_indices_poison = self.indices_poison
 
         # Apply De-Normalization
         if isinstance(


### PR DESCRIPTION
# Description

When the loss is nan or inf, then best_x_poisoned is never assigned, leading to the error mentioned in 
- [https://github.com/Trusted-AI/adversarial-robustness-toolbox/issues/1865](url)

Fixes # (1865)

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
