### PR TITLE
correct f-strings in parallel/non-parallel AutoAttack metadata

### DIFF
--- a/art/attacks/evasion/auto_attack.py
+++ b/art/attacks/evasion/auto_attack.py
@@ -330,7 +330,7 @@ class AutoAttack(EvasionAttack):
             )
             auto_attack_meta = (
                 f"AutoAttack(targeted={self.targeted}, parallel_pool_size={self.parallel_pool_size}, "
-                + "num_attacks={len(self.args)})"
+                + f"num_attacks={len(self.args)})"
             )
             return f"{auto_attack_meta}\nBestAttacks:\n{best_attack_meta}"
 
@@ -342,7 +342,7 @@ class AutoAttack(EvasionAttack):
         )
         auto_attack_meta = (
             f"AutoAttack(targeted={self.targeted}, parallel_pool_size={self.parallel_pool_size}, "
-            + "num_attacks={len(self.attacks)})"
+            + f"num_attacks={len(self.attacks)})"
         )
         return f"{auto_attack_meta}\nBestAttacks:\n{best_attack_meta}"
 


### PR DESCRIPTION
# Description

Full Issue Details: https://github.com/Trusted-AI/adversarial-robustness-toolbox/issues/2548
- Fixes string literals in returned AutoAttack metadata (both parallel and non-parallel) to correctly use f-strings


Fixes #2548

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

- I utilized the same test that is outlined in #2548
- I corrected the f-strings locally and built a local wheel for ART-Core, which was then installed
- I repeated the testing to assert that the metadata returned correctly uses the f-string substitution

```bash
>>> attack_noparallel = AutoAttack(estimator=ptc, attacks=attacks, targeted=True, parallel_pool_size = 0)
>>> attack_parallel = AutoAttack(estimator=ptc, attacks=attacks, targeted=True, parallel_pool_size = pool)
>>>
>>>
>>> no_parallel_adv = attack_noparallel.generate(x=x_train, y=y_train)
>>> parallel_adv = attack_parallel.generate(x=x_train, y=y_train)
>>> print(repr(attack_noparallel))
AutoAttack(targeted=True, parallel_pool_size=0, num_attacks=1)
BestAttacks:
image 1: ProjectedGradientDescentPyTorch(norm=inf, eps=0.1, eps_step=0.1, targeted=True, num_random_init=0, batch_size=32, minimal=False, summary_writer=None, decay=None, max_iter=10, random_eps=False, verbose=False, )
image 2: ProjectedGradientDescentPyTorch(norm=inf, eps=0.1, eps_step=0.1, targeted=True, num_random_init=0, batch_size=32, minimal=False, summary_writer=None, decay=None, max_iter=10, random_eps=False, verbose=False, )
image 3: ProjectedGradientDescentPyTorch(norm=inf, eps=0.1, eps_step=0.1, targeted=True, num_random_init=0, batch_size=32, minimal=False, summary_writer=None, decay=None, max_iter=10, random_eps=False, verbose=False, )
image 4: n/a
image 5: n/a
image 6: n/a
image 7: n/a
image 8: ProjectedGradientDescentPyTorch(norm=inf, eps=0.1, eps_step=0.1, targeted=True, num_random_init=0, batch_size=32, minimal=False, summary_writer=None, decay=None, max_iter=10, random_eps=False, verbose=False, )
image 9: ProjectedGradientDescentPyTorch(norm=inf, eps=0.1, eps_step=0.1, targeted=True, num_random_init=0, batch_size=32, minimal=False, summary_writer=None, decay=None, max_iter=10, random_eps=False, verbose=False, )
image 10: n/a
>>>
>>>
>>> print(repr(attack_parallel))
AutoAttack(targeted=True, parallel_pool_size=15, num_attacks=10)
BestAttacks:
image 1: ProjectedGradientDescentPyTorch(norm=inf, eps=0.1, eps_step=0.1, targeted=True, num_random_init=0, batch_size=32, minimal=False, summary_writer=None, decay=None, max_iter=10, random_eps=False, verbose=False, )
image 2: ProjectedGradientDescentPyTorch(norm=inf, eps=0.1, eps_step=0.1, targeted=True, num_random_init=0, batch_size=32, minimal=False, summary_writer=None, decay=None, max_iter=10, random_eps=False, verbose=False, )
image 3: ProjectedGradientDescentPyTorch(norm=inf, eps=0.1, eps_step=0.1, targeted=True, num_random_init=0, batch_size=32, minimal=False, summary_writer=None, decay=None, max_iter=10, random_eps=False, verbose=False, )
image 4: n/a
image 5: n/a
image 6: n/a
image 7: n/a
image 8: ProjectedGradientDescentPyTorch(norm=inf, eps=0.1, eps_step=0.1, targeted=True, num_random_init=0, batch_size=32, minimal=False, summary_writer=None, decay=None, max_iter=10, random_eps=False, verbose=False, )
image 9: ProjectedGradientDescentPyTorch(norm=inf, eps=0.1, eps_step=0.1, targeted=True, num_random_init=0, batch_size=32, minimal=False, summary_writer=None, decay=None, max_iter=10, random_eps=False, verbose=False, )
image 10: n/a
>>>
```

**Test Configuration**:
OS = Ubuntu 22.04.4 LTS
Python version = 3.11
ART version or commit number = 1.19.0
PyTorch version = 2.3.1

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes have been tested using both CPU and GPU devices
