### PR TITLE
Add Support for Probability Distribution Labels in PyTorchClassifier

### DIFF
--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -272,7 +272,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         # Check if the loss function supports probability labels and probability labels are provided
         if self._probability_labels and len(y.shape) == 2:
             if isinstance(y, torch.Tensor):
-                is_one_hot = torch.equal(y, y.int())
+                is_one_hot = torch.equal(y.floor(), y.ceil())
             else:
                 is_one_hot = np.array_equal(y, y.astype(np.int32))
             if not is_one_hot:  # probability labels

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -153,7 +153,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
             self._reduce_labels = True
             self._int_labels = True
             self._probability_labels = True
-        if isinstance(self._loss, (torch.nn.NLLLoss, torch.nn.MultiMarginLoss)):
+        elif isinstance(self._loss, (torch.nn.NLLLoss, torch.nn.MultiMarginLoss)):
             self._reduce_labels = True
             self._int_labels = True
             self._probability_labels = False
@@ -272,9 +272,9 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         # Check if the loss function supports probability labels and probability labels are provided
         if self._probability_labels and len(y.shape) == 2:
             if isinstance(y, torch.Tensor):
-                is_one_hot = torch.all(torch.remainder(y, 1) == 0)
+                is_one_hot = torch.equal(y, y.int())
             else:
-                is_one_hot = np.all(np.mod(y, 1) == 0)
+                is_one_hot = np.array_equal(y, y.astype(np.int32))
             if not is_one_hot:  # probability labels
                 return y
 

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -149,16 +149,13 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         # Index of layer at which the class gradients should be calculated
         self._layer_idx_gradients = -1
 
-        if isinstance(
-            self._loss,
-            (torch.nn.CrossEntropyLoss, torch.nn.NLLLoss, torch.nn.MultiMarginLoss),
-        ):
+        if isinstance(self._loss, torch.nn.CrossEntropyLoss):
+            self._reduce_labels = False
+            self._int_labels = False
+        if isinstance(self._loss, (torch.nn.NLLLoss, torch.nn.MultiMarginLoss)):
             self._reduce_labels = True
             self._int_labels = True
-        elif isinstance(
-            self._loss,
-            (torch.nn.BCELoss),
-        ):
+        elif isinstance(self._loss, torch.nn.BCELoss):
             self._reduce_labels = True
             self._int_labels = False
         else:
@@ -277,7 +274,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
                 return np.argmax(y, axis=1)
             if self._reduce_labels:  # float labels
                 if isinstance(y, torch.Tensor):
-                    return torch.argmax(y, dim=1).type("torch.FloatTensor")
+                    return torch.argmax(y, dim=1).float()
                 y_index = np.argmax(y, axis=1).astype(np.float32)
                 y_index = np.expand_dims(y_index, axis=1)
                 return y_index

--- a/art/estimators/regression/pytorch.py
+++ b/art/estimators/regression/pytorch.py
@@ -502,9 +502,6 @@ class PyTorchRegressor(RegressorMixin, PyTorchEstimator):
         # Apply preprocessing
         x_preprocessed, y_preprocessed = self._apply_preprocessing(x, y, fit=False)
 
-        # Check label shape
-        # y_preprocessed = self.reduce_labels(y_preprocessed)
-
         if isinstance(x, torch.Tensor):
             inputs_t = x_preprocessed
             labels_t = y_preprocessed
@@ -649,9 +646,6 @@ class PyTorchRegressor(RegressorMixin, PyTorchEstimator):
             inputs_t = x_grad
         else:
             raise NotImplementedError("Combination of inputs and preprocessing not supported.")
-
-        # Check label shape
-        # y_preprocessed = self.reduce_labels(y_preprocessed)
 
         if isinstance(y_preprocessed, np.ndarray):
             labels_t = torch.from_numpy(y_preprocessed).to(self._device)


### PR DESCRIPTION
# Description

Create a new property `_probability_labels` in the `PyTorchClassifier` and have it set to True when using `nn.CrossEntropyLoss`. This allows the `reduce_labels()` function to check if the labels are one-hot encoded or a probability distribution and handle it accordingly. This allows support for probability distribution labels.

Additionally do the following minor changes: 
* Clean up some of the code/formatting for the label checking in `PyTorchClassifier`
* Add `BCEWithLogitsLoss` as one of the loss functions to be checked since the same reduction should occur as with `BCELoss`
* Removed commented code for label reduction in the PyTorch regressor, mainly to avoid false positives when searching the usage of the `reduce_labels()` function

Fixes #1966 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
