### PR TITLE
Deprecation Fix in spatial_smoothing.py

### DIFF
--- a/art/defences/preprocessor/spatial_smoothing.py
+++ b/art/defences/preprocessor/spatial_smoothing.py
@@ -30,7 +30,7 @@ import logging
 from typing import Optional, Tuple
 
 import numpy as np
-from scipy.ndimage.filters import median_filter
+from scipy.ndimage import median_filter
 
 from art.utils import CLIP_VALUES_TYPE
 from art.defences.preprocessor.preprocessor import Preprocessor


### PR DESCRIPTION
# Description

Replaced the import statement from `scipy.ndimage.filters import median_filter` with from `scipy.ndimage import median_filter`.

Fixes # (issue)

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
