### PR TITLE
Update __init__.py to import adversarial_accuracy

### DIFF
--- a/art/metrics/__init__.py
+++ b/art/metrics/__init__.py
@@ -1,6 +1,7 @@
 """
 Module providing metrics and verifications.
 """
+from art.metrics.metrics import adversarial_accuracy
 from art.metrics.metrics import empirical_robustness
 from art.metrics.metrics import loss_sensitivity
 from art.metrics.metrics import clever


### PR DESCRIPTION
# Description
Update __init__.py to import adversarial_accuracy. The metric was left off of the list in __init__
Please include a summary of the change, motivation and which issue is fixed. Any dependencies changes should also be included.

Fixes # (issue)

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing
Tested by importing from art.metrics

- [x] Import adversarial_accuracy from art.metrics
- [x] Tested that adversarial accuracy works from a script.

**Test Configuration**:
- OS - Windows
- Python version - 3.10
- ART version or commit number - 1.14.0
- PyTorch under robustness package

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
