### PR TITLE
bug fix for getting best poison indices after all trials

### DIFF
--- a/art/attacks/poisoning/sleeper_agent_attack.py
+++ b/art/attacks/poisoning/sleeper_agent_attack.py
@@ -234,6 +234,8 @@ class SleeperAgentAttack(GradientMatchingAttack):
             best_B = B_  # pylint: disable=C0103
             best_x_poisoned = x_poisoned
             best_indices_poison = self.indices_poison
+        # set indices_poison to be the best indices after all trials
+        self.indices_poison = best_indices_poison
 
         # Apply De-Normalization
         if isinstance(


### PR DESCRIPTION
Signed-off-by: Shriti Priya <shritip@ibm.com>
In Sleeper Agent, get_poison_indices() returns self.indices_poison, however, the poisoning procedure does not update this variable to the final indices used. The fix is to update self.indices_poison with the best_poison_indices found across all trials.

Fixes # [1952](https://github.com/Trusted-AI/adversarial-robustness-toolbox/issues/1952)

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
