### PR TITLE
FIx `PytorchObjectDetector` loss gradient bug

### DIFF
--- a/art/estimators/object_detection/pytorch_object_detector.py
+++ b/art/estimators/object_detection/pytorch_object_detector.py
@@ -219,7 +219,10 @@ class PyTorchObjectDetector(ObjectDetectorMixin, PyTorchEstimator):
 
             # Set gradients
             if not no_grad:
-                x_tensor.requires_grad = True
+                if x_tensor.is_leaf:
+                    x_tensor.requires_grad = True
+                else:
+                    x_tensor.retain_grad()
 
             # Apply framework-specific preprocessing
             x_preprocessed, y_preprocessed = self._apply_preprocessing(x=x_tensor, y=y_tensor, fit=fit, no_grad=no_grad)


### PR DESCRIPTION
# Description

Add the missing if-condition when setting gradients in the `PyTorchObjectDetector` estimator such that loss gradients can be properly calculated. This if-condition is copied from `PyTorchYolo`.

Fixes #2237 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Tests for `PyTorchObjectDetector` are unchanged
- [ ] Tests for `PyTorchFasterRCNN` are unchanged

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
