### PR TITLE
Small enhancement to PDTP privacy metric

### DIFF
--- a/art/metrics/__init__.py
+++ b/art/metrics/__init__.py
@@ -9,4 +9,4 @@ from art.metrics.metrics import clever_t
 from art.metrics.metrics import wasserstein_distance
 from art.metrics.verification_decisions_trees import RobustnessVerificationTreeModelsCliqueMethod
 from art.metrics.gradient_check import loss_gradient_check
-from art.metrics.privacy import PDTP
+from art.metrics.privacy import PDTP, ComparisonType

--- a/art/metrics/privacy/__init__.py
+++ b/art/metrics/privacy/__init__.py
@@ -1,5 +1,5 @@
 """
 Module providing metrics and verifications.
 """
-from art.metrics.privacy.membership_leakage import PDTP
+from art.metrics.privacy.membership_leakage import PDTP, ComparisonType
 from art.metrics.privacy.worst_case_mia_score import get_roc_for_fpr, get_roc_for_multi_fprs

--- a/art/metrics/privacy/membership_leakage.py
+++ b/art/metrics/privacy/membership_leakage.py
@@ -20,14 +20,26 @@ This module implements membership leakage metrics.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 from typing import TYPE_CHECKING, Optional, Tuple
+from enum import Enum, auto
 
 import numpy as np
 import scipy
+
+from sklearn.neighbors import KNeighborsClassifier
 
 from art.utils import check_and_transform_label_format, is_probability_array
 
 if TYPE_CHECKING:
     from art.estimators.classification.classifier import Classifier
+
+
+class ComparisonType(Enum):
+    """
+    An Enum type for different kinds of comparisons between model outputs.
+    """
+
+    RATIO = auto()
+    DIFFERENCE = auto()
 
 
 def PDTP(  # pylint: disable=C0103
@@ -37,6 +49,7 @@ def PDTP(  # pylint: disable=C0103
     y: np.ndarray,
     indexes: Optional[np.ndarray] = None,
     num_iter: Optional[int] = 10,
+    comparison_type: Optional[ComparisonType] = ComparisonType.RATIO,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Compute the pointwise differential training privacy metric for the given classifier and training set.
@@ -52,6 +65,8 @@ def PDTP(  # pylint: disable=C0103
                     computed for all samples in `x`.
     :param num_iter: the number of iterations of PDTP computation to run for each sample. If not supplied,
                      defaults to 10. The result is the average across iterations.
+    :param comparison_type: the way in which to compare the model outputs between models trained with and without
+                            a certain sample. Default is to compute the ratio.
     :return: A tuple of three arrays, containing the average (worse, standard deviation) PDTP value for each sample in
              the training set respectively. The higher the value, the higher the privacy leakage for that sample.
     """
@@ -88,7 +103,7 @@ def PDTP(  # pylint: disable=C0103
         pred_bin_indexes[pred_bin_indexes == 101] = 100
         pred_bin = bins[pred_bin_indexes] - 0.005
 
-        if not indexes:
+        if indexes is None:
             indexes = range(x.shape[0])
         for row in indexes:
             # create new model without sample in training data
@@ -109,15 +124,20 @@ def PDTP(  # pylint: disable=C0103
             alt_pred_bin_indexes = np.digitize(alt_pred, bins)
             alt_pred_bin_indexes[alt_pred_bin_indexes == 101] = 100
             alt_pred_bin = bins[alt_pred_bin_indexes] - 0.005
-            ratio_1 = pred_bin / alt_pred_bin
-            ratio_2 = alt_pred_bin / pred_bin
-            # get max value
-            max_value = max(ratio_1.max(), ratio_2.max())
+            if comparison_type == ComparisonType.RATIO:
+                ratio_1 = pred_bin / alt_pred_bin
+                ratio_2 = alt_pred_bin / pred_bin
+                # get max value
+                max_value = max(ratio_1.max(), ratio_2.max())
+            elif comparison_type == ComparisonType.DIFFERENCE:
+                max_value = np.max(abs(pred_bin - alt_pred_bin))
+            else:
+                raise ValueError("Unsupported comparison type.")
             iter_results.append(max_value)
         results.append(iter_results)
 
     # get average of iterations for each sample
-    # We now have a list of list, internal lists represent an iteration. We need to transpose and get averages.
+    # We now have a list of lists, internal lists represent an iteration. We need to transpose and get averages.
     per_sample = list(map(list, zip(*results)))
     avg_per_sample = np.array([sum(val) / len(val) for val in per_sample])
     worse_per_sample = np.max(per_sample, axis=1)

--- a/art/metrics/privacy/membership_leakage.py
+++ b/art/metrics/privacy/membership_leakage.py
@@ -25,8 +25,6 @@ from enum import Enum, auto
 import numpy as np
 import scipy
 
-from sklearn.neighbors import KNeighborsClassifier
-
 from art.utils import check_and_transform_label_format, is_probability_array
 
 if TYPE_CHECKING:

--- a/tests/metrics/privacy/test_membership_leakage.py
+++ b/tests/metrics/privacy/test_membership_leakage.py
@@ -22,7 +22,7 @@ import pytest
 import numpy as np
 import random
 
-from art.metrics import PDTP
+from art.metrics import PDTP, ComparisonType
 from tests.utils import ARTTestException
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,10 @@ def test_membership_leakage_decision_tree(art_warning, decision_tree_estimator, 
         logger.info("Max PDTP leakage: %.2f", (np.max(avg_leakage)))
         assert classifier.model.tree_ == prev
         assert np.all(avg_leakage >= 1.0)
-        assert np.all(worse_leakage >= avg_leakage)
+        assert np.all(np.around(worse_leakage, decimals=10) >= np.around(avg_leakage, decimals=10))
+        assert len(avg_leakage.shape) == 1
+        assert len(worse_leakage.shape) == 1
+        assert len(std_dev.shape) == 1
         assert avg_leakage.shape[0] == x_train.shape[0]
         assert worse_leakage.shape[0] == x_train.shape[0]
         assert std_dev.shape[0] == x_train.shape[0]
@@ -48,7 +51,7 @@ def test_membership_leakage_decision_tree(art_warning, decision_tree_estimator, 
         art_warning(e)
 
 
-@pytest.mark.skip_framework("keras", "kerastf", "tensorflow1", "mxnet")
+@pytest.mark.skip_framework("keras", "kerastf", "tensorflow1", "tensorflow2v1", "mxnet")
 def test_membership_leakage_tabular(art_warning, tabular_dl_estimator, get_iris_dataset):
     try:
         classifier = tabular_dl_estimator()
@@ -58,7 +61,10 @@ def test_membership_leakage_tabular(art_warning, tabular_dl_estimator, get_iris_
         logger.info("Average PDTP leakage: %.2f", (np.average(avg_leakage)))
         logger.info("Max PDTP leakage: %.2f", (np.max(avg_leakage)))
         assert np.all(avg_leakage >= 1.0)
-        assert np.all(worse_leakage >= avg_leakage)
+        assert np.all(np.around(worse_leakage, decimals=10) >= np.around(avg_leakage, decimals=10))
+        assert len(avg_leakage.shape) == 1
+        assert len(worse_leakage.shape) == 1
+        assert len(std_dev.shape) == 1
         assert avg_leakage.shape[0] == x_train.shape[0]
         assert worse_leakage.shape[0] == x_train.shape[0]
         assert std_dev.shape[0] == x_train.shape[0]
@@ -79,7 +85,10 @@ def test_membership_leakage_image(art_warning, image_dl_estimator, get_default_m
         logger.info("Average PDTP leakage: %.2f", (np.average(avg_leakage)))
         logger.info("Max PDTP leakage: %.2f", (np.max(avg_leakage)))
         assert np.all(avg_leakage >= 1.0)
-        assert np.all(worse_leakage >= avg_leakage)
+        assert np.all(np.around(worse_leakage, decimals=10) >= np.around(avg_leakage, decimals=10))
+        assert len(avg_leakage.shape) == 1
+        assert len(worse_leakage.shape) == 1
+        assert len(std_dev.shape) == 1
         assert avg_leakage.shape[0] == 100
         assert worse_leakage.shape[0] == 100
         assert std_dev.shape[0] == 100
@@ -87,7 +96,85 @@ def test_membership_leakage_image(art_warning, image_dl_estimator, get_default_m
         art_warning(e)
 
 
-@pytest.mark.skip_framework("scikitlearn", "keras", "kerastf", "tensorflow1", "mxnet")
+@pytest.mark.skip_framework("dl_frameworks")
+def test_membership_leakage_decision_tree_diff(art_warning, decision_tree_estimator, get_iris_dataset):
+    try:
+        classifier = decision_tree_estimator()
+        extra_classifier = decision_tree_estimator()
+        (x_train, y_train), _ = get_iris_dataset
+        prev = classifier.model.tree_
+        avg_leakage, worse_leakage, std_dev = PDTP(
+            classifier, extra_classifier, x_train, y_train, comparison_type=ComparisonType.DIFFERENCE
+        )
+        logger.info("Average PDTP leakage: %.2f", (np.average(avg_leakage)))
+        logger.info("Max PDTP leakage: %.2f", (np.max(avg_leakage)))
+        assert classifier.model.tree_ == prev
+        assert np.all(avg_leakage >= 0.0)
+        assert np.all(np.around(worse_leakage, decimals=10) >= np.around(avg_leakage, decimals=10))
+        assert len(avg_leakage.shape) == 1
+        assert len(worse_leakage.shape) == 1
+        assert len(std_dev.shape) == 1
+        assert avg_leakage.shape[0] == x_train.shape[0]
+        assert worse_leakage.shape[0] == x_train.shape[0]
+        assert std_dev.shape[0] == x_train.shape[0]
+    except ARTTestException as e:
+        art_warning(e)
+
+
+@pytest.mark.skip_framework("keras", "kerastf", "tensorflow1", "tensorflow2v1", "mxnet")
+def test_membership_leakage_tabular_diff(art_warning, tabular_dl_estimator, get_iris_dataset):
+    try:
+        classifier = tabular_dl_estimator()
+        extra_classifier = tabular_dl_estimator()
+        (x_train, y_train), _ = get_iris_dataset
+        avg_leakage, worse_leakage, std_dev = PDTP(
+            classifier, extra_classifier, x_train, y_train, comparison_type=ComparisonType.DIFFERENCE
+        )
+        logger.info("Average PDTP leakage: %.2f", (np.average(avg_leakage)))
+        logger.info("Max PDTP leakage: %.2f", (np.max(avg_leakage)))
+        assert np.all(avg_leakage >= 0.0)
+        assert np.all(np.around(worse_leakage, decimals=10) >= np.around(avg_leakage, decimals=10))
+        assert len(avg_leakage.shape) == 1
+        assert len(worse_leakage.shape) == 1
+        assert len(std_dev.shape) == 1
+        assert avg_leakage.shape[0] == x_train.shape[0]
+        assert worse_leakage.shape[0] == x_train.shape[0]
+        assert std_dev.shape[0] == x_train.shape[0]
+    except ARTTestException as e:
+        art_warning(e)
+
+
+@pytest.mark.skip_framework("keras", "kerastf", "tensorflow1", "tensorflow2v1", "mxnet")
+def test_membership_leakage_image_diff(art_warning, image_dl_estimator, get_default_mnist_subset):
+    try:
+        classifier, _ = image_dl_estimator()
+        extra_classifier, _ = image_dl_estimator()
+        (x_train, y_train), _ = get_default_mnist_subset
+        indexes = random.sample(range(x_train.shape[0]), 100)
+        avg_leakage, worse_leakage, std_dev = PDTP(
+            classifier,
+            extra_classifier,
+            x_train,
+            y_train,
+            indexes=indexes,
+            num_iter=1,
+            comparison_type=ComparisonType.DIFFERENCE,
+        )
+        logger.info("Average PDTP leakage: %.2f", (np.average(avg_leakage)))
+        logger.info("Max PDTP leakage: %.2f", (np.max(avg_leakage)))
+        assert np.all(avg_leakage >= 0.0)
+        assert np.all(np.around(worse_leakage, decimals=10) >= np.around(avg_leakage, decimals=10))
+        assert len(avg_leakage.shape) == 1
+        assert len(worse_leakage.shape) == 1
+        assert len(std_dev.shape) == 1
+        assert avg_leakage.shape[0] == len(indexes)
+        assert worse_leakage.shape[0] == len(indexes)
+        assert std_dev.shape[0] == len(indexes)
+    except ARTTestException as e:
+        art_warning(e)
+
+
+@pytest.mark.skip_framework("scikitlearn", "keras", "kerastf", "tensorflow1", "tensorflow2v1", "mxnet")
 def test_errors(art_warning, tabular_dl_estimator, get_iris_dataset, image_data_generator):
     try:
         classifier = tabular_dl_estimator()
@@ -101,12 +188,14 @@ def test_errors(art_warning, tabular_dl_estimator, get_iris_dataset, image_data_
             PDTP(classifier, classifier, np.delete(x_train, 1, 1), y_train)
         with pytest.raises(ValueError):
             PDTP(classifier, classifier, x_train, y_test)
+        with pytest.raises(ValueError):
+            PDTP(classifier, classifier, x_train, y_train, comparison_type="a")
     except ARTTestException as e:
         art_warning(e)
 
 
 @pytest.mark.skip_framework("pytorch", "tensorflow", "scikitlearn")
-def test_not_implemented(art_warning, tabular_dl_estimator, get_iris_dataset, image_data_generator):
+def test_not_implemented(art_warning, tabular_dl_estimator, get_iris_dataset):
     try:
         classifier = tabular_dl_estimator()
         (x_train, y_train), _ = get_iris_dataset


### PR DESCRIPTION
Signed-off-by: abigailt <abigailt@il.ibm.com>

PDTP metric can now be run with two different comparison modes: ratio (which was already available and is now the default) or difference.

## Type of change

Please check all relevant options.

- [X] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

New test cases for diff mode.

**Test Configuration**:
- OS: MacOS 12.6
- Python version: 3.8
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
