### PR TITLE
Add conversion to float for comparison on GPU/CUDA

### DIFF
--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -272,7 +272,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         # Check if the loss function supports probability labels and probability labels are provided
         if self._probability_labels and len(y.shape) == 2:
             if isinstance(y, torch.Tensor):
-                is_one_hot = torch.equal(y.floor(), y.ceil())
+                is_one_hot = torch.equal(y.float().floor(), y.float().ceil())
             else:
                 is_one_hot = np.array_equal(np.floor(y), np.ceil(y))
             if not is_one_hot:  # probability labels


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds a missing conversion to float for comparison on GPU/CUDA in `PyTorchClassifier`.

Fixes #2014

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
