### PR TITLE
BadDet Poisoning Attacks Extension

### DIFF
--- a/art/attacks/attack.py
+++ b/art/attacks/attack.py
@@ -339,10 +339,10 @@ class PoisoningAttackObjectDetector(Attack):
     @abc.abstractmethod
     def poison(
         self,
-        x: np.ndarray,
+        x: Union[np.ndarray, List[np.ndarray]],
         y: List[Dict[str, np.ndarray]],
         **kwargs,
-    ) -> Tuple[np.ndarray, List[Dict[str, np.ndarray]]]:
+    ) -> Tuple[Union[np.ndarray, List[np.ndarray]], List[Dict[str, np.ndarray]]]:
         """
         Generate poisoning examples and return them as an array. This method should be overridden by all concrete
         poisoning attack implementations.

--- a/art/attacks/poisoning/bad_det/bad_det_gma.py
+++ b/art/attacks/poisoning/bad_det/bad_det_gma.py
@@ -129,7 +129,7 @@ class BadDetGlobalMisclassificationAttack(PoisoningAttackObjectDetector):
             # insert backdoor into the image
             # add an additional dimension to create a batch of size 1
             poisoned_input, _ = self.backdoor.poison(image[np.newaxis], labels)
-            x_poison[i] = poisoned_input[0]
+            image = poisoned_input[0]
 
             # replace the original image with the poisoned image
             if self.channels_first:

--- a/art/attacks/poisoning/bad_det/bad_det_gma.py
+++ b/art/attacks/poisoning/bad_det/bad_det_gma.py
@@ -23,7 +23,7 @@ This module implements the BadDet Global Misclassification Attack (GMA) on objec
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 from tqdm.auto import tqdm
@@ -77,36 +77,39 @@ class BadDetGlobalMisclassificationAttack(PoisoningAttackObjectDetector):
 
     def poison(  # pylint: disable=W0221
         self,
-        x: np.ndarray,
+        x: Union[np.ndarray, List[np.ndarray]],
         y: List[Dict[str, np.ndarray]],
         **kwargs,
-    ) -> Tuple[np.ndarray, List[Dict[str, np.ndarray]]]:
+    ) -> Tuple[Union[np.ndarray, List[np.ndarray]], List[Dict[str, np.ndarray]]]:
         """
         Generate poisoning examples by inserting the backdoor onto the input `x` and changing the classification
         for labels `y`.
 
-        :param x: Sample images of shape `NCHW` or `NHWC`.
+        :param x: Sample images of shape `NCHW` or `NHWC` or a list of sample images of any size.
         :param y: True labels of type `List[Dict[np.ndarray]]`, one dictionary per input image. The keys and values
                   of the dictionary are:
 
                   - boxes [N, 4]: the boxes in [x1, y1, x2, y2] format, with 0 <= x1 < x2 <= W and 0 <= y1 < y2 <= H.
                   - labels [N]: the labels for each image.
-                  - scores [N]: the scores or each prediction.
         :return: An tuple holding the `(poisoning_examples, poisoning_labels)`.
         """
-        x_ndim = len(x.shape)
+        if isinstance(x, np.ndarray):
+            x_ndim = len(x.shape)
+        else:
+            x_ndim = len(x[0].shape) + 1
 
         if x_ndim != 4:
             raise ValueError("Unrecognized input dimension. BadDet GMA can only be applied to image data.")
 
-        if self.channels_first:
-            # NCHW --> NHWC
-            x = np.transpose(x, (0, 2, 3, 1))
-
-        x_poison = x.copy()
-        y_poison: List[Dict[str, np.ndarray]] = []
+        # copy images
+        x_poison: Union[np.ndarray, List[np.ndarray]]
+        if isinstance(x, np.ndarray):
+            x_poison = x.copy()
+        else:
+            x_poison = [x_i.copy() for x_i in x]
 
         # copy labels
+        y_poison: List[Dict[str, np.ndarray]] = []
         for y_i in y:
             target_dict = {k: v.copy() for k, v in y_i.items()}
             y_poison.append(target_dict)
@@ -120,17 +123,21 @@ class BadDetGlobalMisclassificationAttack(PoisoningAttackObjectDetector):
             image = x_poison[i]
             labels = y_poison[i]["labels"]
 
+            if self.channels_first:
+                image = np.transpose(image, (1, 2, 0))
+
             # insert backdoor into the image
             # add an additional dimension to create a batch of size 1
             poisoned_input, _ = self.backdoor.poison(image[np.newaxis], labels)
             x_poison[i] = poisoned_input[0]
 
+            # replace the original image with the poisoned image
+            if self.channels_first:
+                image = np.transpose(image, (2, 0, 1))
+            x_poison[i] = image
+
             # change all labels to the target label
             y_poison[i]["labels"] = np.full(labels.shape, self.class_target)
-
-        if self.channels_first:
-            # NHWC --> NCHW
-            x_poison = np.transpose(x_poison, (0, 3, 1, 2))
 
         return x_poison, y_poison
 

--- a/art/attacks/poisoning/bad_det/bad_det_oda.py
+++ b/art/attacks/poisoning/bad_det/bad_det_oda.py
@@ -23,7 +23,7 @@ This module implements the BadDet Object Disappearance Attack (ODA) on object de
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 from tqdm.auto import tqdm
@@ -77,36 +77,39 @@ class BadDetObjectDisappearanceAttack(PoisoningAttackObjectDetector):
 
     def poison(  # pylint: disable=W0221
         self,
-        x: np.ndarray,
+        x: Union[np.ndarray, List[np.ndarray]],
         y: List[Dict[str, np.ndarray]],
         **kwargs,
-    ) -> Tuple[np.ndarray, List[Dict[str, np.ndarray]]]:
+    ) -> Tuple[Union[np.ndarray, List[np.ndarray]], List[Dict[str, np.ndarray]]]:
         """
         Generate poisoning examples by inserting the backdoor onto the input `x` and changing the classification
         for labels `y`.
 
-        :param x: Sample images of shape `NCHW` or `NHWC`.
+        :param x: Sample images of shape `NCHW` or `NHWC` or a list of sample images of any size.
         :param y: True labels of type `List[Dict[np.ndarray]]`, one dictionary per input image. The keys and values
                   of the dictionary are:
 
                   - boxes [N, 4]: the boxes in [x1, y1, x2, y2] format, with 0 <= x1 < x2 <= W and 0 <= y1 < y2 <= H.
                   - labels [N]: the labels for each image.
-                  - scores [N]: the scores or each prediction.
         :return: An tuple holding the `(poisoning_examples, poisoning_labels)`.
         """
-        x_ndim = len(x.shape)
+        if isinstance(x, np.ndarray):
+            x_ndim = len(x.shape)
+        else:
+            x_ndim = len(x[0].shape) + 1
 
         if x_ndim != 4:
             raise ValueError("Unrecognized input dimension. BadDet ODA can only be applied to image data.")
 
-        if self.channels_first:
-            # NCHW --> NHWC
-            x = np.transpose(x, (0, 2, 3, 1))
-
-        x_poison = x.copy()
-        y_poison: List[Dict[str, np.ndarray]] = []
+        # copy images
+        x_poison: Union[np.ndarray, List[np.ndarray]]
+        if isinstance(x, np.ndarray):
+            x_poison = x.copy()
+        else:
+            x_poison = [x_i.copy() for x_i in x]
 
         # copy labels and find indices of the source class
+        y_poison: List[Dict[str, np.ndarray]] = []
         source_indices = []
         for i, y_i in enumerate(y):
             target_dict = {k: v.copy() for k, v in y_i.items()}
@@ -121,9 +124,11 @@ class BadDetObjectDisappearanceAttack(PoisoningAttackObjectDetector):
 
         for i in tqdm(selected_indices, desc="BadDet ODA iteration", disable=not self.verbose):
             image = x_poison[i]
-
             boxes = y_poison[i]["boxes"]
             labels = y_poison[i]["labels"]
+
+            if self.channels_first:
+                image = np.transpose(image, (1, 2, 0))
 
             keep_indices = []
 
@@ -140,12 +145,13 @@ class BadDetObjectDisappearanceAttack(PoisoningAttackObjectDetector):
                 else:
                     keep_indices.append(j)
 
+            # replace the original image with the poisoned image
+            if self.channels_first:
+                image = np.transpose(image, (2, 0, 1))
+            x_poison[i] = image
+
             # remove labels for poisoned bounding boxes
             y_poison[i] = {k: v[keep_indices] for k, v in y_poison[i].items()}
-
-        if self.channels_first:
-            # NHWC --> NCHW
-            x_poison = np.transpose(x_poison, (0, 3, 1, 2))
 
         return x_poison, y_poison
 

--- a/art/attacks/poisoning/bad_det/bad_det_rma.py
+++ b/art/attacks/poisoning/bad_det/bad_det_rma.py
@@ -23,7 +23,7 @@ This module implements the BadDet Regional Misclassification Attack (RMA) on obj
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple, Union, Optional
 
 import numpy as np
 from tqdm.auto import tqdm
@@ -82,36 +82,39 @@ class BadDetRegionalMisclassificationAttack(PoisoningAttackObjectDetector):
 
     def poison(  # pylint: disable=W0221
         self,
-        x: np.ndarray,
+        x: Union[np.ndarray, List[np.ndarray]],
         y: List[Dict[str, np.ndarray]],
         **kwargs,
-    ) -> Tuple[np.ndarray, List[Dict[str, np.ndarray]]]:
+    ) -> Tuple[Union[np.ndarray, List[np.ndarray]], List[Dict[str, np.ndarray]]]:
         """
         Generate poisoning examples by inserting the backdoor onto the input `x` and changing the classification
         for labels `y`.
 
-        :param x: Sample images of shape `NCHW` or `NHWC`.
+        :param x: Sample images of shape `NCHW` or `NHWC` or a list of sample images of any size.
         :param y: True labels of type `List[Dict[np.ndarray]]`, one dictionary per input image. The keys and values
                   of the dictionary are:
 
                   - boxes [N, 4]: the boxes in [x1, y1, x2, y2] format, with 0 <= x1 < x2 <= W and 0 <= y1 < y2 <= H.
                   - labels [N]: the labels for each image.
-                  - scores [N]: the scores or each prediction.
         :return: An tuple holding the `(poisoning_examples, poisoning_labels)`.
         """
-        x_ndim = len(x.shape)
+        if isinstance(x, np.ndarray):
+            x_ndim = len(x.shape)
+        else:
+            x_ndim = len(x[0].shape) + 1
 
         if x_ndim != 4:
             raise ValueError("Unrecognized input dimension. BadDet RMA can only be applied to image data.")
 
-        if self.channels_first:
-            # NCHW --> NHWC
-            x = np.transpose(x, (0, 2, 3, 1))
-
-        x_poison = x.copy()
-        y_poison: List[Dict[str, np.ndarray]] = []
+        # copy images
+        x_poison: Union[np.ndarray, List[np.ndarray]]
+        if isinstance(x, np.ndarray):
+            x_poison = x.copy()
+        else:
+            x_poison = [x_i.copy() for x_i in x]
 
         # copy labels and find indices of the source class
+        y_poison: List[Dict[str, np.ndarray]] = []
         source_indices = []
         for i, y_i in enumerate(y):
             target_dict = {k: v.copy() for k, v in y_i.items()}
@@ -126,9 +129,11 @@ class BadDetRegionalMisclassificationAttack(PoisoningAttackObjectDetector):
 
         for i in tqdm(selected_indices, desc="BadDet RMA iteration", disable=not self.verbose):
             image = x_poison[i]
-
             boxes = y_poison[i]["boxes"]
             labels = y_poison[i]["labels"]
+
+            if self.channels_first:
+                image = np.transpose(image, (1, 2, 0))
 
             for j, (box, label) in enumerate(zip(boxes, labels)):
                 if self.class_source is None or label == self.class_source:
@@ -144,9 +149,10 @@ class BadDetRegionalMisclassificationAttack(PoisoningAttackObjectDetector):
                     # change the source label to the target label
                     labels[j] = self.class_target
 
-        if self.channels_first:
-            # NHWC --> NCHW
-            x_poison = np.transpose(x_poison, (0, 3, 1, 2))
+            # replace the original image with the poisoned image
+            if self.channels_first:
+                image = np.transpose(image, (2, 0, 1))
+            x_poison[i] = image
 
         return x_poison, y_poison
 


### PR DESCRIPTION
# Description

The BadDet backdoor poisoning attacks have been extended to also accept a list of images of arbitrary sizes to insert the backdoor. The jupyter demo notebook has also been updated accordingly to reflect this new feature.

Fixes #2081 

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Existing test cases for BadDet RMA
- [x] Existing test cases for BadDet GMA
- [x] Existing test cases for BadDet OGA
- [x] Existing test cases for BadDet ODA

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
