### PR TITLE
Adding compatibility check in GeoDA for neural network-based classifiers

### DIFF
--- a/art/attacks/evasion/geometric_decision_based_attack.py
+++ b/art/attacks/evasion/geometric_decision_based_attack.py
@@ -94,6 +94,13 @@ class GeoDA(EvasionAttack):
         """
         super().__init__(estimator=estimator)
 
+        # **Compatibility Checks**
+        if not hasattr(estimator, "input_shape") or not hasattr(estimator, "channels_first"):
+            raise ValueError(
+                f"GeoDA is incompatible with {type(estimator)}. "
+                "Please use a neural network-based classifier."
+            )
+
         self.batch_size = batch_size
         self.norm = norm
         self.sub_dim = sub_dim
@@ -102,16 +109,18 @@ class GeoDA(EvasionAttack):
         self.lambda_param = lambda_param
         self.sigma = sigma
         self._targeted = False
-
         self.verbose = verbose
+
         self._check_params()
 
         self.sub_basis: np.ndarray
         self.nb_calls = 0
         self.clip_min = 0.0
         self.clip_max = 0.0
+
         if self.estimator.input_shape is None:  # pragma: no cover
-            raise ValueError("The `input_shape` of the is required but None.")
+            raise ValueError("The `input_shape` of the estimator is required but None.")
+
         self.nb_channels = (
             self.estimator.input_shape[0] if self.estimator.channels_first else self.estimator.input_shape[2]
         )

--- a/tests/attacks/evasion/test_geoda_incompatibility.py
+++ b/tests/attacks/evasion/test_geoda_incompatibility.py
@@ -1,0 +1,28 @@
+# test_geoda_incompatibility.py
+
+import pytest
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+from art.estimators.classification import SklearnClassifier
+from art.attacks.evasion import GeoDA
+
+
+def test_geoda_with_random_forest():
+    # Load the Iris dataset
+    data = load_iris()
+    X_train, X_test, y_train, y_test = train_test_split(
+        data.data, data.target, test_size=0.2, random_state=42
+    )
+
+    # Train a RandomForestClassifier
+    model = RandomForestClassifier()
+    model.fit(X_train, y_train)
+
+    # Wrap the model with ART's SklearnClassifier
+    classifier = SklearnClassifier(model=model)
+
+    # Expect GeoDA to raise ValueError when used with RandomForestClassifier
+    with pytest.raises(ValueError, match="GeoDA is incompatible with"):
+        attack = GeoDA(classifier)
+        attack.generate(X_test)


### PR DESCRIPTION
# Description

This update addresses the compatibility issue between GeoDA and Scikit-learn's RandomForestClassifier. I added a check in the GeoDA constructor to ensure that it only runs with classifiers that include input_shape and channels_first attributes. When an incompatible model, like RandomForestClassifier, is used, the code now raises a ValueError. 

Fixes #2493

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

I added a unit test (test_geoda_incompatibility.py) that verifies the compatibility check by raising a ValueError when GeoDA is applied to a RandomForestClassifier. This test passed successfully.

**Test Configuration**:
- OS: Windows 11
- Python version:  3.12
- ART version or commit number: 1.18.1
- Scikit-learn version: 1.0.2

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] My changes have been tested using both CPU and GPU devices
