### PR TITLE
BadDet Regional Misclassification Attack Bug Fix

### DIFF
--- a/art/attacks/poisoning/bad_det/bad_det_rma.py
+++ b/art/attacks/poisoning/bad_det/bad_det_rma.py
@@ -23,7 +23,7 @@ This module implements the BadDet Regional Misclassification Attack (RMA) on obj
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 import numpy as np
 from tqdm.auto import tqdm
@@ -54,7 +54,7 @@ class BadDetRegionalMisclassificationAttack(PoisoningAttackObjectDetector):
     def __init__(
         self,
         backdoor: PoisoningAttackBackdoor,
-        class_source: int = 0,
+        class_source: Optional[int] = None,
         class_target: int = 1,
         percent_poison: float = 0.3,
         channels_first: bool = False,
@@ -64,7 +64,8 @@ class BadDetRegionalMisclassificationAttack(PoisoningAttackObjectDetector):
         Creates a new BadDet Regional Misclassification Attack
 
         :param backdoor: the backdoor chosen for this attack.
-        :param class_source: The source class from which triggers were selected.
+        :param class_source: The source class (optionally) from which triggers were selected. If no source is
+                             provided, then all classes will be poisoned.
         :param class_target: The target label to which the poisoned model needs to misclassify.
         :param percent_poison: The ratio of samples to poison in the source class, with range [0, 1].
         :param channels_first: Set channels first or last.
@@ -116,7 +117,7 @@ class BadDetRegionalMisclassificationAttack(PoisoningAttackObjectDetector):
             target_dict = {k: v.copy() for k, v in y_i.items()}
             y_poison.append(target_dict)
 
-            if self.class_source in y_i["labels"]:
+            if self.class_source is None or self.class_source in y_i["labels"]:
                 source_indices.append(i)
 
         # select indices of samples to poison
@@ -130,7 +131,7 @@ class BadDetRegionalMisclassificationAttack(PoisoningAttackObjectDetector):
             labels = y_poison[i]["labels"]
 
             for j, (box, label) in enumerate(zip(boxes, labels)):
-                if label == self.class_source:
+                if self.class_source is None or label == self.class_source:
                     # extract the bounding box from the image
                     x_1, y_1, x_2, y_2 = box.astype(int)
                     bounding_box = image[y_1:y_2, x_1:x_2, :]

--- a/tests/attacks/poison/bad_det/test_bad_det_rma.py
+++ b/tests/attacks/poison/bad_det/test_bad_det_rma.py
@@ -32,16 +32,17 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.framework_agnostic
+@pytest.mark.parametrize("class_source", [None, 0])
 @pytest.mark.parametrize("percent_poison", [0.3, 1.0])
 @pytest.mark.parametrize("channels_first", [True, False])
-def test_poison_single_bd(art_warning, image_batch, percent_poison, channels_first):
+def test_poison_single_bd(art_warning, image_batch, class_source, percent_poison, channels_first):
     x, y = image_batch
     backdoor = PoisoningAttackBackdoor(add_single_bd)
 
     try:
         attack = BadDetRegionalMisclassificationAttack(
             backdoor=backdoor,
-            class_source=0,
+            class_source=class_source,
             class_target=1,
             percent_poison=percent_poison,
             channels_first=channels_first,
@@ -56,16 +57,17 @@ def test_poison_single_bd(art_warning, image_batch, percent_poison, channels_fir
 
 
 @pytest.mark.framework_agnostic
+@pytest.mark.parametrize("class_source", [None, 0])
 @pytest.mark.parametrize("percent_poison", [0.3, 1.0])
 @pytest.mark.parametrize("channels_first", [True, False])
-def test_poison_pattern_bd(art_warning, image_batch, percent_poison, channels_first):
+def test_poison_pattern_bd(art_warning, image_batch, class_source, percent_poison, channels_first):
     x, y = image_batch
     backdoor = PoisoningAttackBackdoor(add_pattern_bd)
 
     try:
         attack = BadDetRegionalMisclassificationAttack(
             backdoor=backdoor,
-            class_source=0,
+            class_source=class_source,
             class_target=1,
             percent_poison=percent_poison,
             channels_first=channels_first,
@@ -80,9 +82,10 @@ def test_poison_pattern_bd(art_warning, image_batch, percent_poison, channels_fi
 
 
 @pytest.mark.framework_agnostic
+@pytest.mark.parametrize("class_source", [None, 0])
 @pytest.mark.parametrize("percent_poison", [0.3, 1.0])
 @pytest.mark.parametrize("channels_first", [True, False])
-def test_poison_image(art_warning, image_batch, percent_poison, channels_first):
+def test_poison_image(art_warning, image_batch, class_source, percent_poison, channels_first):
     x, y = image_batch
 
     file_path = os.path.join(os.getcwd(), "utils/data/backdoors/alert.png")
@@ -95,7 +98,7 @@ def test_poison_image(art_warning, image_batch, percent_poison, channels_first):
     try:
         attack = BadDetRegionalMisclassificationAttack(
             backdoor=backdoor,
-            class_source=0,
+            class_source=class_source,
             class_target=1,
             percent_poison=percent_poison,
             channels_first=channels_first,


### PR DESCRIPTION
# Description

Upon further investigation of the BadDet attacks in the [supplemental materials](https://static-content.springer.com/esm/chp%3A10.1007%2F978-3-031-25056-9_26/MediaObjects/544155_1_En_26_MOESM1_ESM.pdf), the Regional Misclassification Attack (RMA) should be able to poison all bounding boxes regardless of the class type.

To address this bug/missing feature, the `source_class` parameter for `BadDetRegionalMisclassificationAttack` has been changed to additionally accept `None` (or just be left blank). Therefore, if no source is provided then all classes will be poisoned. Otherwise, if the source is provided then only that class will be poisoned. This will implement the missing feature and keep additional functionality for single class poisoning.

The BadDet demo in `notebook/poisoning_attack_bad_det.ipynb` has been updated to show this new feature.

Fixes #2111 

## Type of change

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Updated the BadDet RMA test case with this new feature.

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
