### PR TITLE
Support sklearn models with multiple outputs 

### DIFF
--- a/art/estimators/classification/classifier.py
+++ b/art/estimators/classification/classifier.py
@@ -114,7 +114,7 @@ class ClassifierMixin(ABC, metaclass=InputFilter):
         """
         Set the number of output classes.
         """
-        if nb_classes is None or nb_classes < 2:
+        if nb_classes is None or (isinstance(nb_classes, int) and nb_classes < 2):
             raise ValueError("nb_classes must be greater than or equal to 2.")
 
         self._nb_classes = nb_classes

--- a/art/estimators/classification/classifier.py
+++ b/art/estimators/classification/classifier.py
@@ -114,7 +114,7 @@ class ClassifierMixin(ABC, metaclass=InputFilter):
         """
         Set the number of output classes.
         """
-        if nb_classes is None or (isinstance(nb_classes, int) and nb_classes < 2):
+        if nb_classes is None or (isinstance(nb_classes, (int, np.integer)) and nb_classes < 2):
             raise ValueError("nb_classes must be greater than or equal to 2.")
 
         self._nb_classes = nb_classes

--- a/art/utils.py
+++ b/art/utils.py
@@ -801,7 +801,7 @@ def check_and_transform_label_format(
     """
     labels_return = labels
 
-    if nb_classes is not None and not isinstance(nb_classes, int):
+    if nb_classes is not None and not isinstance(nb_classes, (int, np.integer)):
         raise TypeError("nb_classes that is not an integer is not supported")
 
     if len(labels.shape) == 2 and labels.shape[1] > 1:  # multi-class, one-hot encoded

--- a/art/utils.py
+++ b/art/utils.py
@@ -792,14 +792,17 @@ def check_and_transform_label_format(
     labels: np.ndarray, nb_classes: Optional[int], return_one_hot: bool = True
 ) -> np.ndarray:
     """
-    Check label format and transform to one-hot-encoded labels if necessary
+    Check label format and transform to one-hot-encoded labels if necessary. Only supports single-output classification.
 
     :param labels: An array of integer labels of shape `(nb_samples,)`, `(nb_samples, 1)` or `(nb_samples, nb_classes)`.
-    :param nb_classes: The number of classes. If None the number of classes is determined automatically.
+    :param nb_classes: The number of classes, as an integer. If None the number of classes is determined automatically.
     :param return_one_hot: True if returning one-hot encoded labels, False if returning index labels.
     :return: Labels with shape `(nb_samples, nb_classes)` (one-hot) or `(nb_samples,)` (index).
     """
     labels_return = labels
+
+    if nb_classes is not None and not isinstance(nb_classes, int):
+        raise TypeError("nb_classes that is not an integer is not supported")
 
     if len(labels.shape) == 2 and labels.shape[1] > 1:  # multi-class, one-hot encoded
         if not return_one_hot:


### PR DESCRIPTION
(i.e., nb_classes is an array instead of an integer).

# Description

The Classifier nb_classes setter now accepts non-integer values to support cases where the classifier has multiple outputs.
check_and_transform_label_format still only supports integer nb_classes values, but throws a TypeError if a different type is received.

## Type of change

Please check all relevant options.

- [X] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Added a test with a multi-output DecisionTreeClassifier

**Test Configuration**:
- OS: MacOS 14.4
- Python version: 3.9
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] My changes have been tested using both CPU and GPU devices
