### PR TITLE
Implementing more realistic transforms in Robust DPatch EoT

### DIFF
--- a/art/attacks/evasion/dpatch_robust_eot.py
+++ b/art/attacks/evasion/dpatch_robust_eot.py
@@ -1,0 +1,121 @@
+from art.attacks.evasion import RobustDPatch
+
+import logging
+import math
+import random
+from typing import Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import torchvision
+from tqdm.auto import trange
+
+from art.estimators.object_detection.pytorch_object_detector import PyTorchObjectDetector
+from art import config
+from art.summary_writer import SummaryWriter
+
+logger = logging.getLogger(__name__)
+
+import torch
+
+class PatchOperator:
+    """
+    Class to specify Expectations Over Transformations for RobustDPatchEoT
+    """
+
+    def __init__(
+        self,
+        device_type='cpu',
+        channels_first=False,#default is channel last
+        rotation_max: float = 22.5,
+        scale_min: float = 0.1,
+        scale_max: float = 1.0,
+        distortion_scale_max: float = 0.0,
+        patch_shape: Tuple[int, int, int] = (224, 224, 3),
+        patch_location: Optional[Tuple[int, int]] = None,
+        patch_type: str = "circle",
+    ):
+        """
+        Create an instance of the :class:`.PatchOperator`.
+        :param rotation_max: The maximum rotation applied to random patches. The value is expected to be in the
+               range `[0, 180]`.
+        :param scale_min: The minimum scaling applied to random patches. The value should be in the range `[0, 1]`,
+               but less than `scale_max`.
+        :param scale_max: The maximum scaling applied to random patches. The value should be in the range `[0, 1]`, but
+               larger than `scale_min`.
+        :param distortion_scale_max: The maximum distortion scale for perspective transformation in range `[0, 1]`. If
+               distortion_scale_max=0.0 the perspective transformation sampling will be disabled.
+        :param learning_rate: The learning rate of the optimization. For `optimizer="pgd"` the learning rate gets
+                              multiplied with the sign of the loss gradients.
+        :param max_iter: The number of optimization steps.
+        :param batch_size: The size of the training batch.
+        :param patch_shape: The shape of the adversarial patch as a tuple of shape CHW (nb_channels, height, width).
+        :param patch_location: The location of the adversarial patch as a tuple of shape (upper left x, upper left y).
+        :param patch_type: The patch type, either circle or square.
+        :param optimizer: The optimization algorithm. Supported values: "Adam", and "pgd". "pgd" corresponds to
+                          projected gradient descent in L-Inf norm.
+        :param targeted: Indicates whether the attack is targeted (True) or untargeted (False).
+        :param summary_writer: Activate summary writer for TensorBoard.
+                               Default is `False` and deactivated summary writer.
+                               If `True` save runs/CURRENT_DATETIME_HOSTNAME in current directory.
+                               If of type `str` save in path.
+                               If of type `SummaryWriter` apply provided custom summary writer.
+                               Use hierarchical folder structure to compare between runs easily. e.g. pass in
+                               ‘runs/exp1’, ‘runs/exp2’, etc. for each new experiment to compare across them.
+        :param verbose: Show progress bars.
+        """
+
+
+class EoTRobustDPatch(RobustDPatch):
+    """
+    Implementation of Robust DPatch attack with EoT.
+    It extend the RobustDPatch attack with significantly increased variation of transforms in expectations over transformations.
+    """
+    eot = None
+    _estimator_requirements = (PyTorchObjectDetector)
+
+    def __init__(
+        self,
+        estimator: PyTorchObjectDetector,
+        rotation_max: float = 22.5,
+        scale_min: float = 0.1,
+        scale_max: float = 1.0,
+        distortion_scale_max: float = 0.0,
+        patch_shape: Tuple[int, int, int] = (224, 224, 3),
+        patch_location: Optional[Tuple[int, int]] = None,
+        patch_type: str = "circle",
+        sample_size: int = 1,
+        learning_rate: float = 5.0,
+        max_iter: int = 500,
+        batch_size: int = 16,
+        targeted: bool = False,
+        summary_writer: Union[str, bool, SummaryWriter] = False,
+        verbose: bool = True,
+    ):
+        """
+        Create an instance of the :class:`.EoTRobustDPatch`.
+        :param estimator: A trained PyTorch object detector.
+        :param eot: `PatchOperator` object holding configurations for transforms in Expectations Over Transformations
+        :param sample_size: Number of samples to be used in expectations over transformation.
+        :param learning_rate: The learning rate of the optimization.
+        :param max_iter: The number of optimization steps.
+        :param batch_size: The size of the training batch.
+        :param targeted: Indicates whether the attack is targeted (True) or untargeted (False).
+        :param summary_writer: Activate summary writer for TensorBoard.
+                               Default is `False` and deactivated summary writer.
+                               If `True` save runs/CURRENT_DATETIME_HOSTNAME in current directory.
+                               If of type `str` save in path.
+                               If of type `SummaryWriter` apply provided custom summary writer.
+                               Use hierarchical folder structure to compare between runs easily. e.g. pass in
+                               ‘runs/exp1’, ‘runs/exp2’, etc. for each new experiment to compare across them.
+        :param verbose: Show progress bars.
+        """
+        super().__init__(
+            estimator=estimator,
+            sample_size=sample_size,
+            learning_rate=learning_rate,
+            max_iter=max_iter,
+            batch_size=batch_size,
+            targeted=targeted,
+            summary_writer=summary_writer,
+            verbose=verbose,
+        )

--- a/tests/attacks/evasion/test_dpatch_robust_eot.py
+++ b/tests/attacks/evasion/test_dpatch_robust_eot.py
@@ -1,0 +1,106 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import logging
+
+import numpy as np
+import pytest
+
+from art.attacks.evasion.dpatch_robust_eot import EoTRobustDPatch, PatchOperator
+from art.estimators.object_detection.pytorch_object_detector import PyTorchObjectDetector
+
+from tests.attacks.utils import backend_test_classifier_type_check_fail
+from tests.utils import ARTTestException
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def fix_get_mnist_subset(get_mnist_dataset):
+    (x_train_mnist, y_train_mnist), (x_test_mnist, y_test_mnist) = get_mnist_dataset
+    n_train = 10
+    n_test = 10
+    yield x_train_mnist[:n_train], y_train_mnist[:n_train], x_test_mnist[:n_test], y_test_mnist[:n_test]
+
+
+@pytest.mark.skip_framework("keras", "scikitlearn", "mxnet", "kerastf", "tensorflow")
+def test_generate(art_warning, fix_get_mnist_subset, fix_get_rcnn, framework):
+    try:
+        (_, _, x_test_mnist, y_test_mnist) = fix_get_mnist_subset
+
+        if framework == "pytorch":
+            x_test_mnist = np.transpose(x_test_mnist, (0, 2, 3, 1))
+
+        frcnn = fix_get_rcnn
+        attack = EoTRobustDPatch(
+            frcnn,
+            distortion_scale_max = 0.3,
+            patch_shape = (4,4,1),
+            sample_size=1,
+            learning_rate=1.0,
+            max_iter=100,
+            batch_size=5,
+            verbose=False,
+        )
+        """
+        patch = attack.generate(x=x_test_mnist)
+        assert patch.shape == (4, 4, 1)
+
+        with pytest.raises(ValueError):
+            _ = attack.generate(x=np.repeat(x_test_mnist, axis=3, repeats=2))
+
+        with pytest.raises(ValueError):
+            _ = attack.generate(x=x_test_mnist, y=y_test_mnist)
+        """
+    except ARTTestException as e:
+        art_warning(e)
+
+
+@pytest.mark.skip_framework("keras", "scikitlearn", "mxnet", "kerastf", "tensorflow")
+def test_generate_targeted(art_warning, fix_get_mnist_subset, fix_get_rcnn, framework):
+    try:
+        (_, _, x_test_mnist, _) = fix_get_mnist_subset
+
+        if framework == "pytorch":
+            x_test_mnist = np.transpose(x_test_mnist, (0, 2, 3, 1))
+
+        frcnn = fix_get_rcnn
+        attack = EoTRobustDPatch(
+            frcnn,
+            patch_shape=(4, 4, 1),
+            patch_location=(2, 2),
+            crop_range=(0, 0),
+            brightness_range=(1.0, 1.0),
+            rotation_weights=(1, 0, 0, 0),
+            sample_size=1,
+            learning_rate=1.0,
+            max_iter=1,
+            batch_size=1,
+            targeted=True,
+            verbose=False,
+        )
+        """
+        y = frcnn.predict(x_test_mnist)
+        patch = attack.generate(x=x_test_mnist, y=y)
+        assert patch.shape == (4, 4, 1)
+
+        with pytest.raises(ValueError):
+            _ = attack.generate(x=x_test_mnist, y=None)
+    """
+
+    except ARTTestException as e:
+        art_warning(e)


### PR DESCRIPTION
# Description

**Summary**: PyTorch implementation of Robust DPatch with Expectations Over Transformations (EoT) that use wider variety and range of transforms.
**Motivation**: The current implementation provides limited type and range of transformations in its EoT. Also, the current implementation transforms whole patched image as opposed to transforming patch before applying onto the image. For real world use cases that my team has seen, we would like 1. more diverse transforms and 2. transforming the patch before applying onto image.
**Dependencies**: `PyTorchObjectDetector`

Fixes #1907

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
