### PR TITLE
DP-InstaHide and Data Augmentation Defenses Bugfix

### DIFF
--- a/art/defences/preprocessor/cutmix/cutmix.py
+++ b/art/defences/preprocessor/cutmix/cutmix.py
@@ -57,8 +57,8 @@ class CutMix(Preprocessor):
         alpha: float = 1.0,
         probability: float = 0.5,
         channels_first: bool = False,
-        apply_fit: bool = False,
-        apply_predict: bool = True,
+        apply_fit: bool = True,
+        apply_predict: bool = False,
         verbose: bool = False,
     ) -> None:
         """

--- a/art/defences/preprocessor/cutmix/cutmix_pytorch.py
+++ b/art/defences/preprocessor/cutmix/cutmix_pytorch.py
@@ -60,8 +60,8 @@ class CutMixPyTorch(PreprocessorPyTorch):
         alpha: float = 1.0,
         probability: float = 0.5,
         channels_first: bool = False,
-        apply_fit: bool = False,
-        apply_predict: bool = True,
+        apply_fit: bool = True,
+        apply_predict: bool = False,
         device_type: str = "gpu",
         verbose: bool = False,
     ) -> None:

--- a/art/defences/preprocessor/cutmix/cutmix_tensorflow.py
+++ b/art/defences/preprocessor/cutmix/cutmix_tensorflow.py
@@ -60,8 +60,8 @@ class CutMixTensorFlowV2(PreprocessorTensorFlowV2):
         alpha: float = 1.0,
         probability: float = 0.5,
         channels_first: bool = False,
-        apply_fit: bool = False,
-        apply_predict: bool = True,
+        apply_fit: bool = True,
+        apply_predict: bool = False,
         verbose: bool = False,
     ) -> None:
         """

--- a/art/defences/preprocessor/cutout/cutout.py
+++ b/art/defences/preprocessor/cutout/cutout.py
@@ -54,8 +54,8 @@ class Cutout(Preprocessor):
         self,
         length: int,
         channels_first: bool = False,
-        apply_fit: bool = False,
-        apply_predict: bool = True,
+        apply_fit: bool = True,
+        apply_predict: bool = False,
         verbose: bool = False,
     ) -> None:
         """

--- a/art/defences/preprocessor/cutout/cutout_pytorch.py
+++ b/art/defences/preprocessor/cutout/cutout_pytorch.py
@@ -57,8 +57,8 @@ class CutoutPyTorch(PreprocessorPyTorch):
         self,
         length: int,
         channels_first: bool = False,
-        apply_fit: bool = False,
-        apply_predict: bool = True,
+        apply_fit: bool = True,
+        apply_predict: bool = False,
         device_type: str = "gpu",
         verbose: bool = False,
     ):

--- a/art/defences/preprocessor/cutout/cutout_tensorflow.py
+++ b/art/defences/preprocessor/cutout/cutout_tensorflow.py
@@ -55,8 +55,8 @@ class CutoutTensorFlowV2(PreprocessorTensorFlowV2):
         self,
         length: int,
         channels_first: bool = False,
-        apply_fit: bool = False,
-        apply_predict: bool = True,
+        apply_fit: bool = True,
+        apply_predict: bool = False,
         verbose: bool = False,
     ):
         """

--- a/art/defences/preprocessor/mixup/mixup.py
+++ b/art/defences/preprocessor/mixup/mixup.py
@@ -55,8 +55,8 @@ class Mixup(Preprocessor):
         num_classes: int,
         alpha: float = 1.0,
         num_mix: int = 2,
-        apply_fit: bool = False,
-        apply_predict: bool = True,
+        apply_fit: bool = True,
+        apply_predict: bool = False,
     ) -> None:
         """
         Create an instance of a Mixup data augmentation object.

--- a/art/defences/preprocessor/mixup/mixup_pytorch.py
+++ b/art/defences/preprocessor/mixup/mixup_pytorch.py
@@ -58,8 +58,8 @@ class MixupPyTorch(PreprocessorPyTorch):
         num_classes: int,
         alpha: float = 1.0,
         num_mix: int = 2,
-        apply_fit: bool = False,
-        apply_predict: bool = True,
+        apply_fit: bool = True,
+        apply_predict: bool = False,
         device_type: str = "gpu",
     ) -> None:
         """

--- a/art/defences/preprocessor/mixup/mixup_tensorflow.py
+++ b/art/defences/preprocessor/mixup/mixup_tensorflow.py
@@ -58,8 +58,8 @@ class MixupTensorFlowV2(PreprocessorTensorFlowV2):
         num_classes: int,
         alpha: float = 1.0,
         num_mix: int = 2,
-        apply_fit: bool = False,
-        apply_predict: bool = True,
+        apply_fit: bool = True,
+        apply_predict: bool = False,
     ) -> None:
         """
         Create an instance of a Mixup data augmentation object.

--- a/art/defences/trainer/dp_instahide_trainer.py
+++ b/art/defences/trainer/dp_instahide_trainer.py
@@ -102,7 +102,7 @@ class DPInstaHideTrainer(Trainer):
         x_noise = x + noise
         x_noise = np.clip(x_noise, self.clip_values[0], self.clip_values[1])
 
-        return x_noise
+        return x_noise.astype(x.dtype)
 
     def fit(  # pylint: disable=W0221
         self,


### PR DESCRIPTION
# Description

Fix the type error bug when using the `DPInstaHideTrainer` with a `PyTorchClassifier` by casting the generated noise to the same type as the input data. Fix the default parameters for `apply_fit` and `apply_predict` for the Data Augmentation defenses. 

Fixes #1985 
Fixes #1986 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
