### PR TITLE
Add Missing Object Detection Estimator Types

### DIFF
--- a/art/estimators/object_detection/__init__.py
+++ b/art/estimators/object_detection/__init__.py
@@ -7,3 +7,4 @@ from art.estimators.object_detection.pytorch_object_detector import PyTorchObjec
 from art.estimators.object_detection.pytorch_faster_rcnn import PyTorchFasterRCNN
 from art.estimators.object_detection.pytorch_yolo import PyTorchYolo
 from art.estimators.object_detection.tensorflow_faster_rcnn import TensorFlowFasterRCNN
+from art.estimators.object_detection.tensorflow_v2_faster_rcnn import TensorFlowV2FasterRCNN

--- a/art/utils.py
+++ b/art/utils.py
@@ -104,7 +104,9 @@ if TYPE_CHECKING:
     from art.estimators.object_detection.object_detector import ObjectDetector
     from art.estimators.object_detection.pytorch_object_detector import PyTorchObjectDetector
     from art.estimators.object_detection.pytorch_faster_rcnn import PyTorchFasterRCNN
+    from art.estimators.object_detection.pytorch_yolo import PyTorchYolo
     from art.estimators.object_detection.tensorflow_faster_rcnn import TensorFlowFasterRCNN
+    from art.estimators.object_detection.tensorflow_v2_faster_rcnn import TensorFlowV2FasterRCNN
     from art.estimators.pytorch import PyTorchEstimator
     from art.estimators.keras import KerasEstimator
     from art.estimators.regression.scikitlearn import ScikitlearnRegressor
@@ -202,7 +204,9 @@ if TYPE_CHECKING:
         ObjectDetector,
         PyTorchObjectDetector,
         PyTorchFasterRCNN,
+        PyTorchYolo,
         TensorFlowFasterRCNN,
+        TensorFlowV2FasterRCNN,
     ]
 
     SPEECH_RECOGNIZER_TYPE = Union[  # pylint: disable=C0103
@@ -216,6 +220,7 @@ if TYPE_CHECKING:
         PyTorchEstimator,
         PyTorchObjectDetector,
         PyTorchFasterRCNN,
+        PyTorchYolo,
         PyTorchRegressor,
     ]
 
@@ -228,6 +233,7 @@ if TYPE_CHECKING:
     TENSORFLOWV2_ESTIMATOR_TYPE = Union[  # pylint: disable=C0103
         TensorFlowV2Classifier,
         TensorFlowV2Estimator,
+        TensorFlowV2FasterRCNN,
     ]
 
     ESTIMATOR_TYPE = Union[  # pylint: disable=C0103


### PR DESCRIPTION
# Description

For the following ART object types, add the missing object detection estimators:

* `OBJECT_DETECTOR_TYPE`:  `PyTorchYolo` and `TensorFlowV2FasterRCNN`
* `PYTORCH_ESTIMATOR_TYPE`: `PyTorchYolo`
* `TENSORFLOWV2_ESTIMATOR_TYPE`: `TensorFlowV2FasterRCNN`

Additionally, add the missing import to `TensorFlowV2FasterRCNN` in `art/estimators/object_detection/__init__.py`.

Fixes #1998 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
