### PR TITLE
Targeted Universal Perturbation documentation and example script

### DIFF
--- a/art/attacks/evasion/targeted_universal_perturbation.py
+++ b/art/attacks/evasion/targeted_universal_perturbation.py
@@ -68,12 +68,15 @@ class TargetedUniversalPerturbation(EvasionAttack):
     ):
         """
         :param classifier: A trained classifier.
-        :param attacker: Adversarial attack name. Default is 'deepfool'. Supported names: 'fgsm'.
+        :param attacker: Adversarial attack name. Default is 'fgsm'. Supported names: 'simba'.
         :param attacker_params: Parameters specific to the adversarial attack. If this parameter is not specified,
                                 the default parameters of the chosen attack will be used.
-        :param delta: desired accuracy
+        :param delta: The maximum acceptable rate of correctly classified adversarial examples by the target classifier.
+                      The attack will stop when the targeted success rate exceeds `(1 - delta)`. 'delta' should be in the range `[0, 1]`.
         :param max_iter: The maximum number of iterations for computing universal perturbation.
-        :param eps: Attack step size (input variation)
+        :param eps: The perturbation magnitude, which controls the strength of the universal perturbation applied to the input samples.
+                    A larger `eps` value will result in a more noticeable perturbation, potentially leading to higher attack success rates
+                    but also increasing the visual distortion in the generated adversarial examples. Default is `10.0`.
         :param norm: The norm of the adversarial perturbation. Possible values: "inf", np.inf, 2
         """
         super().__init__(estimator=classifier)
@@ -92,8 +95,9 @@ class TargetedUniversalPerturbation(EvasionAttack):
         Generate adversarial samples and return them in an array.
 
         :param x: An array with the original inputs.
-        :param y: An array with the targeted labels.
+        :param y: The target labels for the targeted perturbation. The shape of y should match the number of instances in x.
         :return: An array holding the adversarial examples.
+        :raises: `ValueError`: if the labels `y` are None or if the attack has not been tested for binary classification with a single output classifier.
         """
         if y is None:
             raise ValueError("Labels `y` cannot be None.")
@@ -165,7 +169,6 @@ class TargetedUniversalPerturbation(EvasionAttack):
         return x_adv
 
     def _check_params(self) -> None:
-
         if not isinstance(self.delta, (float, int)) or self.delta < 0 or self.delta > 1:
             raise ValueError("The desired accuracy must be in the range [0, 1].")
 

--- a/examples/targeted_universal_perturbation.py
+++ b/examples/targeted_universal_perturbation.py
@@ -1,0 +1,99 @@
+"""Trains a pytorch classifier on the MNIST dataset, then attacks it with the targeted universal adversarial perturbation attack."""
+
+from torch import nn
+from torch import optim
+import numpy as np
+import matplotlib.pyplot as plt
+
+from art.attacks.evasion import TargetedUniversalPerturbation
+from art.estimators.classification import PyTorchClassifier
+from art.utils import load_mnist
+
+# Step 1: Load the MNIST dataset
+(x_train, y_train), (x_test, y_test), min_pixel_value, max_pixel_value = load_mnist()
+
+# Step 1a: Swap axes to PyTorch's NCHW format
+x_train = np.transpose(x_train, (0, 3, 1, 2)).astype(np.float32)
+x_test = np.transpose(x_test, (0, 3, 1, 2)).astype(np.float32)
+
+# Step 2: Create the model
+model = nn.Sequential(
+    nn.Conv2d(1, 4, 5),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Conv2d(4, 10, 5),
+    nn.ReLU(),
+    nn.MaxPool2d(2, 2),
+    nn.Flatten(),
+    nn.Linear(4 * 4 * 10, 100),
+    nn.Linear(100, 10),
+)
+
+# Step 2a: Define the loss function and the optimizer
+criterion = nn.CrossEntropyLoss()
+optimizer = optim.Adam(model.parameters(), lr=0.01)
+
+# Step 3: Create the ART classifier
+classifier = PyTorchClassifier(
+    model=model,
+    clip_values=(min_pixel_value, max_pixel_value),
+    loss=criterion,
+    optimizer=optimizer,
+    input_shape=(1, 28, 28),
+    nb_classes=10,
+)
+
+# Step 4: Train the ART classifier
+
+classifier.fit(x_train, y_train, batch_size=64, nb_epochs=5)
+
+# Step 5: Create a one-hot encoded target label array, specifying a specific class as the target for the attack.
+TARGET = 0
+y_target = np.zeros([len(x_train), 10])
+for i in range(len(x_train)):
+    y_target[i, TARGET] = 1.0
+
+# Step 6: Run Targeted Universal Perturbation attack
+attack = TargetedUniversalPerturbation(
+    classifier,
+    max_iter=1,
+    attacker="fgsm",
+    attacker_params={"delta": 0.4, "eps": 0.01, "targeted": True, "verbose": False},
+)
+x_train_adv = attack.generate(x_train, y=y_target)
+
+# Step 7: Print attack statistics
+print("Attack statistics:")
+print(f"Fooling rate: {attack.fooling_rate:.2%}")
+print(f"Targeted success rate: {attack.targeted_success_rate:.2%}")
+print(f"Converged: {attack.converged}")
+
+# Step 7a: Evaluate the attack results
+train_y_pred = np.argmax(classifier.predict(x_train_adv), axis=1)
+print("\nMisclassified train samples:", np.sum(np.argmax(y_train, axis=1) != train_y_pred))
+
+# Step 8: Generate adversarial examples for test set
+x_test_adv = x_test + attack.noise
+
+# Step 8a: Evaluate the attack results on the test set
+test_y_pred = np.argmax(classifier.predict(x_test_adv), axis=1)
+print("Misclassified test samples:", len(x_test_adv[np.argmax(y_test, axis=1) != test_y_pred]))
+
+# Step 9: Plot some misclassified samples
+fig, axes = plt.subplots(3, 3, figsize=(10, 10))
+
+for i, ax in enumerate(axes.flat):
+    ax.imshow(x_test_adv[i, ...].squeeze())
+    ax.axis("off")
+    ax.text(
+        0.5,
+        -0.05,
+        f"True Label: {np.argmax(y_test, axis=1)[i]}, Predicted Label: {test_y_pred[i]}",
+        transform=ax.transAxes,
+        horizontalalignment="center",
+        verticalalignment="center",
+    )
+
+plt.tight_layout()
+plt.suptitle("Adversarial example and labels", fontsize=16, y=1.01)
+plt.show()


### PR DESCRIPTION
# Description

Enhances the documentation for the `TargetedUniversalPerturbation` class in ART. It includes a detailed explanation of some of the parameters in the constructor. 

- Corrected the allowed adversarial attacker name and which is the default.
- Explain what `delta` and `eps` do. Please feel free to correct me if I misinterpreted it in the comments and/or cut it short if it is too long.
- Added **:raises:** `ValueError` in the `generate()` method for the docs.

The added documentation improves the code's readability and helps users understand the purpose and usage of the class more effectively.

Also, I added an example script that uses this attack (mostly derived from the test for this attack. I can make this into a notebook if you think it makes more sense.

Fixes # (issue)

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
