### PR TITLE
Fix PyTorch Object Detection Estimators Missing Gradients Bug

### DIFF
--- a/art/estimators/object_detection/pytorch_object_detector.py
+++ b/art/estimators/object_detection/pytorch_object_detector.py
@@ -270,6 +270,12 @@ class PyTorchObjectDetector(ObjectDetectorMixin, PyTorchEstimator):
         x_preprocessed = x_preprocessed.to(self.device)
         y_preprocessed = [{k: v.to(self.device) for k, v in y_i.items()} for y_i in y_preprocessed]
 
+        # Set gradients again after inputs are moved to another device
+        if x_preprocessed.is_leaf:
+            x_preprocessed.requires_grad = True
+        else:
+            x_preprocessed.retain_grad()
+
         loss_components = self._model(x_preprocessed, y_preprocessed)
 
         return loss_components, x_preprocessed

--- a/art/estimators/object_detection/pytorch_yolo.py
+++ b/art/estimators/object_detection/pytorch_yolo.py
@@ -358,6 +358,12 @@ class PyTorchYolo(ObjectDetectorMixin, PyTorchEstimator):
         x_preprocessed = x_preprocessed.to(self.device)
         y_preprocessed_yolo = y_preprocessed_yolo.to(self.device)
 
+        # Set gradients again after inputs are moved to another device
+        if x_preprocessed.is_leaf:
+            x_preprocessed.requires_grad = True
+        else:
+            x_preprocessed.retain_grad()
+
         # Calculate loss components
         loss_components = self._model(x_preprocessed, y_preprocessed_yolo)
 


### PR DESCRIPTION
# Description

When a non-leaf tensor is moved to another device, the gradient retention property is lost and needs to be manually set again. This PR adds this minor change to both the `PyTorchObjectDetector` and `PyTorchYolo` estimators.

Fixes #2248

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Tests for `PyTorchObjectDetector` are unchanged
- [x] Tests for `PyTorchFasterRCNN` are unchanged

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
