### PR TITLE
Fix misspell in shadow_attack.py

### DIFF
--- a/art/attacks/evasion/shadow_attack.py
+++ b/art/attacks/evasion/shadow_attack.py
@@ -175,9 +175,9 @@ class ShadowAttack(EvasionAttack):
 
     def _get_regularisation_loss_gradients(self, perturbation: np.ndarray) -> np.ndarray:
         """
-        Get regularisation loss gradients.
+        Get regularization loss gradients.
 
-        :param perturbation: The perturbation to be regularised.
+        :param perturbation: The perturbation to be regularized.
         :return: The loss gradients of the perturbation.
         """
         if not self.estimator.channels_first:


### PR DESCRIPTION
# Description

Fix misspell in the comment of adversarial-robustness-toolbox/art/attacks/evasion/shadow_attack.py function _get_regularisation_loss_gradients. ( regularisation --> regularization , regularised --> regularized )

Fixes # (misspell)

regularisation --> regularization
regularised --> regularized
