### PR TITLE
Remove check from BoundaryAttack to enable binary classification

### DIFF
--- a/art/attacks/evasion/boundary.py
+++ b/art/attacks/evasion/boundary.py
@@ -133,11 +133,6 @@ class BoundaryAttack(EvasionAttack):
 
         y = check_and_transform_label_format(y, nb_classes=self.estimator.nb_classes, return_one_hot=False)
 
-        if y is not None and self.estimator.nb_classes == 2 and y.shape[1] == 1:
-            raise ValueError(  # pragma: no cover
-                "This attack has not yet been tested for binary classification with a single output classifier."
-            )
-
         # Get clip_min and clip_max from the classifier or infer them from data
         if self.estimator.clip_values is not None:
             clip_min, clip_max = self.estimator.clip_values


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request removes a check from `BoundaryAttack` to enable binary classification.

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing