### PR TITLE
Migrate to assertEqual

### DIFF
--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -78,7 +78,7 @@ class TestNumpyDataGenerator(unittest.TestCase):
             drop_remainder=True,
             shuffle=False,
         )
-        self.assertEquals(data_generator.batches_per_epoch, 3)
+        self.assertEqual(data_generator.batches_per_epoch, 3)
         for i in range(3):
             data_generator.get_batch()
         _, y_batch = data_generator.get_batch()
@@ -92,11 +92,11 @@ class TestNumpyDataGenerator(unittest.TestCase):
             drop_remainder=True,
             shuffle=False,
         )
-        self.assertEquals(data_generator.batches_per_epoch, 10)
+        self.assertEqual(data_generator.batches_per_epoch, 10)
         for i in range(9):
             data_generator.get_batch()
         _, y_batch = data_generator.get_batch()
-        self.assertEquals(len(y_batch), 10)
+        self.assertEqual(len(y_batch), 10)
 
     def test_drop_remainder_false(self):
         data_generator = NumpyDataGenerator(
@@ -106,11 +106,11 @@ class TestNumpyDataGenerator(unittest.TestCase):
             drop_remainder=False,
             shuffle=False,
         )
-        self.assertEquals(data_generator.batches_per_epoch, 4)
+        self.assertEqual(data_generator.batches_per_epoch, 4)
         for i in range(3):
             data_generator.get_batch()
         x_batch, _ = data_generator.get_batch()
-        self.assertEquals(len(x_batch), self.m % self.batch_size)
+        self.assertEqual(len(x_batch), self.m % self.batch_size)
 
     def test_shuffle(self):
         """
@@ -143,7 +143,7 @@ class TestNumpyDataGenerator(unittest.TestCase):
             drop_remainder=True,
             shuffle=False,
         )
-        self.assertEquals(data_generator.batches_per_epoch, 3)
+        self.assertEqual(data_generator.batches_per_epoch, 3)
         for i in range(3):
             data_generator.get_batch()
         _, y_batch = data_generator.get_batch()


### PR DESCRIPTION
# Description
This small PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```

## Type of change

Please check all relevant options.

- [x] Improvement (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing


**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes have been tested using both CPU and GPU devices
