### PR TITLE
Validate labels in `compute_loss` call for `TensorFlowV2Classifier` and `KerasClassifier`

### DIFF
--- a/art/estimators/classification/keras.py
+++ b/art/estimators/classification/keras.py
@@ -378,7 +378,11 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
         else:
             import keras.backend as k
 
+        y = check_and_transform_label_format(y, self.nb_classes)  # type: ignore
+
+        # Apply preprocessing
         x_preprocessed, y_preprocessed = self._apply_preprocessing(x, y, fit=False)
+
         shape_match = [i is None or i == j for i, j in zip(self._input_shape, x_preprocessed.shape[1:])]
         if not all(shape_match):  # pragma: no cover
             raise ValueError(

--- a/art/estimators/classification/tensorflow.py
+++ b/art/estimators/classification/tensorflow.py
@@ -1123,16 +1123,18 @@ class TensorFlowV2Classifier(ClassGradientsMixin, ClassifierMixin, TensorFlowV2E
         elif reduction == "sum":
             self._loss_object.reduction = tf.keras.losses.Reduction.SUM
 
+        y = check_and_transform_label_format(y, self.nb_classes)  # type: ignore
+
         # Apply preprocessing
-        x_preprocessed, _ = self._apply_preprocessing(x, y, fit=False)
+        x_preprocessed, y_preprocessed = self._apply_preprocessing(x, y, fit=False)
 
         if tf.executing_eagerly():
             x_preprocessed_tf = tf.convert_to_tensor(x_preprocessed)
             predictions = self.model(x_preprocessed_tf, training=training_mode)
             if self._reduce_labels:
-                loss = self._loss_object(np.argmax(y, axis=1), predictions)
+                loss = self._loss_object(np.argmax(y_preprocessed, axis=1), predictions)
             else:
-                loss = self._loss_object(y, predictions)
+                loss = self._loss_object(y_preprocessed, predictions)
         else:
             raise NotImplementedError("Expecting eager execution.")
 


### PR DESCRIPTION
# Description

Call the `check_and_transform_label_format` function when calling the `compute_loss` function in the `TensorFlowV2Classifier` and `KerasClassifier` classes. This fixes the argmax issue when passing integer labels.

Fixes #1959 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
