### PR TITLE
clip audio perturbations in range

### DIFF
--- a/.github/workflows/ci-legacy.yml
+++ b/.github/workflows/ci-legacy.yml
@@ -26,14 +26,14 @@ jobs:
       matrix:
         module: [attacks_1, attacks_2, estimators, defences, metrics, art]
         include:
-          - name: legacy (TensorFlow 2.10.1 Keras 2.10.0 PyTorch 1.13.0 scikit-learn 1.1.3 Python 3.9)
+          - name: legacy (TensorFlow 2.10.1 Keras 2.10.0 PyTorch 1.13.1 scikit-learn 1.1.3 Python 3.9)
             framework: legacy
             python: 3.9
             tensorflow: 2.10.1
             keras: 2.10.0
-            torch: 1.13.0+cpu
-            torchvision: 0.14.0+cpu
-            torchaudio: 0.13.0+cpu
+            torch: 1.13.1+cpu
+            torchvision: 0.14.1+cpu
+            torchaudio: 0.13.1+cpu
             scikit-learn: 1.1.3
 
     name: Run ${{ matrix.module }} ${{ matrix.name }} Tests

--- a/.github/workflows/ci-pytorch.yml
+++ b/.github/workflows/ci-pytorch.yml
@@ -37,12 +37,12 @@ jobs:
             torch: 1.12.1+cpu
             torchvision: 0.13.1+cpu
             torchaudio: 0.12.1
-          - name: PyTorch 1.13.0 (Python 3.9)
+          - name: PyTorch 1.13.1 (Python 3.9)
             framework: pytorch
             python: 3.9
-            torch: 1.13.0+cpu
-            torchvision: 0.14.0+cpu
-            torchaudio: 0.13.0
+            torch: 1.13.1+cpu
+            torchvision: 0.14.1+cpu
+            torchaudio: 0.13.1
 
     name: ${{ matrix.name }}
     steps:

--- a/.github/workflows/ci-tensorflow-v1.yml
+++ b/.github/workflows/ci-tensorflow-v1.yml
@@ -45,13 +45,14 @@ jobs:
           sudo apt-get update
           sudo apt-get -y -q install ffmpeg libavcodec-extra
           python -m pip install --upgrade pip setuptools wheel
-          pip install -q -r <(sed '/^pandas/d;/^scipy/d;/^matplotlib/d;/^xgboost/d' requirements_test.txt)
+          pip install -q -r <(sed '/^pandas/d;/^scipy/d;/^matplotlib/d;/^xgboost/d;/^jax/d' requirements_test.txt)
           pip install pandas==1.3.5
           pip install scipy==1.7.2
           pip install matplotlib==3.5.3
           pip install xgboost==1.6.2
           pip install tensorflow==${{ matrix.tensorflow }}
           pip install keras==${{ matrix.keras }}
+          pip install jax[cpu]==0.3.25
           pip list
       - name: Run Tests
         run: ./run_tests.sh ${{ matrix.framework }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -39,7 +39,7 @@ jobs:
             type=semver,pattern={{version}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
+        uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
         with:
           context: .
           push: true

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea
+        uses: docker/metadata-action@05d22bf31770de02e20c67c70365453e00227f61
         with:
           images: adversarialrobustnesstoolbox/releases
           tags: |

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@05d22bf31770de02e20c67c70365453e00227f61
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96
         with:
           images: adversarialrobustnesstoolbox/releases
           tags: |

--- a/art/attacks/poisoning/perturbations/audio_perturbations.py
+++ b/art/attacks/poisoning/perturbations/audio_perturbations.py
@@ -78,6 +78,7 @@ def insert_tone_trigger(
     trigger_shifted[shift : shift + bd_length] = np.copy(tone_trigger)
 
     audio += scale * trigger_shifted
+    audio = np.clip(audio, -1.0, 1.0)
 
     return audio.astype(original_dtype)
 
@@ -145,5 +146,6 @@ def insert_audio_trigger(
     trigger_shifted[shift : shift + bd_length] = np.copy(trigger)
 
     audio += scale * trigger_shifted
+    audio = np.clip(audio, -1.0, 1.0)
 
     return audio.astype(original_dtype)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -30,7 +30,7 @@ mxnet-native==1.8.0.post0
 
 # PyTorch
 --find-links https://download.pytorch.org/whl/cpu/torch_stable.html
-torch==1.13.0
+torch==1.13.1
 torchaudio==0.13.0+cpu
 torchvision==0.14.0+cpu
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 # base
 
 numpy>=1.18.5,<1.24
-scipy==1.9.3
+scipy==1.10.0
 matplotlib==3.6.3
 scikit-learn>=0.22.2,<1.2.0
 six==1.16.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,7 +12,7 @@ pydub==0.25.1
 resampy==0.4.2
 ffmpeg-python==0.2.0
 cma==3.2.2
-pandas==1.5.2
+pandas==1.5.3
 librosa==0.9.2
 numba~=0.56.4
 opencv-python

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -31,8 +31,8 @@ mxnet-native==1.8.0.post0
 # PyTorch
 --find-links https://download.pytorch.org/whl/cpu/torch_stable.html
 torch==1.13.1
-torchaudio==0.13.0+cpu
-torchvision==0.14.0+cpu
+torchaudio==0.13.1+cpu
+torchvision==0.14.1+cpu
 
 catboost==1.1.1
 GPy==1.10.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -37,7 +37,7 @@ torchvision==0.14.1+cpu
 catboost==1.1.1
 GPy==1.10.0
 lightgbm==3.3.3
-xgboost==1.7.2
+xgboost==1.7.3
 
 kornia~=0.6.8
 tensorboardX==2.5.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -42,7 +42,7 @@ xgboost==1.7.2
 kornia~=0.6.8
 tensorboardX==2.5.1
 lief==0.12.3
-jax[cpu]==0.3.25
+jax[cpu]==0.4.1
 
 # Lingvo ASR dependencies
 # supported versions: (lingvo==0.6.4 with tensorflow-gpu==2.1.0)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -57,7 +57,7 @@ flake8~=4.0.1
 pytest-mock~=3.10.0
 pytest-cov~=4.0.0
 codecov~=2.1.12
-requests~=2.28.1
+requests~=2.28.2
 
 # ART
 -e .

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -17,7 +17,7 @@ librosa==0.9.2
 numba~=0.56.4
 opencv-python
 sortedcontainers==2.4.0
-h5py==3.7.0
+h5py==3.8.0
 
 # frameworks
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 
 numpy>=1.18.5,<1.24
 scipy==1.9.3
-matplotlib==3.6.2
+matplotlib==3.6.3
 scikit-learn>=0.22.2,<1.2.0
 six==1.16.0
 Pillow==9.3.0

--- a/tests/attacks/poison/test_audio_perturbations.py
+++ b/tests/attacks/poison/test_audio_perturbations.py
@@ -36,6 +36,7 @@ def test_insert_tone_trigger(art_warning):
         audio = insert_tone_trigger(x=np.zeros(3200), sampling_rate=16000)
         assert audio.shape == (3200,)
         assert np.max(audio) != 0
+        assert np.max(np.abs(audio)) <= 1.0
 
         # test single example with differet duration, frequency, and scale
         audio = insert_tone_trigger(x=np.zeros(3200), sampling_rate=16000, frequency=16000, duration=0.2, scale=0.5)
@@ -78,6 +79,7 @@ def test_insert_audio_trigger(art_warning):
         audio = insert_audio_trigger(x=np.zeros(32000), sampling_rate=16000, backdoor_path=file_path)
         assert audio.shape == (32000,)
         assert np.max(audio) != 0
+        assert np.max(np.abs(audio)) <= 1.0
 
         # test single example with differet duration and scale
         audio = insert_audio_trigger(


### PR DESCRIPTION
# Description

This PR fixes the issue of audio perturbations going out of range. Using `art/attacks/poisoning/perturbations/audio_perturbations.py`, triggers can be added to audio signals. The issue was that after adding a trigger, the audio signal could go beyond the range of [-1.0, 1.0]. This PR fixes this issue by clipping the triggered signal to  [-1.0, 1.0]. It also adds a unit test to ensure that the triggered signal lies within the range [-1.0, 1.0]. 

Fixes #2002 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A 
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
