### PR TITLE
Fix bug in PixelThreshold for single input

### DIFF
--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -167,7 +167,7 @@ class PixelThreshold(EvasionAttack):
             if y.ndim > 1 and y.shape[1] > 1:
                 y = np.argmax(y, axis=1)
 
-        y = np.squeeze(y)  # type: ignore
+        y = y.flatten()  # type: ignore
 
         if self.th is None:
             logger.info(

--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -167,7 +167,7 @@ class PixelThreshold(EvasionAttack):
             if y.ndim > 1 and y.shape[1] > 1:
                 y = np.argmax(y, axis=1)
 
-        y = y.flatten()  # type: ignore
+        y = y.flatten()  # type: ignore 
 
         if self.th is None:
             logger.info(


### PR DESCRIPTION
# Description

Calling `.generate()` on a batch of length one, a `TypeError` is raised on line 193. 
```
TypeError: iteration over a 0-d array
```
This is because `np.squeeze(y)` returns a 0-dimensional array when `y.shape == (1, 1)`. Changing it to `y.flatten()` solves this issue by returning a 1-dimensional array in this case, while not changing the behavior in the case when the batch has more than one input.

Fixes # (issue)

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Ran Pixel Attack on input array of shape `(1, 3, 224, 224)` (this did not work before, and it does not)
- [x] Ran Pixel Attack on input array of shape `(3, 3, 224, 224)` (this still works as before)

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
