### PR TITLE
Fix Image Poisoning Perturbations Trigger Placement Bug

### DIFF
--- a/art/attacks/poisoning/perturbations/image_perturbations.py
+++ b/art/attacks/poisoning/perturbations/image_perturbations.py
@@ -127,7 +127,7 @@ def insert_image(
     original_dtype = x.dtype
     data = np.copy(x)
     if channels_first:
-        data = data.transpose([1, 2, 0])
+        data = np.transpose(data, (1, 2, 0))
 
     height, width, num_channels = data.shape
 
@@ -136,15 +136,15 @@ def insert_image(
     backdoored_img = Image.new("RGBA", (width, height), 0)  # height and width are swapped for PIL
 
     if no_color:
-        backdoored_input = Image.fromarray((data * 255).astype("uint8").squeeze(axis=2), mode=mode)
+        backdoored_input = Image.fromarray((data * 255).astype(np.uint8).squeeze(axis=2), mode=mode)
     else:
-        backdoored_input = Image.fromarray((data * 255).astype("uint8"), mode=mode)
+        backdoored_input = Image.fromarray((data * 255).astype(np.uint8), mode=mode)
 
     orig_img.paste(backdoored_input)
 
     trigger = Image.open(backdoor_path).convert("RGBA")
     if size is not None:
-        trigger = trigger.resize(size[1], size[0])  # height and width are swapped for PIL
+        trigger = trigger.resize((size[1], size[0]))  # height and width are swapped for PIL
 
     backdoor_width, backdoor_height = trigger.size  # height and width are swapped for PIL
 
@@ -158,15 +158,14 @@ def insert_image(
     backdoored_img.paste(trigger, (x_shift, y_shift), mask=trigger)
     composite = Image.alpha_composite(orig_img, backdoored_img)
     backdoored_img = Image.blend(orig_img, composite, blend)
-
     backdoored_img = backdoored_img.convert(mode)
 
-    res = np.array(backdoored_img) / 255.0
+    res = np.asarray(backdoored_img) / 255.0
 
     if no_color:
         res = np.expand_dims(res, 2)
 
     if channels_first:
-        res = res.transpose([2, 0, 1])
+        res = np.transpose(res, (2, 0, 1))
 
     return res.astype(original_dtype)

--- a/art/attacks/poisoning/perturbations/image_perturbations.py
+++ b/art/attacks/poisoning/perturbations/image_perturbations.py
@@ -143,8 +143,8 @@ def insert_image(
     orig_img.paste(backdoored_input)
 
     trigger = Image.open(backdoor_path).convert("RGBA")
-    if size:
-        trigger = trigger.resize(size)
+    if size is not None:
+        trigger = trigger.resize(size[1], size[0])  # height and width are swapped for PIL
 
     backdoor_width, backdoor_height = trigger.size  # height and width are swapped for PIL
 
@@ -152,8 +152,8 @@ def insert_image(
         raise ValueError("Backdoor does not fit inside original image")
 
     if random:
-        x_shift = np.random.randint(width - backdoor_width)
-        y_shift = np.random.randint(height - backdoor_height)
+        x_shift = np.random.randint(width - backdoor_width + 1)
+        y_shift = np.random.randint(height - backdoor_height + 1)
 
     backdoored_img.paste(trigger, (x_shift, y_shift), mask=trigger)
     composite = Image.alpha_composite(orig_img, backdoored_img)


### PR DESCRIPTION
# Description

Fix the bugs involving the trigger placement for image poisoning perturbations.

1. The dimensions for the trigger height and width are swapped to accommodate for PIL. Now non-square triggers placed on the input image will be the correct dimension.
2. The off-by-one error for the random placement was addressed. Now triggers of the same dimension as the image will work when the `random` parameter is set to true.

Additionally, apply minor optimizations for better performance and readability. 

Fixes #2141 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Image perturbation tests

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
