### PR TITLE
Update AdversarialPatchPytorch untargeted attacks to throw a Value Error when the user provides labels

### DIFF
--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_pytorch.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_pytorch.py
@@ -490,7 +490,7 @@ class AdversarialPatchPyTorch(EvasionAttack):
 
         :param x: An array with the original input images of shape NCHW or input videos of shape NFCHW.
         :param y: True or target labels of format `list[dict[str, Union[np.ndarray, torch.Tensor]]]`, one for each
-                  input image. The fields of the dict are as follows:
+                  input image. For untargeted attacks, this should be None. The fields of the dict are as follows:
 
                   - boxes [N, 4]: the boxes in [x1, y1, x2, y2] format, with 0 <= x1 < x2 <= W and 0 <= y1 < y2 <= H.
                   - labels [N]: the labels for each image.
@@ -515,6 +515,9 @@ class AdversarialPatchPyTorch(EvasionAttack):
 
             y_array: np.ndarray
 
+            if y is not None and not self.targeted:
+                raise ValueError("The untargeted version of AdversarialPatch attack does not use target labels.")
+
             if y is None:  # pragma: no cover
                 logger.info("Setting labels to estimator classification predictions.")
                 y_array = to_categorical(
@@ -533,6 +536,9 @@ class AdversarialPatchPyTorch(EvasionAttack):
             else:
                 self.use_logits = True
         else:
+            if y is not None and not self.targeted:
+                raise ValueError("The untargeted version of AdversarialPatch attack does not use target labels.")
+
             if y is None:  # pragma: no cover
                 logger.info("Setting labels to estimator object detection predictions.")
                 y = self.estimator.predict(x=x)

--- a/tests/attacks/test_steal_now_attack_later.py
+++ b/tests/attacks/test_steal_now_attack_later.py
@@ -66,6 +66,8 @@ def test_generate(art_warning, get_pytorch_detector_yolo):
                 pos_matrix[:, 2] = torch.clamp_max(pos_matrix[:, 2], imgs.shape[3])
                 pos_matrix[:, 3] = torch.clamp_max(pos_matrix[:, 3], imgs.shape[2])
                 for pos_m in pos_matrix:
+                    if pos_m[3] - pos_m[1] == 0 or pos_m[2] - pos_m[0] == 0:
+                        continue
                     p = imgs[i, :, pos_m[1] : pos_m[3], pos_m[0] : pos_m[2]]
                     patch.append(p.to(detector.device))
 
@@ -165,7 +167,7 @@ def test_generate(art_warning, get_pytorch_detector_yolo):
         attack = SNAL(
             object_detector,
             eps=16.0 / 255.0,
-            max_iter=10,
+            max_iter=5,
             num_grid=10,
             candidates=candidates_list,
             collector=collect_patches_from_images,


### PR DESCRIPTION
# Full Issue Details: #2618 

- Fixes the inconsistency between `AdversarialPatchPytorch` and `RobustDPatch` attack where `AdversarialPatchPytorch` silently ignores the labels when the user provides it during untargeted attacks. It should throw a `ValueError` in this case.

Fixes #2618 

## Type of change

Please check all relevant options.

- [ ] Improvement (non-breaking)
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing
- I utilized the same test that is outlined in [API Inconsistency: AdversarialPatchPytorch silently ignores labels in untargeted mode rather than throwing a ValueError #2618](https://github.com/Trusted-AI/adversarial-robustness-toolbox/issues/2618).

- I added code that throws a `ValueError` when the user provides labels during an untargeted `AdversarialPatchPytorch` attack. I then created a script that replicates an untargeted `AdversarialPatchPytorch` attack where user provides labels and then ran the script to test functionality.

![Screenshot 2025-06-03 164016](https://github.com/user-attachments/assets/be90d286-e7c9-427f-bacc-caa6a14964d6)


**Test Configuration**:
- OS = `Windows 11`
- Python version = `3.9`
- ART version = `1.19.1`
- PyTorch version = `2.7.0`

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes have been tested using both CPU and GPU devices
