### PR TITLE
Ignore labels for untargeted robustdpatch, similar to other attacks

### DIFF
--- a/art/attacks/evasion/dpatch_robust.py
+++ b/art/attacks/evasion/dpatch_robust.py
@@ -146,7 +146,7 @@ class RobustDPatch(EvasionAttack):
         Generate RobustDPatch.
 
         :param x: Sample images.
-        :param y: Target labels for object detector.
+        :param y: Target labels for object detector. For untargeted attacks, this should be None.
         :return: Adversarial patch.
         """
         channel_index = 1 if self.estimator.channels_first else x.ndim - 1
@@ -155,7 +155,8 @@ class RobustDPatch(EvasionAttack):
         if y is None and self.targeted:
             raise ValueError("The targeted version of RobustDPatch attack requires target labels provided to `y`.")
         if y is not None and not self.targeted:
-            raise ValueError("The RobustDPatch attack does not use target labels.")
+            logger.warning("Labels provided for untargeted attack will be ignored")
+            y = None
         if x.ndim != 4:  # pragma: no cover
             raise ValueError("The adversarial patch can only be applied to images.")
 

--- a/tests/attacks/evasion/test_dpatch_robust.py
+++ b/tests/attacks/evasion/test_dpatch_robust.py
@@ -39,7 +39,7 @@ def fix_get_mnist_subset(get_mnist_dataset):
 
 
 @pytest.mark.skip_framework("keras", "scikitlearn", "mxnet", "kerastf")
-def test_generate(art_warning, fix_get_mnist_subset, fix_get_rcnn, framework):
+def test_generate(art_warning, fix_get_mnist_subset, fix_get_rcnn, framework, caplog):
     try:
         (_, _, x_test_mnist, y_test_mnist) = fix_get_mnist_subset
 
@@ -66,8 +66,9 @@ def test_generate(art_warning, fix_get_mnist_subset, fix_get_rcnn, framework):
         with pytest.raises(ValueError):
             _ = attack.generate(x=np.repeat(x_test_mnist, axis=3, repeats=2))
 
-        with pytest.raises(ValueError):
+        with caplog.at_level(logging.WARNING):
             _ = attack.generate(x=x_test_mnist, y=y_test_mnist)
+            assert "Labels provided for untargeted attack will be ignored" in caplog.text
 
     except ARTTestException as e:
         art_warning(e)


### PR DESCRIPTION
# Full Issue Details: #2618 

- Fixes the inconsistency between `AdversarialPatchPytorch` and `RobustDPatch` attack where `AdversarialPatchPytorch` silently ignores the labels when the user provides it during untargeted attacks. It should throw a `ValueError` in this case.

Fixes #2618 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing
- I utilized the same test that is outlined in [API Inconsistency: AdversarialPatchPytorch silently ignores labels in untargeted mode rather than throwing a ValueError #2618](https://github.com/Trusted-AI/adversarial-robustness-toolbox/issues/2618).

- I added code that throws a `ValueError` when the user provides labels during an untargeted `AdversarialPatchPytorch` attack. I then created a script that replicates an untargeted `AdversarialPatchPytorch` attack where user provides labels and then ran the script to test functionality.

![Screenshot 2025-06-03 164016](https://github.com/user-attachments/assets/be90d286-e7c9-427f-bacc-caa6a14964d6)


**Test Configuration**:
- OS = `Windows 11`
- Python version = `3.9`
- ART version = `1.19.1`
- PyTorch version = `2.7.0`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes have been tested using both CPU and GPU devices
