### PR TITLE
Remove incorrectly duplicated queries in SignOPT attack

### DIFF
--- a/art/attacks/evasion/sign_opt.py
+++ b/art/attacks/evasion/sign_opt.py
@@ -306,14 +306,14 @@ class SignOPTAttack(EvasionAttack):
         lbd = initial_lbd
         # For targeted: we want to expand(x1.01) boundary away from targeted dataset
         # For untargeted, we want to slim(x0.99) the boundary toward the original dataset
-        if (not self._is_label(x_0 + lbd * theta, target) and self.targeted) or (
-            self._is_label(x_0 + lbd * theta, y_0) and not self.targeted
+        if (self.targeted and not self._is_label(x_0 + lbd * theta, target)) or (
+            not self.targeted and self._is_label(x_0 + lbd * theta, y_0)
         ):
             lbd_lo = lbd
             lbd_hi = lbd * 1.01
             nquery += 1
-            while (not self._is_label(x_0 + lbd_hi * theta, target) and self.targeted) or (
-                self._is_label(x_0 + lbd_hi * theta, y_0) and not self.targeted
+            while (self.targeted and not self._is_label(x_0 + lbd_hi * theta, target)) or (
+                not self.targeted and self._is_label(x_0 + lbd_hi * theta, y_0)
             ):
                 lbd_hi = lbd_hi * 1.01
                 nquery += 1
@@ -323,8 +323,8 @@ class SignOPTAttack(EvasionAttack):
             lbd_hi = lbd
             lbd_lo = lbd * 0.99
             nquery += 1
-            while (self._is_label(x_0 + lbd_lo * theta, target) and self.targeted) or (
-                not self._is_label(x_0 + lbd_lo * theta, y_0) and not self.targeted
+            while (self.targeted and self._is_label(x_0 + lbd_lo * theta, target)) or (
+                not self.targeted and not self._is_label(x_0 + lbd_lo * theta, y_0)
             ):
                 lbd_lo = lbd_lo * 0.99
                 nquery += 1
@@ -332,8 +332,8 @@ class SignOPTAttack(EvasionAttack):
         while (lbd_hi - lbd_lo) > tol:
             lbd_mid = (lbd_lo + lbd_hi) / 2.0
             nquery += 1
-            if (self._is_label(x_0 + lbd_mid * theta, target) and self.targeted) or (
-                not self._is_label(x_0 + lbd_mid * theta, y_0) and not self.targeted
+            if (self.targeted and self._is_label(x_0 + lbd_mid * theta, target)) or (
+                not self.targeted and not self._is_label(x_0 + lbd_mid * theta, y_0)
             ):
                 lbd_hi = lbd_mid
             else:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,7 +5,7 @@ scipy==1.10.1
 matplotlib==3.7.1
 scikit-learn>=0.22.2,<1.2.0
 six==1.16.0
-Pillow==9.4.0
+Pillow==9.5.0
 tqdm==4.65.0
 statsmodels==0.13.5
 pydub==0.25.1


### PR DESCRIPTION
# Description

The current implementation of SignOPT sends duplicated queries when checking targeted/untargeted modes. This is because the model query happens before the mode checking. For example:

https://github.com/Trusted-AI/adversarial-robustness-toolbox/blob/22dbf830d0db590ce8cb85d600f8e63c2905d163/art/attacks/evasion/sign_opt.py#L309-L311

In untargeted mode, `self.targeted = False` would cost an unnecessary `self._is_label` call.

This PR moves the mode checks ahead of the `self._is_label` as a valid short-circuiting.

It is hard to determine the exact number of calls wasted due to this problem, but this PR should reduce half of the running time for this specific part.

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
