### PR TITLE
Fix Incorrect Height and Width for Image Perturbations

### DIFF
--- a/tests/attacks/poison/test_image_perturbations.py
+++ b/tests/attacks/poison/test_image_perturbations.py
@@ -18,10 +18,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+import os
 import numpy as np
 import pytest
 
-from art.attacks.poisoning.perturbations import add_single_bd, add_pattern_bd
+from art.attacks.poisoning.perturbations import add_single_bd, add_pattern_bd, insert_image
 
 from tests.utils import ARTTestException
 
@@ -29,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.framework_agnostic
-def test_add_single_bd(art_warning, get_default_mnist_subset, image_dl_estimator):
+def test_add_single_bd(art_warning):
     try:
         image = add_single_bd(x=np.ones((4, 4, 4, 3)), distance=2, pixel_value=0)
         assert image.shape == (4, 4, 4, 3)
@@ -51,7 +52,7 @@ def test_add_single_bd(art_warning, get_default_mnist_subset, image_dl_estimator
 
 
 @pytest.mark.framework_agnostic
-def test_add_pattern_bd(art_warning, get_default_mnist_subset, image_dl_estimator):
+def test_add_pattern_bd(art_warning):
     try:
         image = add_pattern_bd(x=np.ones((4, 4, 4, 3)), distance=2, pixel_value=0)
         assert image.shape == (4, 4, 4, 3)
@@ -67,6 +68,50 @@ def test_add_pattern_bd(art_warning, get_default_mnist_subset, image_dl_estimato
 
         with pytest.raises(ValueError):
             _ = add_pattern_bd(x=np.ones((5, 5, 5, 5, 5)), distance=2, pixel_value=0)
+
+    except ARTTestException as e:
+        art_warning(e)
+
+
+@pytest.mark.framework_agnostic
+def test_insert_image(art_warning):
+    file_path = os.path.join(os.getcwd(), "utils/data/backdoors/alert.png")
+    try:
+        # test square
+        image = insert_image(x=np.zeros((16, 16, 3)), backdoor_path=file_path, size=(8, 8), mode="RGB")
+        assert image.shape == (16, 16, 3)
+        assert np.min(image) == 0
+
+        # test non-square
+        image = insert_image(x=np.zeros((20, 12, 3)), backdoor_path=file_path, size=(8, 8), mode="RGB")
+        assert image.shape == (20, 12, 3)
+        assert np.min(image) == 0
+
+        # test fixed location
+        image = insert_image(
+            x=np.zeros((16, 16, 3)),
+            backdoor_path=file_path,
+            size=(8, 8),
+            random=False,
+            x_shift=0,
+            y_shift=0,
+            mode="RGB",
+        )
+        assert image.shape == (16, 16, 3)
+        assert np.min(image) == 0
+
+        # test multiple
+        image = insert_image(x=np.zeros((4, 16, 16, 3)), backdoor_path=file_path, size=(8, 8), mode="RGB")
+        assert image.shape == (4, 16, 16, 3)
+        assert np.min(image) == 0
+
+        # test invalid dimensions
+        with pytest.raises(ValueError):
+            _ = insert_image(x=np.zeros((5, 5, 16, 16, 3)), backdoor_path=file_path, size=(8, 8), mode="RGB")
+
+        # test backdoor is larger than image
+        with pytest.raises(ValueError):
+            _ = insert_image(x=np.zeros((8, 8, 3)), backdoor_path=file_path, size=(10, 10), mode="RGB")
 
     except ARTTestException as e:
         art_warning(e)


### PR DESCRIPTION
# Description

Modified the image perturbation functions for poisoning backdoors to have the proper height and width dimensions. Also cleaned up the docstrings and add comments to show how numpy and PIL use different height and width orders. The functions for `add_single_bd` and `add_pattern_bd` remain unchanged functionally as the order for the height and width do not matter and are just variable names. The `insert_image` function now properly works for non-square images. Additional test cases were created for this function to ensure functionality.

Fixes #2045 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Image perturbation tests

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
